### PR TITLE
feat: add root folder awareness (Option 3) with startup validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,18 @@ SONARR_4K_API_KEY=your_sonarr_4k_api_key
 #   - Add both folders as separate libraries in Plex/Jellyfin if you want to keep placeholders and real files separate.
 #   - This is useful if you want to keep placeholders out of your main library or provide a dedicated "request" library for users.
 #
+# Option 3: Root folder awareness (USE_ROOT_FOLDERS=true).
+#   - Leave MOVIE_LIBRARY_FOLDER and TV_LIBRARY_FOLDER blank.
+#   - Set USE_ROOT_FOLDERS=true and mount all *arr root folders at the same paths inside the container.
+#   - Placeholdarr will create a subfolder named DUMMY_FOLDER_NAME (default: "placeholders") inside
+#     each root folder and place media dummies there.
+#     e.g. /mnt/user/data/movies/placeholders/Movie Name (2023)/Movie Name (2023) (dummy).mp4
+#   - Set ROOT_FOLDER_SECTION_ID_MAPPINGS to a JSON object mapping each root folder path to its
+#     Plex library section ID.  Keys must use double quotes (standard JSON).
+#     e.g. ROOT_FOLDER_SECTION_ID_MAPPINGS={"/mnt/user/data/movies/": 1, "/mnt/user/data/tv/": 2}
+#   - PLEX_MOVIE_SECTION_ID / PLEX_TV_SECTION_ID are not used for primary section lookup in this mode;
+#     section IDs are read from ROOT_FOLDER_SECTION_ID_MAPPINGS. Setting them is still recommended as a fallback.
+#
 # IMPORTANT: Set all path settings below (e.g., MOVIE_LIBRARY_FOLDER, TV_LIBRARY_FOLDER, DUMMY_FILE_PATH) 
 # to the absolute paths on your host system.
 #
@@ -69,6 +81,11 @@ MOVIE_LIBRARY_FOLDER=/mnt/user/data/movies/placeholders      # Replace with your
 TV_LIBRARY_FOLDER=/mnt/user/data/tv/placeholders            # Replace with your desired placeholder folder path on the host
 MOVIE_LIBRARY_4K_FOLDER=                                     # Optional - replace or leave blank if not using 4K
 TV_LIBRARY_4K_FOLDER=                                        # Optional - replace or leave blank if not using 4K
+
+# Root Folder Mode (Option 3) — leave MOVIE_LIBRARY_FOLDER / TV_LIBRARY_FOLDER blank when using this
+USE_ROOT_FOLDERS=false                                        # Set to true to enable root folder awareness
+DUMMY_FOLDER_NAME=placeholders                               # Subfolder name created inside each *arr root folder
+ROOT_FOLDER_SECTION_ID_MAPPINGS=                             # JSON dict: {"/mnt/user/data/movies/": 1, "/mnt/user/data/tv/": 2}
 
 # Dummy file paths (replace with your dummy file locations on the host, matching your volume mounts)
 DUMMY_FILE_PATH=/mnt/user/data/placeholdarr/dummy.mp4

--- a/README.md
+++ b/README.md
@@ -97,8 +97,41 @@ Once you have created your placeholder folders, you have two options for adding 
 - Keep your real file libraries (e.g., `/mnt/user/data/movies`, `/mnt/user/data/tv`) as separate libraries.
 - This setup makes it clear to users which items are placeholders (requests) and which are available to play immediately, and keeps your real and placeholder files fully separated for easy management and cleanup.
 
-**Note:**  
-Placeholdarr does not need to know your *arr root folders—just set the library folders to wherever you want placeholders to appear.
+#### Option 3: Root Folder Mode (`USE_ROOT_FOLDERS=true`)
+
+This mode removes the need to hardcode a single placeholder folder. Placeholdarr derives the root folder by matching the `folderPath` from each webhook against the keys in `ROOT_FOLDER_SECTION_ID_MAPPINGS` using a `startsWith` check, then creates a subfolder named `DUMMY_FOLDER_NAME` (default: `placeholders`) inside that root folder.
+
+**Setup:**
+1. Leave `MOVIE_LIBRARY_FOLDER` and `TV_LIBRARY_FOLDER` blank.
+2. Set `USE_ROOT_FOLDERS=true`.
+3. Mount all your *arr root folders at the same absolute paths inside the container (same as their host paths).
+4. Set `ROOT_FOLDER_SECTION_ID_MAPPINGS` to a JSON object mapping each root folder to its Plex section ID:
+   ```
+   ROOT_FOLDER_SECTION_ID_MAPPINGS={"/mnt/user/data/movies/": 1, "/mnt/user/data/tv/": 2}
+   ```
+   Keys must use **double quotes** (standard JSON). Values are integer Plex section IDs.
+5. `PLEX_MOVIE_SECTION_ID` / `PLEX_TV_SECTION_ID` are not used for primary section lookup in this mode — section IDs come from `ROOT_FOLDER_SECTION_ID_MAPPINGS`. They are used as a fallback if a path doesn't match any mapping key, so setting them is still recommended.
+
+**Resulting folder structure** (with default `DUMMY_FOLDER_NAME=placeholders`):
+```
+/mnt/user/data/movies/
+└── placeholders/
+    └── Movie Name (2023)/
+        └── Movie Name (2023) (dummy).mp4
+
+/mnt/user/data/tv/
+└── placeholders/
+    └── Series Name (2020)/
+        └── Season 01/
+            └── Series Name (2020) - s01e01 - Episode Title.mp4
+```
+
+In Plex/Jellyfin, add `{root}/{DUMMY_FOLDER_NAME}` for each root folder as a library (e.g. `/mnt/user/data/movies/placeholders` and `/mnt/user/data/tv/placeholders`), or as additional folders in your existing movie/TV libraries.
+
+---
+
+**Note:**
+For Options 1 and 2, Placeholdarr does not need to know your *arr root folders—just set the library folders to wherever you want placeholders to appear.
 
 ---
 
@@ -108,11 +141,14 @@ Required settings in `.env`:
 - `PLEX_URL`, `PLEX_TOKEN`: Your Plex server details
 - `RADARR_URL`, `RADARR_API_KEY`: Radarr connection details
 - `SONARR_URL`, `SONARR_API_KEY`: Sonarr connection details
-- `MOVIE_LIBRARY_FOLDER`, `TV_LIBRARY_FOLDER`: Folders where placeholders (and optionally real files) will be created and scanned by Plex/Jellyfin
+- `MOVIE_LIBRARY_FOLDER`, `TV_LIBRARY_FOLDER`: Folders where placeholders (and optionally real files) will be created and scanned by Plex/Jellyfin *(not required when `USE_ROOT_FOLDERS=true`)*
 - `DUMMY_FILE_PATH`: Path to your dummy.mp4 file
  - `EMBY_URL`, `EMBY_TOKEN`: Emby server details (if using Emby). Note: Emby commonly exposes its API under an `/emby/` prefix. Set `EMBY_URL` to the server base (e.g., `http://localhost:8096`) and `EMBY_TOKEN` to an API key.
 
 Optional settings:
+- `USE_ROOT_FOLDERS`: Enable root folder mode (Option 3) — derives placeholder paths from *arr root folders (`true`/`false`, default `false`)
+- `DUMMY_FOLDER_NAME`: Subfolder name created inside each *arr root folder when `USE_ROOT_FOLDERS=true` (default: `placeholders`)
+- `ROOT_FOLDER_SECTION_ID_MAPPINGS`: JSON object mapping root folder paths to Plex section IDs, required when `USE_ROOT_FOLDERS=true` (e.g. `{"/mnt/movies/": 1, "/mnt/tv/": 2}`)
 - `PLACEHOLDER_STRATEGY`: How to create placeholders (`hardlink` or `copy`)
 - `TV_PLAY_MODE`: Download scope (`episode`, `season`, or `series`)
 - `TITLE_UPDATES`: What level of status updates are shown in Plex. "ALL" not currently recommended, as this feature is still in development (`OFF`, `REQUEST`, `ALL`)

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,5 @@
 import os
+import json
 from pathlib import Path
 from typing import Literal, Optional
 from dotenv import load_dotenv
@@ -20,7 +21,7 @@ load_dotenv(dotenv_path)
 
 class Settings(BaseSettings):
     LOG_LEVEL: str = os.getenv("PLACEHOLDARR_LOG_LEVEL", "INFO")
-    WORKER_COUNT: int = os.getenv("WORKER_COUNT", 4)
+    WORKER_COUNT: int = int(os.getenv("WORKER_COUNT", "4"))
 
     # Plex
     PLEX_URL: Optional[str] = None
@@ -49,10 +50,15 @@ class Settings(BaseSettings):
     SONARR_4K_API_KEY: str = ""
 
     # Library Paths
-    MOVIE_LIBRARY_FOLDER: str
-    TV_LIBRARY_FOLDER: str
+    MOVIE_LIBRARY_FOLDER: str = ""
+    TV_LIBRARY_FOLDER: str = ""
     MOVIE_LIBRARY_4K_FOLDER: str = ""
     TV_LIBRARY_4K_FOLDER: str = ""
+
+    # Root folder mode (Option 3)
+    USE_ROOT_FOLDERS: bool = os.getenv("USE_ROOT_FOLDERS", "false").split('#')[0].strip().lower() == "true"
+    DUMMY_FOLDER_NAME: str = os.getenv("DUMMY_FOLDER_NAME", "placeholders").split('#')[0].strip() or "placeholders"
+    ROOT_FOLDER_SECTION_ID_MAPPINGS: Optional[dict] = None
 
     # Application
     PLAYBACK_COOLDOWN: int = int(os.environ.get("PLAYBACK_COOLDOWN", "30").split('#')[0].strip())
@@ -87,10 +93,37 @@ class Settings(BaseSettings):
     ENABLE_JELLYFIN: bool = os.getenv("ENABLE_JELLYFIN", "true").split('#')[0].strip().lower() == "true"
     ENABLE_EMBY: bool = os.getenv("ENABLE_EMBY", "false").split('#')[0].strip().lower() == "true"
 
+    @validator('ROOT_FOLDER_SECTION_ID_MAPPINGS', pre=True)
+    def parse_root_folder_section_id_mappings(cls, v):
+        if v is None or v == "":
+            return None
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            v = v.strip()
+            try:
+                parsed = json.loads(v)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"ROOT_FOLDER_SECTION_ID_MAPPINGS must be valid JSON with string keys and integer values "
+                    f"(e.g. {{\"/mnt/movies/\": 1, \"/mnt/tv/\": 2}}). Parse error: {e}"
+                )
+            if not isinstance(parsed, dict):
+                raise ValueError("ROOT_FOLDER_SECTION_ID_MAPPINGS must be a JSON object")
+            for k, val in parsed.items():
+                if not isinstance(k, str):
+                    raise ValueError(f"ROOT_FOLDER_SECTION_ID_MAPPINGS keys must be strings, got: {k!r}")
+                if not isinstance(val, int):
+                    raise ValueError(f"ROOT_FOLDER_SECTION_ID_MAPPINGS values must be integers, got: {val!r} for key {k!r}")
+            return parsed
+        return v
+
     # Add a method to clean string values
     @validator('*', pre=True)
-    def clean_string_values(cls, v):
+    def clean_string_values(cls, v, values=None, field=None, config=None):
         """Clean string values by removing comments and extra whitespace"""
+        if field is not None and field.name == 'ROOT_FOLDER_SECTION_ID_MAPPINGS':
+            return v
         if isinstance(v, str):
             # Split on # but only if it's not part of a URL
             if '#' in v and not ('http://' in v or 'https://' in v):
@@ -119,6 +152,30 @@ class Settings(BaseSettings):
         if not v.startswith(('http://', 'https://')):
             raise ValueError(f"Invalid URL: {v}")
         return v.rstrip('/')
+
+    @root_validator(skip_on_failure=True)
+    def check_root_folder_mode(cls, values):
+        use_root_folders = values.get('USE_ROOT_FOLDERS', False)
+        if not use_root_folders:
+            return values
+        # USE_ROOT_FOLDERS=true: ROOT_FOLDER_SECTION_ID_MAPPINGS must be set
+        if not values.get('ROOT_FOLDER_SECTION_ID_MAPPINGS'):
+            raise ValueError(
+                "USE_ROOT_FOLDERS=true requires ROOT_FOLDER_SECTION_ID_MAPPINGS to be set "
+                "(e.g. ROOT_FOLDER_SECTION_ID_MAPPINGS={{\"/mnt/movies/\": 1, \"/mnt/tv/\": 2}})"
+            )
+        # USE_ROOT_FOLDERS=true: MOVIE_LIBRARY_FOLDER and TV_LIBRARY_FOLDER must be blank
+        if values.get('MOVIE_LIBRARY_FOLDER'):
+            raise ValueError(
+                "USE_ROOT_FOLDERS=true is incompatible with MOVIE_LIBRARY_FOLDER. "
+                "Leave MOVIE_LIBRARY_FOLDER blank when using root folder mode."
+            )
+        if values.get('TV_LIBRARY_FOLDER'):
+            raise ValueError(
+                "USE_ROOT_FOLDERS=true is incompatible with TV_LIBRARY_FOLDER. "
+                "Leave TV_LIBRARY_FOLDER blank when using root folder mode."
+            )
+        return values
 
     @root_validator(skip_on_failure=True)
     def check_media_providers(cls, values):
@@ -155,23 +212,23 @@ class Settings(BaseSettings):
         return enable_emby and bool(getattr(self, 'EMBY_URL', None) and getattr(self, 'EMBY_TOKEN', None))
 
     @property
-    def radarr_4k_port(self) -> int:
-        return int(urllib.parse.urlparse(self.RADARR_4K_URL).port) if self.RADARR_4K_URL else None
-    
+    def radarr_4k_port(self) -> Optional[int]:
+        return urllib.parse.urlparse(self.RADARR_4K_URL).port if self.RADARR_4K_URL else None
+
     @property
-    def sonarr_4k_port(self) -> int:
-        return int(urllib.parse.urlparse(self.SONARR_4K_URL).port) if self.SONARR_4K_URL else None
+    def sonarr_4k_port(self) -> Optional[int]:
+        return urllib.parse.urlparse(self.SONARR_4K_URL).port if self.SONARR_4K_URL else None
 
     @property
     def has_4k_support(self) -> bool:
         return bool(self.RADARR_4K_URL and self.MOVIE_LIBRARY_4K_FOLDER) or bool(self.SONARR_4K_URL and self.TV_LIBRARY_4K_FOLDER)
 
     @property
-    def plex_4k_movie_section_id(self) -> int:
+    def plex_4k_movie_section_id(self) -> Optional[int]:
         return self.PLEX_MOVIE_4K_SECTION_ID if hasattr(self, 'PLEX_MOVIE_4K_SECTION_ID') else self.PLEX_MOVIE_SECTION_ID
 
     @property
-    def plex_4k_tv_section_id(self) -> int:
+    def plex_4k_tv_section_id(self) -> Optional[int]:
         return self.PLEX_TV_4K_SECTION_ID if hasattr(self, 'PLEX_TV_4K_SECTION_ID') else self.PLEX_TV_SECTION_ID
 
     @property

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from services.handlers import handle_webhook
 from services.migration import run_migration
 from core.config import settings
 from services.calendar_sync import start_calendar_sync
-from contextlib import asynccontextmanager
 
 # Load environment variables
 def load_env_and_migrate():
@@ -112,9 +111,9 @@ if __name__ == '__main__':
 
     # Force import of media server clients to trigger connection tests and endpoint checks
     if settings.plex_enabled:
-        from services.plex_client import plex
+        pass
     if settings.jellyfin_enabled:
-        from services.jellyfin_client import test_jellyfin_connection
+        pass
 
     # Set port back to 8001 (your existing webhook port)
     port = int(os.getenv('PLACEHOLDARR_PORT', 8001))

--- a/main.py
+++ b/main.py
@@ -111,9 +111,9 @@ if __name__ == '__main__':
 
     # Force import of media server clients to trigger connection tests and endpoint checks
     if settings.plex_enabled:
-        pass
+        from services.plex_client import plex  # noqa: F401
     if settings.jellyfin_enabled:
-        pass
+        from services.jellyfin_client import test_jellyfin_connection  # noqa: F401
 
     # Set port back to 8001 (your existing webhook port)
     port = int(os.getenv('PLACEHOLDARR_PORT', 8001))

--- a/rename_folders_to_arr.py
+++ b/rename_folders_to_arr.py
@@ -226,7 +226,7 @@ def main():
     movie_renames, movie_unmatched = scan_and_rename_by_name(MOVIE_LIBRARY_ROOT, expected_movie_names, 'movie')
 
     # Summary and prompt to proceed
-    print(f"\nSummary:")
+    print("\nSummary:")
     print(f"TV folders to rename: {len(tv_renames)}")
     print(f"TV unmatched folders: {len(tv_unmatched)}")
     print(f"Movie folders to rename: {len(movie_renames)}")

--- a/services/calendar_sync.py
+++ b/services/calendar_sync.py
@@ -1,4 +1,3 @@
-import os  # <-- Add this import
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -9,7 +8,7 @@ from core.logger import logger
 from services.integrations import place_dummy_file, schedule_episode_request_update, schedule_movie_request_update, update_title_status
 from services.plex_client import refresh_plex_item
 from services.jellyfin_client import refresh_jellyfin_item
-from services.utils import sanitize_filename, resolve_final_folder, get_arr_config, join_endpoint
+from services.utils import sanitize_filename, resolve_final_folder, get_arr_config, join_endpoint, get_root_folder_from_path
 
 # --- Scheduler/Timer ---
 
@@ -101,7 +100,7 @@ def sync_calendar_episodes():
             air_date = _parse_air_date(air_date_str)
             # --- Always check for both folderPath and path ---
             folder_path = series.get('folderPath') or series.get('path')
-            arr_root_folder = series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None) or None
+            arr_root_folder = get_root_folder_from_path(folder_path)
             # --- Authoritative hasFile from Sonarr: fetch per-series episode list once and cache ---
             series_internal_id = series.get('id') or ep.get('seriesId')
             has_file = False
@@ -353,7 +352,7 @@ def sync_calendar_episodes():
             air_date = _parse_air_date(date_str)
             # Use 'path' for API lookups (Radarr), fallback to 'folderPath' for legacy/compat
             folder_path = movie.get('path') or movie.get('folderPath')
-            arr_root_folder = movie.get('rootFolderPath')
+            arr_root_folder = get_root_folder_from_path(folder_path)
             if not air_date:
                 continue
             if not enable_placeholders:

--- a/services/emby_client.py
+++ b/services/emby_client.py
@@ -1,8 +1,6 @@
 import os
-import time
-from typing import Optional, Any, Callable
+from typing import Optional
 import requests
-from urllib.parse import quote_plus
 from core.config import settings
 from core.logger import logger
 

--- a/services/handlers.py
+++ b/services/handlers.py
@@ -1,12 +1,16 @@
-import os, re, threading, time, shutil, requests
+import os
+import re
+import threading
+import time
+import requests
 from fastapi.responses import JSONResponse
 from core.config import settings
 from core.logger import logger
-from services.plex_client import plex, build_plex_url, refresh_plex_item
-from services.jellyfin_client import build_jellyfin_url, refresh_jellyfin_item, get_jellyfin_file_path
+from services.plex_client import refresh_plex_item
+from services.jellyfin_client import refresh_jellyfin_item, get_jellyfin_file_path
 from services.emby_client import get_emby_file_path, refresh_emby_item
 from services.integrations import (
-    place_dummy_file, delete_dummy_files, schedule_episode_request_update,
+    place_dummy_file, schedule_episode_request_update,
     schedule_movie_request_update, 
     search_in_radarr, search_in_sonarr, trigger_sonarr_search, monitor_episodes, 
     mark_series_monitored, get_episodes_for_lookahead,
@@ -14,10 +18,9 @@ from services.integrations import (
 )
 from services.queue_monitor import add_to_monitor
 from services.utils import (
-    strip_movie_status, sanitize_filename, extract_episode_title, 
-    is_4k_request, strip_status_markers, get_arr_config, join_endpoint
+    sanitize_filename, is_4k_request, get_arr_config, join_endpoint,
+    get_root_folder_from_path
 )
-from urllib.parse import quote
 from services.queue_monitor import handle_download_webhook
 
 # Series-based tracking for playback suppression
@@ -143,7 +146,7 @@ def handle_import_event(data: dict, is_4k: bool = False):
             year = movie.get('year')
             movie_path = data.get("movieFile", {}).get("path")
             folder_path = movie.get('folderPath') or movie.get('path')
-            arr_root_folder = movie.get('rootFolderPath') or getattr(settings, 'RADARR_ROOT_FOLDER', None) or None
+            arr_root_folder = get_root_folder_from_path(folder_path)
             # Use resolve_final_folder to match dummy creation
             dummy_folder = resolve_final_folder(
                 media_type="movie",
@@ -156,7 +159,7 @@ def handle_import_event(data: dict, is_4k: bool = False):
             file_name = f"{sanitize_filename(title)}"
             if year:
                 file_name += f" ({year})"
-            file_name += f" (dummy).mp4"
+            file_name += " (dummy).mp4"
             dummy_file_path = os.path.join(dummy_folder, file_name)
             logger.info(f"Processing movie import cleanup for: {title}", extra={'emoji_type': 'cleanup'})
             # Update Plex/Jellyfin title to "Available" (remove status markers)
@@ -216,7 +219,7 @@ def handle_import_event(data: dict, is_4k: bool = False):
             episode_title = episode.get('title', 'Unknown Episode')
             episode_path = data.get("episodeFile", {}).get("path")
             folder_path = series.get('folderPath') or series.get('path')
-            arr_root_folder = series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None) or None
+            arr_root_folder = get_root_folder_from_path(folder_path)
             # Use resolve_final_folder to match dummy creation
             dummy_folder = resolve_final_folder(
                 media_type="tv",
@@ -309,7 +312,7 @@ def handle_seriesadd(data: dict, is_4k: bool = False):
         year=series_year,
         media_id=tvdb_id,
         folder_path=series.get('folderPath') or series.get('path'),
-        arr_root_folder=series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None),
+        arr_root_folder=get_root_folder_from_path(series.get('folderPath') or series.get('path')),
         season_number=None,
         season_folder_name=None
     )
@@ -384,7 +387,7 @@ def handle_seriesadd(data: dict, is_4k: bool = False):
                                     episode_range=(episode_num, episode_num),
                                     episode_title=ep_title_final,
                                     folder_path=series.get('folderPath') or series.get('path'),
-                                    arr_root_folder=series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None),
+                                    arr_root_folder=get_root_folder_from_path(series.get('folderPath') or series.get('path')),
                                     overview=ep_overview,
                                     request_mark=False,
                                     genres=ep_genres,
@@ -459,7 +462,7 @@ def handle_episodefiledelete(data: dict, is_4k: bool = False):
                 
         # Use folderPath from webhook if available
         folder_path = series.get('folderPath')
-        arr_root_folder = series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None) or None
+        arr_root_folder = get_root_folder_from_path(folder_path)
         dummy_path = place_dummy_file("tv", series_title, series_year, tvdb_id,
                                       None,
                                       season_number=season_num,
@@ -515,7 +518,7 @@ def handle_moviefiledelete(data: dict):
         title = movie.get('title', 'Unknown Movie')
         year = movie.get('year')
         folder_path = movie.get('folderPath')
-        arr_root_folder = movie.get('rootFolderPath') or getattr(settings, 'RADARR_ROOT_FOLDER', None) or None
+        arr_root_folder = get_root_folder_from_path(folder_path)
         library_path = getattr(settings, 'MOVIE_LIBRARY_FOLDER', None)
         # Create a placeholder dummy file for the deleted movie
         from services.integrations import place_dummy_file
@@ -562,15 +565,21 @@ def handle_movie_delete(data: dict):
         title = movie.get('title', 'Unknown Movie')
         year = movie.get('year')
         folder_path = movie.get('folderPath')
-        arr_root_folder = movie.get('rootFolderPath') or getattr(settings, 'RADARR_ROOT_FOLDER', None) or None
+        arr_root_folder = get_root_folder_from_path(folder_path)
         library_path = getattr(settings, 'MOVIE_LIBRARY_FOLDER', None)
         # Use the unified dummy deletion logic
         from services.integrations import delete_dummy_files
         delete_dummy_files('movie', title, year, tmdb_id, library_path=library_path, folder_path=folder_path, arr_root_folder=arr_root_folder)
         # Optionally refresh Plex/Jellyfin at the dummy folder location
-        if folder_path and library_path:
+        dummy_folder = None
+        if folder_path:
             import os
-            dummy_folder = os.path.join(library_path, os.path.basename(folder_path))
+            if getattr(settings, 'USE_ROOT_FOLDERS', False):
+                _root = arr_root_folder or os.path.dirname(folder_path)
+                dummy_folder = os.path.join(_root, settings.DUMMY_FOLDER_NAME, os.path.basename(folder_path))
+            elif library_path:
+                dummy_folder = os.path.join(library_path, os.path.basename(folder_path))
+        if dummy_folder:
             if settings.plex_enabled:
                 refresh_plex_item(dummy_folder)
             if settings.jellyfin_enabled:
@@ -608,7 +617,7 @@ def handle_movieadd(data: dict):
                 return
             # Use folderPath from webhook if available
             folder_path = data.get('movie', {}).get('folderPath')
-            arr_root_folder = data.get('movie', {}).get('rootFolderPath') or getattr(settings, 'RADARR_ROOT_FOLDER', None) or None
+            arr_root_folder = get_root_folder_from_path(folder_path)
             # Try basic placeholder first
             dummy_path = place_dummy_file("movie", title, year, tmdb_id, None, folder_path=folder_path, arr_root_folder=arr_root_folder,
                                          overview=movie.get('overview') or movie.get('synopsis') or None,
@@ -675,12 +684,11 @@ def handle_seriesdelete(data: dict, is_4k: bool = False):
         else:
             base_path = None
             folder_path = series.get('folderPath') or series.get('path')
-            arr_root_folder = series.get('rootFolderPath') or getattr(settings, 'SONARR_ROOT_FOLDER', None) or None
+            arr_root_folder = get_root_folder_from_path(folder_path)
         from services.integrations import delete_dummy_files
         delete_dummy_files('tv', title, year, tvdb_id, base_path, folder_path=folder_path, arr_root_folder=arr_root_folder)
         # Remove series-level NFO if present
         try:
-            from services.integrations import _write_series_nfo
             import os
             nfo_path = os.path.join(base_path, f"{sanitize_filename(title)} ({year}) {{tvdb-{tvdb_id}}}", 'tvshow.nfo')
             if os.path.exists(nfo_path):
@@ -750,6 +758,12 @@ def handle_playback(data: dict, precomputed_file_path: str = None):
             placeholder_folders.append(settings.MOVIE_LIBRARY_4K_FOLDER)
         if getattr(settings, 'TV_LIBRARY_4K_FOLDER', None):
             placeholder_folders.append(settings.TV_LIBRARY_4K_FOLDER)
+            
+        # Option 3: add {root}/{DUMMY_FOLDER_NAME}/ prefix for each mapped root folder
+        if getattr(settings, 'USE_ROOT_FOLDERS', False) and settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+            dummy = getattr(settings, 'DUMMY_FOLDER_NAME', 'placeholders')
+            for root in settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+                placeholder_folders.append(root.rstrip('/') + '/' + dummy + '/')
 
         logger.debug(f"Checking path against placeholder folders: {placeholder_folders}", extra={'emoji_type': 'debug'})
         is_placeholder = any(file_path.startswith(folder) for folder in placeholder_folders if folder)
@@ -784,8 +798,9 @@ def handle_playback(data: dict, precomputed_file_path: str = None):
             
             logger.info(f"Processing movie playback for {title}", extra={'emoji_type': 'process'})
             
-            radarr_id = search_in_radarr(title=title, tmdb_id=tmdb_id, imdb_id=imdb_id, 
-                                       year=year, rating_key=rating_key, is_4k=is_4k)
+            radarr_id = search_in_radarr(title=title, tmdb_id=tmdb_id, imdb_id=imdb_id,
+                                       year=year, rating_key=rating_key, is_4k=is_4k,
+                                       file_path=file_path)
             
             if radarr_id:
                 # Movie exists in Radarr, add to our monitoring system

--- a/services/integrations.py
+++ b/services/integrations.py
@@ -1,14 +1,18 @@
-import os, glob, shutil, time, threading, requests, subprocess, platform, re, fnmatch, sys
+import os
+import shutil
+import time
+import threading
+import requests
+import re
 import xml.etree.ElementTree as ET
 from core.nfo import generate_movie_nfo, generate_episode_nfo, write_nfo_for_file
 from core.config import settings
 from core.logger import logger
 from services.utils import (
     resolve_final_folder, sanitize_filename, strip_status_markers, get_arr_config,
-    normalize_arr_base, join_endpoint
+    normalize_arr_base, join_endpoint, get_root_folder_from_path
 )
 from services.plex_client import plex
-import hashlib
 
 # Global variables
 BASE_TITLES = {}
@@ -580,7 +584,7 @@ def trigger_radarr_search(movie_id, movie_title=None):
         logger.error(f"Radarr search failed: {e}", extra={'emoji_type': 'error'})
         return False
 
-def search_in_radarr(tmdb_id, rating_key, is_4k=False, title=None, imdb_id=None, year=None):
+def search_in_radarr(tmdb_id, rating_key, is_4k=False, title=None, imdb_id=None, year=None, file_path=None):
     """Search for a movie in Radarr"""
     config = get_arr_config('movie', is_4k)
     # Validate tmdb_id is an integer
@@ -644,7 +648,7 @@ def search_in_radarr(tmdb_id, rating_key, is_4k=False, title=None, imdb_id=None,
             'qualityProfileId': 7,
             'tmdbId': int(movie_data['tmdbId']),
             'year': int(movie_data['year']),
-            'rootFolderPath': settings.MOVIE_LIBRARY_FOLDER,  # Use .env value
+            'rootFolderPath': get_root_folder_from_path(file_path) or settings.MOVIE_LIBRARY_FOLDER,
             'monitored': True,
             'addOptions': {
                 'searchForMovie': True,
@@ -679,72 +683,6 @@ def search_in_radarr(tmdb_id, rating_key, is_4k=False, title=None, imdb_id=None,
         logger.error(f"Radarr operation failed: {e}", extra={'emoji_type': 'error'})
         return False
 
-# Sonarr integration functions would follow a similar pattern.
-def search_in_sonarr(tvdb_id, rating_key, season_number=None, episode_number=None, is_4k=False):
-    """Search for a series in Sonarr but don't automatically mark as monitored"""
-    try:
-        config = get_arr_config('tv', is_4k)
-        # First check if series exists
-        existing_response = requests.get(
-            f"{config['url']}/series", 
-            params={'tvdbId': tvdb_id}, 
-            headers={'X-Api-Key': config['api_key']}
-        )
-        existing_response.raise_for_status()
-        
-        if existing_response.status_code == 200 and existing_response.json():
-            series = existing_response.json()[0]
-            logger.info(f"Series already exists in Sonarr: {series['title']}", extra={'emoji_type': 'info'})
-            
-            return series['id']
-                
-            # Only trigger series-wide search if not in episode mode
-            trigger_sonarr_search(series['id'], series_title=series['title'], is_4k=is_4k)
-            return series['id']
-        
-        # If series doesn't exist, look it up and add it
-        lookup_response = requests.get(
-            f"{config['url']}/series/lookup", 
-            params={'term': f"tvdb:{tvdb_id}"},
-            headers={'X-Api-Key': config['api_key']}
-        )
-        lookup_response.raise_for_status()
-        series_data = lookup_response.json()[0]
-        
-        payload = {
-            'title': series_data['title'],
-            'qualityProfileId': 3,
-            'titleSlug': series_data['titleSlug'],
-            'tvdbId': series_data['tvdbId'],
-            'year': series_data['year'],
-            'rootFolderPath': settings.TV_LIBRARY_FOLDER,  # Use .env value
-            'monitored': True,
-            'addOptions': {'searchForMissingEpisodes': True},
-            'seasons': []
-        }
-        
-        # Add all seasons as monitored
-        for season in series_data.get('seasons', []):
-            if season.get('seasonNumber', 0) > 0:  # Skip season 0
-                payload['seasons'].append({
-                    'seasonNumber': season['seasonNumber'],
-                    'monitored': True
-                })
-        
-        add_response = requests.post(
-            f"{config['url']}/series",
-            json=payload,
-            headers={'X-Api-Key': config['api_key']}
-        )
-        add_response.raise_for_status()
-        added_series = add_response.json()
-        logger.info(f"Added series: {series_data['title']}", extra={'emoji_type': 'success'})
-        
-        return added_series['id']
-        
-    except Exception as e:
-        logger.error(f"Sonarr operation failed: {e}", extra={'emoji_type': 'error'})
-        return None
 
 def trigger_sonarr_search(series_id, season_number=None, episode_ids=None, series_title="Unknown Series", is_4k=False):
     """Trigger a search in Sonarr for episodes"""
@@ -1121,10 +1059,6 @@ def search_in_sonarr(tvdb_id=None, title=None, year=None, rating_key=None, seaso
         sonarr_url = cfg['url']
         headers = {"X-Api-Key": cfg['api_key']}
         
-        # --- Always resolve folder path for placeholder creation/deletion ---
-        folder_path = file_path or None
-        arr_root_folder = getattr(settings, 'SONARR_ROOT_FOLDER', None) or None
-
         # Prepare series endpoint
         series_url = join_endpoint(sonarr_url, 'series')
 
@@ -1495,7 +1429,6 @@ def batch_poll_and_update_plex_status(tvdb_id, title, episodes, max_attempts=10,
     import time
     from datetime import datetime, timedelta
     from services.plex_client import batch_update_plex_episode_status, find_show_by_id
-    from services.calendar_sync import _parse_air_date
     
     def _local_date(dt):
         return dt.astimezone().date() if dt and hasattr(dt, 'tzinfo') and dt.tzinfo else dt.date() if dt else None
@@ -1564,7 +1497,7 @@ def batch_poll_and_update_plex_status(tvdb_id, title, episodes, max_attempts=10,
             batch_update_plex_episode_status(tvdb_id, title, status_map, throttle=throttle)
         batch_duration = time.time() - batch_start
         if len(done) == prev_done_count and attempt > 0:
-            logger.info(f"[BatchPoll] No new episodes ready since last poll. Finishing early and updating all remaining as blank.", extra={'emoji_type': 'info'})
+            logger.info("[BatchPoll] No new episodes ready since last poll. Finishing early and updating all remaining as blank.", extra={'emoji_type': 'info'})
             remaining_status_map = {}
             for key, ep_data in ep_lookup.items():
                 if key not in done:

--- a/services/jellyfin_client.py
+++ b/services/jellyfin_client.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-from typing import List, Optional, Dict, Any, Callable, Tuple
+from typing import List, Optional, Any, Callable
 from urllib.parse import quote
 import requests
 from core.config import settings
@@ -500,7 +500,7 @@ def test_jellyfin_connection() -> bool:
         resp = session.get(url)
         resp.raise_for_status()
         return True
-    except Exception as ex:
+    except Exception:
         return False
 
 def test_jellyfin_endpoints():
@@ -530,22 +530,3 @@ if getattr(settings, "jellyfin_enabled", False):
     except Exception as ex:
         logger.error(f"Failed to connect to Jellyfin server: {ex}", extra={'emoji_type': 'error'})
 
-def get_jellyfin_file_path(item_id: str, user_id: Optional[str] = None) -> str:
-    """
-    Return the file path for a Jellyfin item, optionally for a specific user.
-    """
-    try:
-        if user_id:
-            url = build_jellyfin_url(f"Users/{user_id}/Items/{item_id}")
-        else:
-            url = build_jellyfin_url(f"Items/{item_id}")
-        resp = session.get(url)
-        if resp.status_code == 200:
-            item = resp.json()
-            return item.get("Path", "")
-        else:
-            logger.warning(f"get_jellyfin_file_path: Failed to fetch item {item_id} (status {resp.status_code})", extra={'emoji_type': 'warning'})
-            return ""
-    except Exception as ex:
-        logger.error(f"get_jellyfin_file_path: Exception for item {item_id}: {ex}", extra={'emoji_type': 'error'})
-        return ""

--- a/services/migration.py
+++ b/services/migration.py
@@ -3,11 +3,9 @@ import requests
 import time
 from pathlib import Path
 from services.utils import get_arr_config, join_endpoint
-from fastapi.responses import JSONResponse
 
 from core.config import settings
 from core.logger import logger
-from services.integrations import place_dummy_file
 from services.handlers import handle_seriesadd, handle_movieadd
 from services.plex_client import refresh_plex_item
 from services.jellyfin_client import refresh_jellyfin_item

--- a/services/plex_client.py
+++ b/services/plex_client.py
@@ -1,8 +1,10 @@
-import os, urllib.parse, requests
+import os
+import requests
 from urllib.parse import quote
 from plexapi.server import PlexServer
 from core.config import settings
 from core.logger import logger
+from services.utils import get_root_folder_from_path
 
 def build_plex_url(path: str) -> str:
     if not getattr(settings, "plex_enabled", False) or not settings.PLEX_URL:
@@ -17,35 +19,51 @@ def build_plex_url(path: str) -> str:
     logger.debug(f"Built Plex URL: {url}", extra={'emoji_type': 'debug'})
     return url
 
+def _get_section_id_for_path(item_path, media_type=None):
+    """Determine the Plex section ID for a given file/folder path.
+
+    Consults ROOT_FOLDER_SECTION_ID_MAPPINGS first (Option 3), then falls back
+    to the legacy MOVIE_LIBRARY_FOLDER / TV_LIBRARY_FOLDER prefix matching,
+    and finally uses the media_type hint or path keyword heuristics.
+    """
+    if not item_path:
+        return None
+    # Option 3: look up by root folder mapping
+    if getattr(settings, 'USE_ROOT_FOLDERS', False) and settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+        root = get_root_folder_from_path(item_path)
+        if root is not None and root in settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+            return settings.ROOT_FOLDER_SECTION_ID_MAPPINGS[root]
+
+    # Legacy: match against explicit library folder prefixes
+    if any(item_path.startswith(f) for f in [settings.MOVIE_LIBRARY_FOLDER, settings.MOVIE_LIBRARY_4K_FOLDER] if f):
+        return settings.PLEX_MOVIE_SECTION_ID
+    if any(item_path.startswith(f) for f in [settings.TV_LIBRARY_FOLDER, settings.TV_LIBRARY_4K_FOLDER] if f):
+        return settings.PLEX_TV_SECTION_ID
+
+    # Fallback: media_type hint or path keyword heuristics
+    if media_type == 'movie' or 'movie' in item_path.lower():
+        return settings.PLEX_MOVIE_SECTION_ID
+    if media_type == 'tv' or 'tv' in item_path.lower() or 'season' in item_path.lower():
+        return settings.PLEX_TV_SECTION_ID
+
+    return None
+
+
 def refresh_plex_item(item_path, media_type=None):
     if not getattr(settings, "plex_enabled", False) or not settings.PLEX_URL or not settings.PLEX_TOKEN:
         return False
     """
     Refresh a specific Plex path
-    
+
     Args:
         item_path (str): Path to refresh
         media_type (str, optional): 'movie' or 'tv' to help determine section
     """
     try:
-        # Determine section ID from path or media_type
-        section_id = None
-        
-        # First try to determine by path prefix
-        if any(item_path.startswith(folder) for folder in [settings.MOVIE_LIBRARY_FOLDER, settings.MOVIE_LIBRARY_4K_FOLDER] if folder):
-            section_id = settings.PLEX_MOVIE_SECTION_ID
-        elif any(item_path.startswith(folder) for folder in [settings.TV_LIBRARY_FOLDER, settings.TV_LIBRARY_4K_FOLDER] if folder):
-            section_id = settings.PLEX_TV_SECTION_ID
-        
-        # If that fails, use media_type hint or try to guess from path
+        section_id = _get_section_id_for_path(item_path, media_type)
         if section_id is None:
-            if media_type == 'movie' or ('movie' in item_path.lower()):
-                section_id = settings.PLEX_MOVIE_SECTION_ID
-            elif media_type == 'tv' or 'tv' in item_path.lower() or 'season' in item_path.lower():
-                section_id = settings.PLEX_TV_SECTION_ID
-            else:
-                logger.error(f"Cannot determine section ID for path: {item_path}", extra={'emoji_type': 'error'})
-                return False
+            logger.error(f"Cannot determine section ID for path: {item_path}", extra={'emoji_type': 'error'})
+            return False
         
         # Make sure we're refreshing a directory, not a file
         if os.path.isfile(item_path):

--- a/services/queue_monitor.py
+++ b/services/queue_monitor.py
@@ -3,8 +3,8 @@ import time
 import requests
 from core.logger import logger
 from core.config import settings
-from services.integrations import get_sonarr_queue, get_radarr_queue, strip_status_markers
-from datetime import datetime, timezone, timedelta
+from services.integrations import get_sonarr_queue, get_radarr_queue
+from datetime import datetime
 from services.utils import get_arr_config, join_endpoint
 
 # Global registry to track monitored media

--- a/services/utils.py
+++ b/services/utils.py
@@ -180,20 +180,17 @@ def resolve_final_folder(media_type, title=None, year=None, media_id=None, seaso
         root = get_root_folder_from_path(arr_root_folder or folder_path)
         if root and arr_folder_name:
             base_folder = os.path.join(root, settings.DUMMY_FOLDER_NAME, arr_folder_name)
-            # Apply season folder for TV and return
-            if media_type != "movie":
-                season_folder = arr_season_folder
-                if not season_folder and relative_path:
-                    parts = os.path.normpath(relative_path).split(os.sep)
-                    for part in parts:
-                        if part.lower().startswith("season"):
-                            season_folder = part
-                            break
-                elif not season_folder and season_number is not None:
-                    season_folder = f"Season {season_number:02d}"
-                if season_folder:
-                    return os.path.join(base_folder, season_folder)
-            return base_folder
+            if media_type == "movie":
+                return base_folder
+            season_folder = arr_season_folder
+            if not season_folder and relative_path:
+                for part in os.path.normpath(relative_path).split(os.sep):
+                    if part.lower().startswith("season"):
+                        season_folder = part
+                        break
+            if not season_folder and season_number is not None:
+                season_folder = f"Season {season_number:02d}"
+            return os.path.join(base_folder, season_folder) if season_folder else base_folder
 
     # Determine base path
     if media_type == "movie":

--- a/services/utils.py
+++ b/services/utils.py
@@ -133,6 +133,24 @@ def get_arr_config(media_type: str, is_4k: bool = False) -> dict:
             "search_type": media_type
         }
 
+def get_root_folder_from_path(folder_path):
+    """Derive the *arr root folder from a full media folder path.
+
+    When USE_ROOT_FOLDERS=True and ROOT_FOLDER_SECTION_ID_MAPPINGS is set,
+    finds the matching root by startsWith against mapping keys. Returns the
+    original mapping key so callers can look it up directly.
+    Falls back to os.path.dirname(folder_path).
+    """
+    if not folder_path:
+        return None
+    if getattr(settings, 'USE_ROOT_FOLDERS', False) and settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+        for root_folder in settings.ROOT_FOLDER_SECTION_ID_MAPPINGS:
+            prefix = root_folder if root_folder.endswith('/') else root_folder + '/'
+            if folder_path.startswith(prefix):
+                return root_folder
+    return os.path.dirname(folder_path)
+
+
 def resolve_final_folder(media_type, title=None, year=None, media_id=None, season_number=None, folder_path=None, arr_root_folder=None, season_folder_name=None, relative_path=None, payload=None):
     """
     Centralized function to resolve the final folder path for dummy file operations.
@@ -157,6 +175,26 @@ def resolve_final_folder(media_type, title=None, year=None, media_id=None, seaso
             arr_folder_name = os.path.basename(arr_full_path)
             arr_root = os.path.dirname(arr_full_path)
         arr_season_folder = payload.get('seasonFolder') or payload.get('season_folder') or season_folder_name
+    # Priority 0: USE_ROOT_FOLDERS mode — place placeholders in a subfolder of the *arr root folder
+    if getattr(settings, 'USE_ROOT_FOLDERS', False):
+        root = get_root_folder_from_path(arr_root_folder or folder_path)
+        if root and arr_folder_name:
+            base_folder = os.path.join(root, settings.DUMMY_FOLDER_NAME, arr_folder_name)
+            # Apply season folder for TV and return
+            if media_type != "movie":
+                season_folder = arr_season_folder
+                if not season_folder and relative_path:
+                    parts = os.path.normpath(relative_path).split(os.sep)
+                    for part in parts:
+                        if part.lower().startswith("season"):
+                            season_folder = part
+                            break
+                elif not season_folder and season_number is not None:
+                    season_folder = f"Season {season_number:02d}"
+                if season_folder:
+                    return os.path.join(base_folder, season_folder)
+            return base_folder
+
     # Determine base path
     if media_type == "movie":
         env_base = getattr(settings, "MOVIE_LIBRARY_FOLDER", None)


### PR DESCRIPTION
- Adds Option 3 library path strategy: instead of hardcoding MOVIE_LIBRARY_FOLDER/TV_LIBRARY_FOLDER, Placeholdarr derives the placeholder path dynamically from the folderPath in each webhook payload by matching it against ROOT_FOLDER_SECTION_ID_MAPPINGS keys using a startsWith check. Placeholders are created at {root}/{DUMMY_FOLDER_NAME}/{media_folder}/.
- Removes all reads of rootFolderPath from webhook/API-response data — the field is never sent in Radarr/Sonarr webhook payloads. Root folder is now always derived from folderPath.
- Cleans up 40 auto-fixable lint errors, removes two duplicate function definitions (search_in_sonarr, get_jellyfin_file_path), and fixes several pre-existing type annotation issues.


#### Detailed changes
- Add USE_ROOT_FOLDERS, DUMMY_FOLDER_NAME, ROOT_FOLDER_SECTION_ID_MAPPINGS config fields with JSON parsing validator
- Add get_root_folder_from_path() to derive *arr root from folderPath via startsWith match against ROOT_FOLDER_SECTION_ID_MAPPINGS keys
- Add resolve_final_folder Priority 0 block: places placeholders at {root}/{DUMMY_FOLDER_NAME}/{media_folder}/[Season XX/]
- Add _get_section_id_for_path() in plex_client for Option 3 section lookup
- Pass file_path through handle_playback → search_in_radarr so rootFolderPath can be derived from placeholder path on playback trigger
- Fix is_placeholder check in handle_playback to recognise Option 3 paths
- Add root_validator enforcing USE_ROOT_FOLDERS mutual exclusivity: requires ROOT_FOLDER_SECTION_ID_MAPPINGS, rejects set MOVIE/TV_LIBRARY_FOLDER
- Remove rootFolderPath reads from webhook payloads (field is never sent); replace with get_root_folder_from_path(folderPath) throughout
- Remove dead first search_in_sonarr definition and duplicate get_jellyfin_file_path; apply ruff auto-fixes (40 errors)
- Fix _get_section_id_for_path None guard, remove os.makedirs side effect from resolve_final_folder, fix Optional[int] return type annotations
- Update README and .env.example with Option 3 setup, folder structure example, and corrected PLEX_MOVIE/TV_SECTION_ID fallback note