### PR TITLE
feat: Add WEBHOOK_BASE_URL override for webhook setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ TAUTULLI_INSTANCE_KEY=tautulli
 JELLYFIN_INSTANCE_KEY=jellyfin
 EMBY_INSTANCE_KEY=emby
 
+# Optional override for the URL ARR/Tautulli/Jellyfin/Emby should use to
+# call Placeholdarr — only the URL displayed in webhook setup instructions.
+# Use this when those services reach Placeholdarr at a different address
+# than the URL you use to view the dashboard (for example, an internal
+# Docker/Kubernetes service name when the dashboard is reached through a
+# public reverse proxy). No trailing slash.
+# Can also be set in Settings → Advanced → "Webhook base URL".
+# WEBHOOK_BASE_URL=http://placeholdarr:8000
+
 # Optional external Postgres overrides
 # Leave commented when using bundled Postgres from docker-compose.yml.
 # Uncomment only if Placeholdarr should connect to an external Postgres server.

--- a/core/config.py
+++ b/core/config.py
@@ -169,6 +169,11 @@ class Settings(BaseSettings):
     TAUTULLI_INSTANCE_KEY: str = os.getenv("TAUTULLI_INSTANCE_KEY", "tautulli").split('#')[0].strip().lower()
     JELLYFIN_INSTANCE_KEY: str = os.getenv("JELLYFIN_INSTANCE_KEY", "jellyfin").split('#')[0].strip().lower()
     EMBY_INSTANCE_KEY: str = os.getenv("EMBY_INSTANCE_KEY", "emby").split('#')[0].strip().lower()
+    # Optional override for the URL displayed in webhook setup instructions.
+    # Set when Placeholdarr is reachable from ARR/Tautulli/etc. at a different
+    # address than the dashboard origin — e.g. an internal Docker/Kubernetes
+    # service name when the dashboard is reached via a public reverse proxy.
+    WEBHOOK_BASE_URL: str = os.getenv("WEBHOOK_BASE_URL", "").split('#')[0].strip().rstrip("/")
 
     # Startup sync mode:
     # - auto: first successful ARR startup run is full, then lite on later startups

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4150,6 +4150,19 @@ function stableArrInstanceId(arrType: "radarr" | "sonarr", slotRole: "primary" |
   return `${arrType}_${slotRole}`;
 }
 
+/**
+ * Resolve the origin used in webhook setup instructions.
+ * Prefers the user-configured WEBHOOK_BASE_URL (when ARR/Tautulli/etc. reach
+ * Placeholdarr at a different address than the dashboard origin — e.g. an
+ * internal Docker name behind a public reverse proxy), otherwise falls back
+ * to the current window origin.
+ */
+function resolveWebhookDisplayOrigin(values: FieldValueMap): string {
+  const override = String(values.WEBHOOK_BASE_URL ?? "").trim().replace(/\/+$/, "");
+  if (override) return override;
+  return typeof window !== "undefined" ? window.location.origin : "";
+}
+
 function buildArrInstanceWebhookUrls(origin: string, instance_id: string, instance_key: string) {
   const id = String(instance_id || "").trim().toLowerCase();
   const key = normalizeInstanceKey(String(instance_key || ""));
@@ -4580,7 +4593,7 @@ function ArrInstancesEditor(props: {
   }
 
   function instanceWebhookUrls(instance_id: string, instance_key: string) {
-    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const origin = resolveWebhookDisplayOrigin(props.values);
     return buildArrInstanceWebhookUrls(origin, instance_id, instance_key);
   }
 
@@ -6303,6 +6316,7 @@ function SettingsPanel(props: {
         dialog={playbackWebhookDialog}
         onClose={() => setPlaybackWebhookDialog(null)}
         accent={accent}
+        displayOrigin={resolveWebhookDisplayOrigin(props.values)}
       />
     ) : null}
     </>
@@ -6482,10 +6496,10 @@ function PlaybackWebhookSetupModal(props: {
   dialog: { serviceId: PlaybackWebhookServiceId; instanceParam: string };
   onClose: () => void;
   accent: { hex: string };
+  displayOrigin: string;
 }) {
   const pb = props.dialog;
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const webhookUrl = `${origin}/webhook?instance=${encodeURIComponent(pb.instanceParam)}`;
+  const webhookUrl = `${props.displayOrigin}/webhook?instance=${encodeURIComponent(pb.instanceParam)}`;
   const svcMeta = PLAYBACK_WEBHOOK_SERVICES.services.find((s) => s.id === pb.serviceId);
   const name = svcMeta?.name ?? pb.serviceId;
   return (
@@ -7750,6 +7764,7 @@ function OnboardingWizard(props: {
           dialog={playbackWebhookDialog}
           onClose={() => setPlaybackWebhookDialog(null)}
           accent={accent}
+          displayOrigin={resolveWebhookDisplayOrigin(props.values)}
         />
       ) : null}
     </>

--- a/services/app_config.py
+++ b/services/app_config.py
@@ -418,6 +418,25 @@ SETTINGS_SCHEMA: "OrderedDict[str, dict[str, Any]]" = OrderedDict(
             },
         ),
         (
+            "WEBHOOK_BASE_URL",
+            {
+                "section": "Advanced",
+                "label": "Webhook base URL",
+                "description": (
+                    "Optional. The URL that ARR, Tautulli, Jellyfin, and Emby should use to call "
+                    "Placeholdarr. When set, this replaces the dashboard origin in the webhook "
+                    "setup instructions. Use this when the address those services should reach "
+                    "Placeholdarr at is different from the URL you use to view the dashboard — "
+                    "for example, an internal Docker/Kubernetes service name when the dashboard "
+                    "is reached through a public reverse proxy. Leave blank to use the dashboard's "
+                    "own URL. Format: http(s)://host[:port] (no trailing slash)."
+                ),
+                "type": "url",
+                "required": False,
+                "restart_required": False,
+            },
+        ),
+        (
             "PLACEHOLDER_STRATEGY",
             {
                 "section": "Advanced",


### PR DESCRIPTION
## Summary

Adds an optional `WEBHOOK_BASE_URL` setting that overrides the URL shown in the webhook setup instructions for ARR, Tautulli, Jellyfin, and Emby. Useful when those services reach Placeholdarr at a different address than the URL used to view the dashboard — for example, an internal Docker or Kubernetes service name when the dashboard is reached through a public reverse proxy.

When unset, the dashboard origin (`window.location.origin`) is used as before, so existing installs are unaffected.

## Changes

- `core/config.py` — new `WEBHOOK_BASE_URL` settings field (env-overridable, trailing slash stripped, default empty).
- `services/app_config.py` — exposes the field in **Settings → Advanced** as an optional URL input. Validated by the existing `_coerce_url` (must be `http(s)://...`).
- `.env.example` — documents the new variable.
- `frontend/src/App.tsx` — new `resolveWebhookDisplayOrigin()` helper used by both the ARR webhook URL builder (`instanceWebhookUrls`) and the Tautulli/Jellyfin/Emby `PlaybackWebhookSetupModal`. Behaviour is unchanged when the field is empty.

## Test plan

- [ ] Leave **Webhook base URL** empty → all webhook setup modals show URLs prefixed with the dashboard origin (existing behaviour).
- [ ] Set **Webhook base URL** to `http://placeholdarr:8000` → ARR (Radarr/Sonarr) webhook URLs in the slot/onboarding panel use `http://placeholdarr:8000` as origin.
- [ ] Same setting → Tautulli, Jellyfin, and Emby `PlaybackWebhookSetupModal` show URLs using `http://placeholdarr:8000`.
- [ ] Save with a trailing slash (e.g. `http://placeholdarr:8000/`) → stored without the trailing slash; rendered URLs are not double-slashed.
- [ ] Save an invalid value (e.g. `not-a-url`) → backend rejects with a validation error from `_coerce_url`.
- [ ] Restart not required: change takes effect on next render of the webhook modals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)