### PR TITLE
Fix placeholder mirroring for episodes and movies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-04-30
+
+### Summary
+
+- REQUEST placeholders now have a one-time startup NFO refresh backfill so summary/runtime projection catches up without waiting for status transitions.
+- REQUEST summary projection now includes duration in the same status bracket for clearer at-a-glance metadata. Done through a one-time startup NFO refresh backfill to add runtime to all "[REQUEST]" status summaries.
+- Placeholder presence drift between `Episode`/`Movie` and linked `Placeholder` rows is now corrected in runtime refresh paths, preventing large libraries from being skipped by NFO refresh jobs.
+- Webhook setup instructions can now be forced to a specific externally reachable base URL.
+
 ### Added
 
+- **Webhook base URL override for setup instructions**
+  - Added `WEBHOOK_BASE_URL` support so generated webhook guidance can use a fixed external URL instead of relying only on request-origin inference.
 - **REQUEST status NFO backfill on startup**
   - After materialization, the app can run a one-time backfill (tracked in `app_config`) that enqueues `nfo_refresh` jobs for active placeholders with `display_status` = `REQUEST`. Once successfully queued, it marks complete and does not rerun on later startups. This refreshes sidecar NFOs to pick up new summary/runtime wording without waiting for a status transition.
 
@@ -16,6 +27,12 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 - **REQUEST placeholder summaries show duration in the status bracket**
   - For `REQUEST` only, the summary prefix includes rounded runtime from Radarr/Sonarr minutes inside the same brackets, e.g. `[1h 5m · REQUEST] …`. Legacy `~45m · [REQUEST]` and `[1h 5m - REQUEST]` text is still stripped when re-projecting. Plex/Jellyfin/Emby direct projection uses the same rule when the projected status is `REQUEST`. Episodes fall back to series runtime when episode runtime is missing.
+
+### Fixed
+
+- **Placeholder presence drift that could skip TV NFO refreshes**
+  - Presence-refresh paths now mirror canonical `Episode`/`Movie` placeholder truth back into linked `Placeholder` rows (including path realignment), reducing long-lived drift where episodes existed on disk but `Placeholder.has_placeholder` stayed false.
+  - NFO refresh processing now self-heals presence drift by honoring linked entity placeholder truth when deciding whether a queued placeholder should be refreshed.
 
 ## [0.9.8] - 2026-04-29
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4191,8 +4191,14 @@ function deriveIs4kFromRole(role: string) {
 }
 
 function getPlexLibraryIdNote(fieldKey: string) {
-  if (fieldKey === "PLEX_MOVIE_SECTION_ID") return "Use the Plex library ID for the placeholder movie library that points at your derived `movies` path.";
-  if (fieldKey === "PLEX_TV_SECTION_ID") return "Use the Plex library ID for the placeholder TV library that points at your derived `tv` path.";
+  const shared =
+    "For best request clarity and fewer scanner/trash cleanup issues, keep placeholders in separate Plex libraries from real media. Required when Plex is enabled.";
+  if (fieldKey === "PLEX_MOVIE_SECTION_ID") {
+    return `Use the Plex library ID for the placeholder movie library that points at your derived \`movies\` path. ${shared}`;
+  }
+  if (fieldKey === "PLEX_TV_SECTION_ID") {
+    return `Use the Plex library ID for the placeholder TV library that points at your derived \`tv\` path. ${shared}`;
+  }
   return null;
 }
 
@@ -4241,6 +4247,10 @@ function parseArrInstancesFromValues(values: FieldValueMap): ArrInstanceDraft[] 
     }
   }
   return [];
+}
+
+function isPlexSectionIdField(fieldKey: string) {
+  return fieldKey === "PLEX_MOVIE_SECTION_ID" || fieldKey === "PLEX_TV_SECTION_ID";
 }
 
 function serializeArrInstances(instances: ArrInstanceDraft[]) {
@@ -5362,7 +5372,9 @@ function LibraryPathsForm(props: {
               {field.secret && <span className="px-1.5 py-0.5 rounded text-[12px] font-bold font-headline uppercase bg-[#252e3a] text-slate-400">Secret</span>}
               {field.restart_required && <span className="px-1.5 py-0.5 rounded text-[12px] font-bold font-headline uppercase bg-orange-600/30 text-orange-300">Restart Required</span>}
             </div>
-            {field.description && <p className="ui-field-description mt-1">{field.description}</p>}
+            {field.description && !isPlexSectionIdField(field.key) ? (
+              <p className="ui-field-description mt-1">{field.description}</p>
+            ) : null}
             {getPlexLibraryIdNote(field.key) ? <p className="ui-field-description mt-1">{getPlexLibraryIdNote(field.key)}</p> : null}
           </div>
         </div>
@@ -5792,9 +5804,12 @@ function SettingsPanel(props: {
                 <PlaceholderStatusUpdatesDescription spacing="settings" />
               ) : field.key === "ENABLE_COMING_SOON_COUNTDOWN" ? (
                 <ComingSoonCountdownDescription spacing="settings" />
-              ) : field.description ? (
+              ) : field.description && !isPlexSectionIdField(field.key) ? (
                 <p className="ui-field-description mt-1">{field.description}</p>
               ) : null)}
+            {getPlexLibraryIdNote(field.key) ? (
+              <p className="ui-field-description mt-1">{getPlexLibraryIdNote(field.key)}</p>
+            ) : null}
             {field.key === "FULL_SYNC_INTERVAL_HOURS" ? (
               <p className="ui-field-description ui-field-description-accent3 mt-2 leading-relaxed">
                 If you have Startup ARR sync mode set to OFF, then a scheduled sync is recommended.

--- a/services/source_of_truth/event_handlers.py
+++ b/services/source_of_truth/event_handlers.py
@@ -44,6 +44,44 @@ from services.source_of_truth.sync_runner import (
 )
 
 
+def _sync_linked_placeholder_presence(
+    session,
+    *,
+    movie_id: int | None = None,
+    episode_id: int | None = None,
+    exists_on_disk: bool,
+    expected_path: str | None,
+) -> int:
+    """Mirror entity-level placeholder presence onto linked Placeholder rows."""
+    if movie_id is None and episode_id is None:
+        return 0
+    query = session.query(Placeholder)
+    if movie_id is not None:
+        query = query.filter(Placeholder.movie_id == int(movie_id))
+    if episode_id is not None:
+        query = query.filter(Placeholder.episode_id == int(episode_id))
+    rows = query.all()
+    normalized_path = str(expected_path or "").strip()
+    changed = 0
+    for row in rows:
+        row_changed = False
+        if bool(getattr(row, "has_placeholder", False)) != bool(exists_on_disk):
+            row.has_placeholder = bool(exists_on_disk)
+            row_changed = True
+        if exists_on_disk and normalized_path and str(getattr(row, "path", "") or "").strip() != normalized_path:
+            row.path = normalized_path
+            row_changed = True
+        if exists_on_disk and hasattr(row, "lifecycle_status") and str(getattr(row, "lifecycle_status", "") or "").upper() == "MISSING":
+            row.lifecycle_status = None
+            row_changed = True
+        if row_changed:
+            row.last_observed_at = func.now()
+            row.updated_at = func.now()
+            session.add(row)
+            changed += 1
+    return changed
+
+
 def _resolve_arr_context(content_type: str, instance: str | None = None) -> dict[str, Any]:
     """Resolve ARR instance routing context for webhook event handlers.
 
@@ -249,6 +287,12 @@ def process_series_add_event(payload: dict[str, Any], instance: str | None = Non
             exists_on_disk = os.path.isfile(expected_path)
             ep_row.has_placeholder = bool(exists_on_disk)
             ep_row.placeholder_filepath = expected_path if exists_on_disk else None
+            _sync_linked_placeholder_presence(
+                session,
+                episode_id=int(ep_row.id),
+                exists_on_disk=bool(exists_on_disk),
+                expected_path=expected_path,
+            )
             if not exists_on_disk:
                 missing_placeholder_episode_rows.append(ep_row)
 
@@ -394,6 +438,12 @@ def process_movie_add_event(payload: dict[str, Any], instance: str | None = None
         exists_on_disk = os.path.isfile(expected_path)
         movie_row.has_placeholder = bool(exists_on_disk)
         movie_row.placeholder_filepath = expected_path if exists_on_disk else None
+        _sync_linked_placeholder_presence(
+            session,
+            movie_id=int(movie_row.id),
+            exists_on_disk=bool(exists_on_disk),
+            expected_path=expected_path,
+        )
         if not exists_on_disk:
             stale_rows = (
                 session.query(Placeholder)

--- a/services/source_of_truth/startup.py
+++ b/services/source_of_truth/startup.py
@@ -10,7 +10,7 @@ from core.config import settings
 from core.logger import logger
 from services.postgres.db import get_session
 from services.placeholders import episode_placeholder_path, movie_placeholder_path
-from services.postgres.models import ArrState, Episode, Movie, Season, Series
+from services.postgres.models import ArrState, Episode, Movie, Placeholder, Season, Series
 from services.source_of_truth.arr_api import (
     fetch_radarr_movies,
     fetch_sonarr_series,
@@ -410,6 +410,8 @@ def _refresh_placeholder_presence_for_entities(*, movie_row_ids: list[int], epis
         "movies_updated": 0,
         "episodes_checked": 0,
         "episodes_updated": 0,
+        "movie_placeholders_synced": 0,
+        "episode_placeholders_synced": 0,
     }
     if not movie_row_ids and not episode_row_ids:
         return stats
@@ -431,6 +433,23 @@ def _refresh_placeholder_presence_for_entities(*, movie_row_ids: list[int], epis
                     movie.updated_at = func.now()
                     session.add(movie)
                     stats["movies_updated"] += 1
+                linked_rows = session.query(Placeholder).filter(Placeholder.movie_id == int(movie.id)).all()
+                for row in linked_rows:
+                    row_changed = False
+                    if bool(getattr(row, "has_placeholder", False)) != exists:
+                        row.has_placeholder = exists
+                        row_changed = True
+                    if exists and new_path and _normalize_path(getattr(row, "path", None)) != _normalize_path(new_path):
+                        row.path = new_path
+                        row_changed = True
+                    if exists and hasattr(row, "lifecycle_status") and str(getattr(row, "lifecycle_status", "") or "").upper() == "MISSING":
+                        row.lifecycle_status = None
+                        row_changed = True
+                    if row_changed:
+                        row.last_observed_at = func.now()
+                        row.updated_at = func.now()
+                        session.add(row)
+                        stats["movie_placeholders_synced"] += 1
 
         if episode_row_ids:
             rows = (
@@ -453,6 +472,23 @@ def _refresh_placeholder_presence_for_entities(*, movie_row_ids: list[int], epis
                     episode.updated_at = func.now()
                     session.add(episode)
                     stats["episodes_updated"] += 1
+                linked_rows = session.query(Placeholder).filter(Placeholder.episode_id == int(episode.id)).all()
+                for row in linked_rows:
+                    row_changed = False
+                    if bool(getattr(row, "has_placeholder", False)) != exists:
+                        row.has_placeholder = exists
+                        row_changed = True
+                    if exists and new_path and _normalize_path(getattr(row, "path", None)) != _normalize_path(new_path):
+                        row.path = new_path
+                        row_changed = True
+                    if exists and hasattr(row, "lifecycle_status") and str(getattr(row, "lifecycle_status", "") or "").upper() == "MISSING":
+                        row.lifecycle_status = None
+                        row_changed = True
+                    if row_changed:
+                        row.last_observed_at = func.now()
+                        row.updated_at = func.now()
+                        session.add(row)
+                        stats["episode_placeholders_synced"] += 1
 
         session.commit()
         return stats

--- a/services/source_of_truth/status_reconciler.py
+++ b/services/source_of_truth/status_reconciler.py
@@ -286,11 +286,21 @@ def process_nfo_refresh_job(session, job: Job) -> dict:
     # (Placeholder row, entity dedupe key) for rows whose NFO was rewritten this run
     refreshed_for_player_push: list[tuple[Placeholder, tuple[str, int]]] = []
     for placeholder in placeholders:
-        if not getattr(placeholder, "has_placeholder", False):
-            continue
-
         movie = session.query(Movie).get(placeholder.movie_id) if placeholder.movie_id else None
         episode = session.query(Episode).get(placeholder.episode_id) if placeholder.episode_id else None
+        effective_has_placeholder = bool(getattr(placeholder, "has_placeholder", False))
+        if movie and bool(getattr(movie, "has_placeholder", False)):
+            effective_has_placeholder = True
+        if episode and bool(getattr(episode, "has_placeholder", False)):
+            effective_has_placeholder = True
+        if effective_has_placeholder and not bool(getattr(placeholder, "has_placeholder", False)):
+            # Self-heal drift so follow-up jobs do not keep skipping valid placeholders.
+            placeholder.has_placeholder = True
+            placeholder.updated_at = datetime.now(timezone.utc)
+            session.add(placeholder)
+        if not effective_has_placeholder:
+            continue
+
         if movie and _refresh_movie_nfo(placeholder, movie):
             refreshed += 1
             refreshed_for_player_push.append((placeholder, ("movie", int(movie.id))))


### PR DESCRIPTION
Enhance the synchronization of placeholder presence for episodes and movies, ensuring accurate mirroring of the `has_placeholder` flag. Update descriptions for Plex library IDs to improve clarity on placeholder usage.