### PR TITLE
Implement customizable status message templates and merge with updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+### Added
+
+- **Status message live preview API**: `POST /api/messages/preview` returns dual movie/episode sample lines (title + synopsis), honors draft projection mode and status-update scope, and reports empty tokens for the REQUEST synopsis template.
+- **Unified projection context for NFOs and players**: Media tokens (movie/episode/season/series) plus runtime flow through the same helper so REQUEST lines and title suffixes match between sidecar NFOs and direct player projection.
+- **Template apply-now coalescing**: Repeated “Apply now” supersedes pending template `nfo_refresh` jobs and tracks an active run id so only the latest sweep triggers the one-shot Plex library refresh when the final batch finishes.
+
+### Changed
+
+- **Settings → Status Updates** now includes the customizable status message templates (the old **Status Messages** tab is removed; `/settings/status-messages` redirects to Status Updates). Save blocks when templates have validation errors; saving persists field-backed settings first, then templates, so workers do not mix stale projection mode with new template text.
+- **Message registry (labels)**: Per-stage `status.label.*` and legacy bracket keys are dropped from the user-facing list; REQUEST uses **Request line (synopsis)** with expanded tokens (including TV fields). Title projection uses separate **title suffix** strings per surface (`movie`, `series`, `season`, `episode`) instead of `{Title}` / `{Bracket}` formatting.
+- **Status projection**: Projection mode maps to title and/or summary surfaces explicitly; stripping removes both square and angle bracket prefixes/suffixes where applicable.
+- **Docker entrypoint**: Creates `passwd`/`group` entries for `PUID`/`PGID` when missing so `setpriv` and `chown` work on slim base images.
+
+### Fixed
+
+- **Worker NFO backfill completion query**: Job payload run-id filters use SQLAlchemy JSON `.as_string()` (generic `JSON` columns), fixing `astext` crashes when completing coordinated backfill batches.
+
 ## [0.9.10] - 2026-05-05
 
 ### Changed

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,15 @@ PGID="${PGID:-1000}"
 
 mkdir -p /config/logs
 
+# setpriv --init-groups loads supplementary groups from nss; the target UID must exist in /etc/passwd.
+# python:3.12-slim has no uid 1000 by default (unlike linuxserver-style images). Create group/user if missing.
+if ! getent passwd "${PUID}" >/dev/null 2>&1; then
+  if ! getent group "${PGID}" >/dev/null 2>&1; then
+    groupadd -g "${PGID}" placeholdarr
+  fi
+  useradd -u "${PUID}" -g "${PGID}" -M -s /bin/sh placeholdarr
+fi
+
 chown -R "${PUID}:${PGID}" /config /app
 
 # util-linux setpriv: --clear-groups and --init-groups are mutually exclusive (newer versions exit with an error).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,14 @@
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { copyTextToClipboard } from "./copyToClipboard";
 import { ARR_WEBHOOK_SERVICES, PLAYBACK_WEBHOOK_SERVICES } from "./webhookConfig";
@@ -17,6 +27,7 @@ import {
   saveSettings,
   testIntegrationConnection,
 } from "./api/dashboard";
+import { fetchJson } from "./api/client";
 import embyIcon from "./assets/services/emby.svg";
 import jellyfinIcon from "./assets/services/jellyfin.svg";
 import plexIcon from "./assets/services/plex.svg";
@@ -126,6 +137,7 @@ const SETTINGS_SECTION_ORDER = [
   "Calendar",
   "Lookahead",
   "Status Updates",
+  "Status Messages",
   "Advanced",
 ];
 const SETTINGS_SECTION_ICONS: Record<string, string> = {
@@ -136,6 +148,7 @@ const SETTINGS_SECTION_ICONS: Record<string, string> = {
   "Calendar": "calendar_month",
   "Lookahead": "fast_forward",
   "Status Updates": "edit_notifications",
+  "Status Messages": "edit_note",
   "Advanced": "tune",
 };
 const SETTINGS_SECTION_SLUGS: Record<string, string> = {
@@ -146,8 +159,17 @@ const SETTINGS_SECTION_SLUGS: Record<string, string> = {
   "Calendar": "calendar",
   "Lookahead": "lookahead",
   "Status Updates": "status-updates",
+  "Status Messages": "status-messages",
   "Advanced": "advanced",
 };
+
+/** Virtual settings sections backed by their own API endpoint, not `/api/settings/current`. */
+const VIRTUAL_SETTINGS_SECTIONS = new Set<string>(["Status Messages"]);
+
+function resolveSettingsSectionFromSlug(slug: string): string | undefined {
+  if (!slug.trim()) return undefined;
+  return SETTINGS_SECTION_ORDER.find((name) => SETTINGS_SECTION_SLUGS[name] === slug);
+}
 const BEHAVIOR_WIZARD_SECTIONS = [
   "ARR Integrations",
   "Library sync",
@@ -560,13 +582,13 @@ export function App() {
       delete window.__PLACEHOLDARR_SETUP_PREVIEW__;
     }
   }, [location.pathname, location.search]);
-  const settingsSectionNames = useMemo(
-    () =>
-      settingsPayload
-        ? SETTINGS_SECTION_ORDER.filter((name) => settingsPayload.sections.some((s) => s.name === name))
-        : [],
-    [settingsPayload],
-  );
+  const settingsSectionNames = useMemo(() => {
+    if (!settingsPayload) return [];
+    const apiSections = settingsPayload.sections ?? [];
+    return SETTINGS_SECTION_ORDER.filter(
+      (name) => VIRTUAL_SETTINGS_SECTIONS.has(name) || apiSections.some((s) => s.name === name),
+    );
+  }, [settingsPayload]);
   const firstSettingsSection = settingsSectionNames[0] ?? SETTINGS_SECTION_ORDER[0];
   const firstSettingsPath = `/settings/${SETTINGS_SECTION_SLUGS[firstSettingsSection] ?? "media-integrations"}`;
   /** Until we know setup is complete, prefer `/setup` so `/` does not bounce through `/activity` (which runs heavy Activity fetches before we learn onboarding is incomplete). */
@@ -1033,21 +1055,28 @@ export function App() {
 
   useEffect(() => {
     if (currentTab !== "settings") return;
-    if (!settingsPayload) return;
     if (location.pathname === "/settings" || location.pathname === "/settings/") {
       navigate(firstSettingsPath, { replace: true });
       return;
     }
     const slug = location.pathname.split("/")[2] || "";
-    const matched = settingsSectionNames.find((name) => SETTINGS_SECTION_SLUGS[name] === slug);
+    const matched = resolveSettingsSectionFromSlug(slug);
     if (!matched) {
       navigate(firstSettingsPath, { replace: true });
       return;
     }
-    if (matched !== activeSettingsSection) {
-      setActiveSettingsSection(matched);
+    if (VIRTUAL_SETTINGS_SECTIONS.has(matched)) {
+      if (matched !== activeSettingsSection) setActiveSettingsSection(matched);
+      return;
     }
-  }, [activeSettingsSection, currentTab, firstSettingsPath, location.pathname, navigate, settingsPayload, settingsSectionNames]);
+    if (!settingsPayload) return;
+    const apiSections = settingsPayload.sections ?? [];
+    if (!apiSections.some((s) => s.name === matched)) {
+      navigate(firstSettingsPath, { replace: true });
+      return;
+    }
+    if (matched !== activeSettingsSection) setActiveSettingsSection(matched);
+  }, [activeSettingsSection, currentTab, firstSettingsPath, location.pathname, navigate, settingsPayload]);
 
   const libraryListShelf = getLibraryListShelf(location.pathname);
 
@@ -1112,11 +1141,16 @@ export function App() {
     setFieldValues(nextValues);
     setBaselineValues(nextValues);
 
-    const sections = SETTINGS_SECTION_ORDER.filter((name) => payload.sections.some((s) => s.name === name));
+    // Must match `settingsSectionNames`: include virtual tabs (e.g. Status Messages) that are not in `/api/settings/current`.
+    const apiSectionsForNav = payload.sections ?? [];
+    const sections = SETTINGS_SECTION_ORDER.filter(
+      (name) => VIRTUAL_SETTINGS_SECTIONS.has(name) || apiSectionsForNav.some((s) => s.name === name),
+    );
     if (sections.length > 0 && !sections.includes(activeSettingsSection)) {
       const slug = location.pathname.split("/")[2] || "";
-      const matched = sections.find((name) => SETTINGS_SECTION_SLUGS[name] === slug);
-      setActiveSettingsSection(matched || sections[0]);
+      const slugMatch = resolveSettingsSectionFromSlug(slug);
+      const matched = slugMatch && sections.includes(slugMatch) ? slugMatch : sections[0];
+      setActiveSettingsSection(matched);
     }
   }
 
@@ -5844,7 +5878,9 @@ function SettingsPanel(props: {
   }
 
   const payload = props.payload;
-  if (!payload.sections?.length) {
+  const settingsApiSections = payload.sections ?? [];
+  const viewingVirtualSettings = VIRTUAL_SETTINGS_SECTIONS.has(props.activeSection);
+  if (!viewingVirtualSettings && settingsApiSections.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 min-h-[40vh] px-6 text-center">
         <p className={`text-[16px] font-headline uppercase tracking-widest ${props.themeMode === "light" ? "text-slate-600" : "text-slate-400"}`}>
@@ -5856,7 +5892,10 @@ function SettingsPanel(props: {
       </div>
     );
   }
-  const active = payload.sections.find((s) => s.name === props.activeSection) || payload.sections[0];
+  const isVirtualActive = viewingVirtualSettings;
+  const virtualActive = isVirtualActive ? { name: props.activeSection, fields: [] as SettingsField[] } : null;
+  const active =
+    virtualActive ?? settingsApiSections.find((s) => s.name === props.activeSection) ?? settingsApiSections[0];
   const canUseAnySecondaryBehavior = canUseRadarrSecondaryBehavior || canUseSonarrSecondaryBehavior;
 
   async function runTest(field: SettingsField) {
@@ -6005,23 +6044,25 @@ function SettingsPanel(props: {
           <h1 className="text-[32px] font-black text-white tracking-tight font-headline">Settings</h1>
         </div>
         <div className="flex items-center gap-3">
-          {props.hasUnsavedChanges && (
+          {props.hasUnsavedChanges && !isVirtualActive && (
             <span className="flex items-center gap-1.5 text-[14px] text-yellow-400 font-headline uppercase tracking-wider">
               <div className="w-1.5 h-1.5 rounded-full bg-yellow-400" />
               Unsaved changes
             </span>
           )}
-          {props.feedback && (
+          {props.feedback && !isVirtualActive && (
             <span className={`text-[14px] font-headline uppercase tracking-wider ${props.feedbackKind === "success" ? "text-green-400" : "text-red-400"}`}>
               {props.feedback}
             </span>
           )}
-          <button type="button" onClick={() => props.onSave()}
-            className="flex items-center gap-2 px-5 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors"
-            style={{ backgroundColor: accent.hex }}>
-            <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
-            Save Settings
-          </button>
+          {!isVirtualActive && (
+            <button type="button" onClick={() => props.onSave()}
+              className="flex items-center gap-2 px-5 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors"
+              style={{ backgroundColor: accent.hex }}>
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
+              Save Settings
+            </button>
+          )}
         </div>
       </div>
 
@@ -6411,6 +6452,8 @@ function SettingsPanel(props: {
                 renderOnboardingStyleSectionRows(active.fields, {
                   intro: <StatusUpdatesSectionIntro variant="onboarding" embedded />,
                 })
+              ) : active.name === "Status Messages" ? (
+                <StatusMessagesPanel brand={props.brand} themeMode={props.themeMode} />
               ) : active.name === "Library sync" ? (
                 renderOnboardingStyleSectionRows(active.fields)
               ) : (
@@ -6430,6 +6473,963 @@ function SettingsPanel(props: {
       />
     ) : null}
     </>
+  );
+}
+
+// ---------- Status Messages panel ----------
+
+type StatusMessageRow = {
+  key: string;
+  label: string;
+  group: string;
+  subgroup: string | null;
+  tooltip: string;
+  default: string;
+  value: string;
+  has_override: boolean;
+  allowed_tokens: string[];
+  sample_render: string;
+};
+
+type StatusMessageTokenSpec = {
+  name: string;
+  label: string;
+  group: string;
+  description: string;
+  sample: string;
+  placeholder: string;
+};
+
+type StatusMessageWrapperPreset = { value: string; label: string; open: string; close: string };
+
+type StatusMessagePayload = {
+  registry: StatusMessageRow[];
+  tokens: StatusMessageTokenSpec[];
+  separator: string;
+  case: string;
+  wrapper_preset: string;
+  wrapper_open: string;
+  wrapper_close: string;
+  overrides: Record<string, string>;
+  separator_presets: Array<{ value: string; label: string }>;
+  case_options: Array<{ value: string; label: string }>;
+  wrapper_presets: StatusMessageWrapperPreset[];
+  max_template_length: number;
+  pending_full_sync_backfill?: boolean;
+};
+
+type ApplyScope = "now" | "next_full_sync" | "future";
+
+const STATUS_MESSAGE_GROUP_ORDER = [
+  "Request",
+  "Title Suffix",
+  "Calendar Coming Soon",
+  "Queue Monitor",
+  "Import Grace",
+];
+
+/** Resolve the (open, close) chrome from a wrapper preset + custom open/close fallback. */
+function resolveWrapperPair(
+  preset: string,
+  open: string,
+  close: string,
+  presets: StatusMessageWrapperPreset[],
+): { open: string; close: string } {
+  const lower = (preset || "").trim().toLowerCase();
+  if (lower === "custom") return { open: open || "", close: close || "" };
+  for (const entry of presets) {
+    if (entry.value === lower) return { open: entry.open, close: entry.close };
+  }
+  return { open: "[", close: "]" };
+}
+
+/** Extract `{Token}` names without `String.prototype.matchAll` (older WebViews / browsers). */
+function collectStatusTemplateTokenNames(template: string): string[] {
+  const out: string[] = [];
+  const re = /\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+  const text = typeof template === "string" ? template : "";
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) out.push(m[1]);
+  return out;
+}
+
+function validateStatusMessageTemplate(
+  template: string,
+  rowKey: string,
+  allowedTokens: Set<string>,
+  knownTokens: Set<string>,
+  maxLength: number,
+): { error: string | null; warnings: string[] } {
+  if (template.length > maxLength) return { error: `Template exceeds ${maxLength} characters`, warnings: [] };
+  const stripped = template.replace(/\{[A-Za-z][A-Za-z0-9_]*\}/g, "");
+  if (stripped.includes("{") || stripped.includes("}")) {
+    return { error: "Unbalanced or stray braces", warnings: [] };
+  }
+  const used = collectStatusTemplateTokenNames(template);
+  const unknown = used.filter((t) => !knownTokens.has(t));
+  const disallowed = used.filter((t) => knownTokens.has(t) && !allowedTokens.has(t));
+  if (unknown.length) return { error: `Unknown tokens: ${unknown.join(", ")}`, warnings: [] };
+  if (disallowed.length) return { error: `Tokens not allowed here: ${disallowed.join(", ")}`, warnings: [] };
+
+  const warnings: string[] = [];
+  if (rowKey.endsWith(".plural") && !template.includes("{DaysUntil}")) {
+    warnings.push("Consider including {DaysUntil} so users see the day count.");
+  }
+  if (rowKey === "queue.downloading" && !template.includes("{Progress}")) {
+    warnings.push("Consider including {Progress} so users see the download progress.");
+  }
+  if (rowKey === "import_grace.countdown" && !template.includes("{MinutesRemaining}")) {
+    warnings.push("Consider including {MinutesRemaining} so the countdown shows the remaining minutes.");
+  }
+  return { error: null, warnings };
+}
+
+function clientRenderStatusMessage(template: string, ctx: Record<string, string>, separator: string, caseMode: string, allTokenSamples: Record<string, string>): string {
+  const filled = template.replace(/\{([A-Za-z][A-Za-z0-9_]*)\}/g, (_match, name: string) => {
+    if (name === "Sep") return separator || "·";
+    if (name in ctx) return ctx[name] ?? "";
+    if (name in allTokenSamples) return allTokenSamples[name];
+    return "";
+  });
+  const collapsed = filled
+    .replace(/[ \t]+/g, " ")
+    .replace(/\(\s+/g, "(")
+    .replace(/\s+\)/g, ")")
+    .replace(/\s+([,.;:!?])/g, "$1")
+    .trim();
+  if (caseMode === "upper") return collapsed.toUpperCase();
+  if (caseMode === "lower") return collapsed.toLowerCase();
+  if (caseMode === "title") return collapsed.replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+  return collapsed;
+}
+
+function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
+  const accent = getBrandAccent(props.brand, props.themeMode);
+  const [payload, setPayload] = useState<StatusMessagePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>("");
+  const [feedback, setFeedback] = useState<{ kind: "success" | "error"; message: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [separator, setSeparator] = useState<string>("·");
+  const [caseMode, setCaseMode] = useState<string>("default");
+  const [wrapperPreset, setWrapperPreset] = useState<string>("brackets");
+  const [wrapperOpen, setWrapperOpen] = useState<string>("");
+  const [wrapperClose, setWrapperClose] = useState<string>("");
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [defaults, setDefaults] = useState<Record<string, string>>({});
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
+  const [tokenModal, setTokenModal] = useState<null | { rowKey: string }>(null);
+  const [scopeModal, setScopeModal] = useState<null | {
+    placeholderCount: number;
+    pending: boolean;
+  }>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await fetchJson<StatusMessagePayload>("/api/messages/templates", { credentials: "same-origin" });
+      if (!Array.isArray(data.registry) || !Array.isArray(data.tokens)) {
+        throw new Error("Invalid messages API response (missing registry or tokens)");
+      }
+      setPayload(data);
+      setSeparator(data.separator || "·");
+      setCaseMode(data.case || "default");
+      setWrapperPreset(data.wrapper_preset || "brackets");
+      setWrapperOpen(data.wrapper_open || "");
+      setWrapperClose(data.wrapper_close || "");
+      const next: Record<string, string> = {};
+      const def: Record<string, string> = {};
+      for (const row of data.registry) {
+        next[row.key] = row.has_override ? row.value : row.default;
+        def[row.key] = row.default;
+      }
+      setValues(next);
+      setDefaults(def);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to load message templates");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const tokenSamplesByName = useMemo(() => {
+    const m: Record<string, string> = {};
+    if (!payload) return m;
+    for (const t of payload.tokens ?? []) m[t.name] = t.sample;
+    return m;
+  }, [payload]);
+
+  const knownTokenSet = useMemo(() => new Set((payload?.tokens ?? []).map((t) => t.name)), [payload]);
+
+  const orderedGroups = useMemo(() => {
+    if (!payload) return [] as Array<{ name: string; rows: StatusMessageRow[] }>;
+    const grouped = new Map<string, StatusMessageRow[]>();
+    for (const row of payload.registry ?? []) {
+      const arr = grouped.get(row.group) ?? [];
+      arr.push(row);
+      grouped.set(row.group, arr);
+    }
+    const orderedNames = [
+      ...STATUS_MESSAGE_GROUP_ORDER.filter((n) => grouped.has(n)),
+      ...Array.from(grouped.keys()).filter((n) => !STATUS_MESSAGE_GROUP_ORDER.includes(n)),
+    ];
+    return orderedNames.map((name) => ({ name, rows: grouped.get(name) ?? [] }));
+  }, [payload]);
+
+  const dirty = useMemo(() => {
+    if (!payload) return false;
+    if ((payload.separator || "·") !== separator) return true;
+    if ((payload.case || "default") !== caseMode) return true;
+    if ((payload.wrapper_preset || "brackets") !== wrapperPreset) return true;
+    if ((payload.wrapper_open ?? "") !== wrapperOpen) return true;
+    if ((payload.wrapper_close ?? "") !== wrapperClose) return true;
+    for (const row of payload.registry ?? []) {
+      const current = values[row.key] ?? "";
+      const initial = row.has_override ? row.value : row.default;
+      if (current !== initial) return true;
+    }
+    return false;
+  }, [payload, separator, caseMode, wrapperPreset, wrapperOpen, wrapperClose, values]);
+
+  const wrapperPair = useMemo(() => {
+    return resolveWrapperPair(wrapperPreset, wrapperOpen, wrapperClose, payload?.wrapper_presets ?? []);
+  }, [wrapperPreset, wrapperOpen, wrapperClose, payload]);
+
+  const hasValidationErrors = useMemo(() => {
+    if (!payload) return false;
+    for (const row of payload.registry ?? []) {
+      const value = values[row.key] ?? "";
+      if (!value.trim()) continue;
+      const result = validateStatusMessageTemplate(
+        value,
+        row.key,
+        new Set(row.allowed_tokens ?? []),
+        knownTokenSet,
+        payload.max_template_length ?? 400,
+      );
+      if (result.error) return true;
+    }
+    return false;
+  }, [payload, values, knownTokenSet]);
+
+  function setRowValue(key: string, value: string) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function resetRow(key: string) {
+    setValues((prev) => ({ ...prev, [key]: defaults[key] ?? "" }));
+  }
+
+  async function handleSavePressed() {
+    if (!payload || saving || !dirty || hasValidationErrors) return;
+    setFeedback(null);
+    try {
+      const data = await fetchJson<{ placeholder_count: number; pending_full_sync_backfill: boolean }>(
+        "/api/messages/templates/apply_estimate",
+        { credentials: "same-origin" },
+      );
+      setScopeModal({
+        placeholderCount: Number(data?.placeholder_count ?? 0),
+        pending: !!data?.pending_full_sync_backfill,
+      });
+    } catch {
+      setScopeModal({ placeholderCount: 0, pending: false });
+    }
+  }
+
+  async function handleSave(applyScope: ApplyScope) {
+    if (!payload) return;
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const overrides: Record<string, string> = {};
+      for (const row of payload.registry ?? []) {
+        const v = values[row.key] ?? "";
+        if (v.trim() && v !== row.default) overrides[row.key] = v;
+      }
+      const resp = await fetch("/api/messages/templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          separator,
+          case: caseMode,
+          wrapper_preset: wrapperPreset,
+          wrapper_open: wrapperOpen,
+          wrapper_close: wrapperClose,
+          overrides,
+          apply_scope: applyScope,
+        }),
+      });
+      if (!resp.ok) {
+        let detail: unknown = null;
+        try {
+          detail = await resp.json();
+        } catch {
+          /* swallow */
+        }
+        const errors =
+          detail && typeof detail === "object" && "detail" in detail && typeof (detail as { detail?: unknown }).detail === "object"
+            ? ((detail as { detail: { errors?: Record<string, string> } }).detail.errors ?? {})
+            : {};
+        const firstKey = Object.keys(errors)[0];
+        const msg = firstKey ? `${firstKey}: ${errors[firstKey]}` : `Save failed (HTTP ${resp.status})`;
+        setFeedback({ kind: "error", message: msg });
+        return;
+      }
+      let savedMsg = "Status messages saved";
+      if (applyScope === "now") savedMsg = "Saved · backfill queued for the current library";
+      else if (applyScope === "next_full_sync") savedMsg = "Saved · backfill scheduled for the next full sync";
+      else savedMsg = "Saved · only future placeholders use the new templates";
+      setFeedback({ kind: "success", message: savedMsg });
+      setScopeModal(null);
+      await reload();
+    } catch (e: unknown) {
+      setFeedback({ kind: "error", message: e instanceof Error ? e.message : "Save failed" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleResetAll() {
+    if (!payload) return;
+    if (typeof window !== "undefined" && !window.confirm("Reset every status message to its default?")) return;
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const resp = await fetch("/api/messages/templates/reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ all: true }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      setFeedback({ kind: "success", message: "All status messages reset to defaults" });
+      await reload();
+    } catch (e: unknown) {
+      setFeedback({ kind: "error", message: e instanceof Error ? e.message : "Reset failed" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48">
+        <div className="flex items-center gap-3 text-slate-400">
+          <div className="w-2 h-2 rounded-full animate-pulse" style={{ backgroundColor: accent.hex }} />
+          <span className="text-[16px] font-headline uppercase tracking-widest">Loading messages…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !payload) {
+    return (
+      <div className="px-6 py-5 text-[14px] text-red-300">{error || "Failed to load message templates."}</div>
+    );
+  }
+
+  return (
+    <div className="min-h-[40vh] px-6 py-5 space-y-5">
+      {/* Top toolbar: separator + case + actions */}
+      <div className={`${UI_SECTION_FRAME_CLASS} px-5 py-4`}>
+        <div className="flex flex-wrap items-end gap-4 justify-between">
+          <div className="flex flex-wrap items-end gap-4">
+            <div>
+              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Separator</label>
+              <div className="flex items-center gap-2">
+                <select
+                  className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  value={payload.separator_presets.some((p) => p.value === separator) ? separator : "__custom__"}
+                  onChange={(e) => {
+                    if (e.target.value === "__custom__") return;
+                    setSeparator(e.target.value);
+                  }}
+                >
+                  {payload.separator_presets.map((p) => (
+                    <option key={p.value} value={p.value}>{p.label}</option>
+                  ))}
+                  <option value="__custom__">Custom…</option>
+                </select>
+                <input
+                  className={`w-24 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  value={separator}
+                  onChange={(e) => setSeparator(e.target.value)}
+                  maxLength={6}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Default Case</label>
+              <select
+                className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                value={caseMode}
+                onChange={(e) => setCaseMode(e.target.value)}
+              >
+                {payload.case_options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Wrapper</label>
+              <div className="flex items-center gap-2">
+                <select
+                  className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  value={wrapperPreset}
+                  onChange={(e) => setWrapperPreset(e.target.value)}
+                >
+                  {(payload.wrapper_presets ?? []).map((p) => (
+                    <option key={p.value} value={p.value}>{p.label}</option>
+                  ))}
+                </select>
+                {wrapperPreset === "custom" && (
+                  <>
+                    <input
+                      className={`w-16 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                      value={wrapperOpen}
+                      onChange={(e) => setWrapperOpen(e.target.value)}
+                      maxLength={8}
+                      placeholder="open"
+                      title="Custom open text"
+                    />
+                    <input
+                      className={`w-16 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                      value={wrapperClose}
+                      onChange={(e) => setWrapperClose(e.target.value)}
+                      maxLength={8}
+                      placeholder="close"
+                      title="Custom close text"
+                    />
+                  </>
+                )}
+              </div>
+              <p className="text-[11px] text-slate-500 mt-1 font-mono">
+                Preview: {wrapperPair.open || ""}REQUEST{wrapperPair.close || ""}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {dirty && (
+              <span className="flex items-center gap-1.5 text-[14px] text-yellow-400 font-headline uppercase tracking-wider">
+                <div className="w-1.5 h-1.5 rounded-full bg-yellow-400" />
+                Unsaved changes
+              </span>
+            )}
+            {payload.pending_full_sync_backfill && (
+              <span className="flex items-center gap-1.5 text-[13px] text-amber-300 font-headline uppercase tracking-wider" title="Earlier save chose Next full sync; the backfill runs at the next full sync.">
+                <span className="material-symbols-outlined" style={{ fontSize: 14 }}>schedule</span>
+                Backfill pending
+              </span>
+            )}
+            {feedback && (
+              <span className={`text-[14px] font-headline uppercase tracking-wider ${feedback.kind === "success" ? "text-green-400" : "text-red-400"}`}>
+                {feedback.message}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={handleResetAll}
+              disabled={saving}
+              className="text-[13px] font-headline uppercase tracking-wider text-slate-400 hover:text-slate-200 underline-offset-2 hover:underline disabled:opacity-50"
+            >
+              Reset all to defaults
+            </button>
+            <button
+              type="button"
+              onClick={handleSavePressed}
+              disabled={saving || !dirty || hasValidationErrors}
+              title={hasValidationErrors ? "Fix validation errors before saving" : ""}
+              className="flex items-center gap-2 px-4 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors disabled:opacity-50"
+              style={{ backgroundColor: accent.hex }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
+              {saving ? "Saving…" : "Save Messages"}
+            </button>
+          </div>
+        </div>
+        <p className="ui-field-description mt-3">
+          Customize the lines Placeholdarr writes into NFOs / projects to your media player. Each row is the inner text; the global <span className="font-mono">Wrapper</span> applies <span className="font-mono">{wrapperPair.open || "·"}{wrapperPair.close || "·"}</span> around it. Missing tokens auto-collapse so optional metadata is safe to include. Click a row's <span className="font-mono">{`{ }`}</span> button to browse tokens.
+        </p>
+      </div>
+
+      {orderedGroups.map((group) => {
+        const collapsed = !!collapsedGroups[group.name];
+        // Order rows: stable, plus sub-grouping by `subgroup` if present.
+        const groupedBySubgroup = new Map<string, StatusMessageRow[]>();
+        for (const row of group.rows) {
+          const sub = row.subgroup || "";
+          const list = groupedBySubgroup.get(sub) ?? [];
+          list.push(row);
+          groupedBySubgroup.set(sub, list);
+        }
+        return (
+          <div key={group.name} className={`${UI_SECTION_FRAME_CLASS} overflow-hidden`}>
+            <button
+              type="button"
+              className="w-full flex items-center justify-between px-5 py-3 border-b border-[#424753]/30 text-left"
+              onClick={() => setCollapsedGroups((p) => ({ ...p, [group.name]: !p[group.name] }))}
+            >
+              <h3 className="text-[16px] font-bold text-white font-headline">{group.name}</h3>
+              <span className="material-symbols-outlined text-slate-400" style={{ fontSize: 18 }}>
+                {collapsed ? "expand_more" : "expand_less"}
+              </span>
+            </button>
+            {!collapsed && (
+              <div className="divide-y divide-[#424753]/20">
+                {Array.from(groupedBySubgroup.entries()).map(([sub, rows]) => (
+                  <div key={sub || "_"} className="px-5 py-4 space-y-4">
+                    {sub && <h4 className="text-[13px] font-headline uppercase tracking-wider text-slate-400">{sub}</h4>}
+                    {rows.map((row) => {
+                      const value = values[row.key] ?? "";
+                      const isOverride = value !== row.default;
+                      const sampleCtx: Record<string, string> = {};
+                      for (const t of row.allowed_tokens ?? []) {
+                        if (t in tokenSamplesByName) sampleCtx[t] = tokenSamplesByName[t];
+                      }
+                      const validation = validateStatusMessageTemplate(
+                        value,
+                        row.key,
+                        new Set(row.allowed_tokens ?? []),
+                        knownTokenSet,
+                        payload.max_template_length ?? 400,
+                      );
+                      const innerPreview = validation.error
+                        ? ""
+                        : clientRenderStatusMessage(value || row.default, sampleCtx, separator, caseMode, tokenSamplesByName);
+                      // Rows whose final Plex/NFO line is wrapped by the global preset show the wrapped form here too.
+                      const isWrappedSituation =
+                        row.key === "line.request" ||
+                        row.key.startsWith("queue.") ||
+                        row.key.startsWith("calendar.") ||
+                        row.key.startsWith("import_grace.");
+                      const preview = innerPreview && isWrappedSituation
+                        ? `${wrapperPair.open}${innerPreview}${wrapperPair.close}`
+                        : innerPreview;
+                      return (
+                        <div key={row.key} className="space-y-2">
+                          <div className="flex items-baseline gap-2 flex-wrap">
+                            <label className="text-[15px] font-semibold text-slate-100">{row.label}</label>
+                            {isOverride && (
+                              <span className="px-1.5 py-0.5 rounded text-[11px] font-bold font-headline uppercase" style={{ backgroundColor: alphaColor(accent.hex, 0.25), color: accent.text }}>
+                                Customized
+                              </span>
+                            )}
+                            <span title={row.tooltip} className="material-symbols-outlined text-slate-500 cursor-help" style={{ fontSize: 16 }}>info</span>
+                            <span className="ml-auto font-mono text-[12px] text-slate-500">{row.key}</span>
+                          </div>
+                          <div className="flex gap-2">
+                            <input
+                              className={`flex-1 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 placeholder-slate-600 outline-none transition-colors ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                              value={value}
+                              maxLength={payload.max_template_length ?? 400}
+                              placeholder={row.default}
+                              onChange={(e) => setRowValue(row.key, e.target.value)}
+                            />
+                            <button
+                              type="button"
+                              onClick={() => setTokenModal({ rowKey: row.key })}
+                              className="px-3 py-2 bg-[#252e3a] hover:bg-[#30353b] border border-[#424753]/40 rounded-lg text-[14px] text-slate-300 font-mono transition-colors"
+                              title="Insert a token"
+                            >
+                              {`{ }`}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => resetRow(row.key)}
+                              disabled={!isOverride}
+                              className="px-3 py-2 text-[13px] font-headline uppercase tracking-wider text-slate-400 hover:text-slate-200 disabled:opacity-30 disabled:cursor-not-allowed"
+                              title="Reset to default"
+                            >
+                              Reset
+                            </button>
+                          </div>
+                          <div className="flex items-center gap-2 text-[13px]">
+                            <span className="text-slate-500 font-headline uppercase tracking-wider">Preview:</span>
+                            <span className="text-slate-200 font-mono">{preview || "—"}</span>
+                          </div>
+                          {validation.error && (
+                            <p className="text-[12px] text-red-400 flex items-center gap-1.5">
+                              <span className="material-symbols-outlined" style={{ fontSize: 14 }}>error</span>
+                              {validation.error}
+                            </p>
+                          )}
+                          {!validation.error && validation.warnings.length > 0 && value.trim() && (
+                            <p className="text-[12px] text-amber-300 flex items-center gap-1.5">
+                              <span className="material-symbols-outlined" style={{ fontSize: 14 }}>warning</span>
+                              {validation.warnings[0]}
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {tokenModal && (
+        <StatusMessagesTokenModal
+          payload={payload}
+          rowKey={tokenModal.rowKey}
+          currentValue={values[tokenModal.rowKey] ?? ""}
+          separator={separator}
+          caseMode={caseMode}
+          tokenSamplesByName={tokenSamplesByName}
+          onClose={() => setTokenModal(null)}
+          onChangeValue={(v) => setRowValue(tokenModal.rowKey, v)}
+          onChangeSeparator={setSeparator}
+          onChangeCase={setCaseMode}
+          brand={props.brand}
+          themeMode={props.themeMode}
+        />
+      )}
+
+      {scopeModal && (
+        <StatusMessagesApplyScopeModal
+          placeholderCount={scopeModal.placeholderCount}
+          alreadyPending={scopeModal.pending}
+          saving={saving}
+          onCancel={() => setScopeModal(null)}
+          onConfirm={(scope) => handleSave(scope)}
+          brand={props.brand}
+          themeMode={props.themeMode}
+        />
+      )}
+    </div>
+  );
+}
+
+function StatusMessagesApplyScopeModal(props: {
+  placeholderCount: number;
+  alreadyPending: boolean;
+  saving: boolean;
+  onCancel: () => void;
+  onConfirm: (scope: ApplyScope) => void;
+  brand: Brand;
+  themeMode: ThemeMode;
+}) {
+  const accent = getBrandAccent(props.brand, props.themeMode);
+  const [scope, setScope] = useState<ApplyScope>("next_full_sync");
+  const count = props.placeholderCount;
+  const countLabel = count === 1 ? "1 placeholder" : `${count.toLocaleString()} placeholders`;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !props.saving) props.onCancel();
+      }}
+    >
+      <div className={`w-full max-w-xl ${UI_SECTION_FRAME_CLASS} bg-[#171c22] flex flex-col overflow-hidden`}>
+        <div className="px-5 py-4 border-b border-[#424753]/30">
+          <h3 className="text-[18px] font-bold text-white font-headline">Apply template changes</h3>
+          <p className="ui-field-description mt-1">
+            Choose when these template updates should affect existing placeholders. New placeholders always use the saved templates.
+          </p>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          {([
+            {
+              value: "now" as ApplyScope,
+              title: "Apply now",
+              body: `Rewrite NFOs and refresh player metadata for ${countLabel} immediately. Best when the library is small or you want to see changes right away.`,
+            },
+            {
+              value: "next_full_sync" as ApplyScope,
+              title: "Next full sync (recommended)",
+              body: props.alreadyPending
+                ? "Already queued. Saving here will keep the next full sync as the apply point."
+                : "Defer the rewrite to the next scheduled or manual full sync. Spreads media-server load and avoids a sudden refresh storm.",
+            },
+            {
+              value: "future" as ApplyScope,
+              title: "Future only",
+              body: "Don't touch existing placeholders. The new templates apply naturally as items move through their stages.",
+            },
+          ]).map((opt) => {
+            const selected = scope === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setScope(opt.value)}
+                className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+                  selected ? "" : "border-[#424753]/40 hover:border-[#5b6473]/60"
+                }`}
+                style={selected ? { borderColor: accent.hex, backgroundColor: alphaColor(accent.hex, 0.08) } : undefined}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="w-3 h-3 rounded-full inline-block"
+                    style={{ backgroundColor: selected ? accent.hex : "#3b424d" }}
+                  />
+                  <span className="text-[15px] font-semibold text-slate-100">{opt.title}</span>
+                </div>
+                <p className="text-[13px] text-slate-400 mt-1">{opt.body}</p>
+              </button>
+            );
+          })}
+        </div>
+        <div className="px-5 py-3 border-t border-[#424753]/30 flex items-center justify-between gap-3">
+          <p className="text-[12px] text-slate-500">
+            Large libraries may take a while to finish backfill and media-server refresh.
+          </p>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={props.onCancel}
+              disabled={props.saving}
+              className="text-[14px] font-headline uppercase tracking-wider text-slate-400 hover:text-slate-200 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => props.onConfirm(scope)}
+              disabled={props.saving}
+              className="flex items-center gap-2 px-4 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg disabled:opacity-50"
+              style={{ backgroundColor: accent.hex }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
+              {props.saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const STATUS_MESSAGE_TOKEN_GROUP_ORDER = [
+  "General",
+  "Status",
+  "Calendar",
+  "Queue",
+  "Import Grace",
+  "Media",
+  "Episode",
+];
+
+function StatusMessagesTokenModal(props: {
+  payload: StatusMessagePayload;
+  rowKey: string;
+  currentValue: string;
+  separator: string;
+  caseMode: string;
+  tokenSamplesByName: Record<string, string>;
+  onClose: () => void;
+  onChangeValue: (next: string) => void;
+  onChangeSeparator: (next: string) => void;
+  onChangeCase: (next: string) => void;
+  brand: Brand;
+  themeMode: ThemeMode;
+}) {
+  const accent = getBrandAccent(props.brand, props.themeMode);
+  const row = (props.payload.registry ?? []).find((r) => r.key === props.rowKey);
+  const [draft, setDraft] = useState(props.currentValue);
+  const editorRef = useRef<HTMLInputElement | null>(null);
+  const cursorRef = useRef<number>(props.currentValue.length);
+
+  useEffect(() => {
+    setDraft(props.currentValue);
+    cursorRef.current = props.currentValue.length;
+  }, [props.currentValue, props.rowKey]);
+
+  if (!row) return null;
+
+  const allowed = new Set(row.allowed_tokens ?? []);
+  const groupedTokens = new Map<string, StatusMessageTokenSpec[]>();
+  for (const token of props.payload.tokens ?? []) {
+    const arr = groupedTokens.get(token.group) ?? [];
+    arr.push(token);
+    groupedTokens.set(token.group, arr);
+  }
+  const orderedTokenGroups = [
+    ...STATUS_MESSAGE_TOKEN_GROUP_ORDER.filter((g) => groupedTokens.has(g)),
+    ...Array.from(groupedTokens.keys()).filter((g) => !STATUS_MESSAGE_TOKEN_GROUP_ORDER.includes(g)),
+  ];
+
+  const sampleCtx: Record<string, string> = {};
+  for (const t of row.allowed_tokens ?? []) {
+    if (t in props.tokenSamplesByName) sampleCtx[t] = props.tokenSamplesByName[t];
+  }
+  const knownTokens = new Set((props.payload.tokens ?? []).map((t) => t.name));
+  const validation = validateStatusMessageTemplate(
+    draft,
+    row.key,
+    new Set(row.allowed_tokens ?? []),
+    knownTokens,
+    props.payload.max_template_length ?? 400,
+  );
+  const preview = validation.error
+    ? ""
+    : clientRenderStatusMessage(draft || row.default, sampleCtx, props.separator, props.caseMode, props.tokenSamplesByName);
+
+  function insert(placeholder: string) {
+    const cursor = cursorRef.current;
+    const next = draft.slice(0, cursor) + placeholder + draft.slice(cursor);
+    setDraft(next);
+    cursorRef.current = cursor + placeholder.length;
+    requestAnimationFrame(() => {
+      const el = editorRef.current;
+      if (el) {
+        el.focus();
+        el.setSelectionRange(cursorRef.current, cursorRef.current);
+      }
+    });
+  }
+
+  function commitAndClose() {
+    props.onChangeValue(draft);
+    props.onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) commitAndClose();
+      }}
+    >
+      <div className={`w-full max-w-3xl ${UI_SECTION_FRAME_CLASS} bg-[#171c22] max-h-[85vh] flex flex-col overflow-hidden`}>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[#424753]/30">
+          <div>
+            <h3 className="text-[18px] font-bold text-white font-headline">Status Message Tokens</h3>
+            <p className="ui-field-description mt-1">Editing <span className="text-slate-300">{row.label}</span> · <span className="font-mono text-[12px] text-slate-500">{row.key}</span></p>
+          </div>
+          <button type="button" onClick={commitAndClose} className="text-slate-400 hover:text-slate-100">
+            <span className="material-symbols-outlined" style={{ fontSize: 22 }}>close</span>
+          </button>
+        </div>
+
+        {/* Top controls: separator + case (mirrors section header) */}
+        <div className="flex flex-wrap items-end gap-4 px-5 py-3 border-b border-[#424753]/30">
+          <div>
+            <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Separator</label>
+            <input
+              className={`w-24 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[14px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+              value={props.separator}
+              onChange={(e) => props.onChangeSeparator(e.target.value)}
+              maxLength={6}
+            />
+          </div>
+          <div>
+            <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Default Case</label>
+            <select
+              className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[14px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+              value={props.caseMode}
+              onChange={(e) => props.onChangeCase(e.target.value)}
+            >
+              {props.payload.case_options.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Token grid */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {orderedTokenGroups.map((groupName) => {
+            const tokens = groupedTokens.get(groupName) ?? [];
+            return (
+              <div key={groupName}>
+                <h4 className="text-[12px] font-headline uppercase tracking-widest text-slate-400 mb-2">{groupName}</h4>
+                <div className="flex flex-wrap gap-2">
+                  {tokens.map((token) => {
+                    const isAllowed = allowed.has(token.name);
+                    const tooltip = isAllowed ? token.description : `${token.description}\n\nNot available for this message.`;
+                    return (
+                      <button
+                        key={token.name}
+                        type="button"
+                        title={tooltip}
+                        disabled={!isAllowed}
+                        onClick={() => isAllowed && insert(token.placeholder)}
+                        className={`flex flex-col items-start gap-0.5 rounded-lg border px-3 py-1.5 text-left transition-colors ${
+                          isAllowed
+                            ? "border-[#424753]/60 bg-[#1e2430] hover:bg-[#252e3a] text-slate-100"
+                            : "border-[#424753]/30 bg-transparent text-slate-600 cursor-not-allowed"
+                        }`}
+                      >
+                        <span className="font-mono text-[13px]">{token.placeholder}</span>
+                        <span className="text-[11px] text-slate-500">{token.label} · {token.sample}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer: editable value + preview */}
+        <div className="px-5 py-4 border-t border-[#424753]/30 space-y-2">
+          <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Template</label>
+          <input
+            ref={editorRef}
+            className={`w-full bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+            value={draft}
+            placeholder={row.default}
+            maxLength={props.payload.max_template_length ?? 400}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              cursorRef.current = e.target.selectionStart ?? e.target.value.length;
+            }}
+            onKeyUp={(e) => {
+              cursorRef.current = e.currentTarget.selectionStart ?? e.currentTarget.value.length;
+            }}
+            onClick={(e) => {
+              cursorRef.current = e.currentTarget.selectionStart ?? e.currentTarget.value.length;
+            }}
+          />
+          <div className="flex items-center gap-2 text-[13px]">
+            <span className="text-slate-500 font-headline uppercase tracking-wider">Preview:</span>
+            <span className="text-slate-200 font-mono">{preview || "—"}</span>
+          </div>
+          {validation.error && (
+            <p className="text-[12px] text-red-400 flex items-center gap-1.5">
+              <span className="material-symbols-outlined" style={{ fontSize: 14 }}>error</span>
+              {validation.error}
+            </p>
+          )}
+          {!validation.error && validation.warnings.length > 0 && draft.trim() && (
+            <p className="text-[12px] text-amber-300 flex items-center gap-1.5">
+              <span className="material-symbols-outlined" style={{ fontSize: 14 }}>warning</span>
+              {validation.warnings[0]}
+            </p>
+          )}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              className="text-[14px] font-headline uppercase tracking-wider text-slate-400 hover:text-slate-200"
+              onClick={() => {
+                setDraft(row.default);
+                cursorRef.current = row.default.length;
+              }}
+            >
+              Reset to default
+            </button>
+            <button
+              type="button"
+              onClick={commitAndClose}
+              className="px-4 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg"
+              style={{ backgroundColor: accent.hex }}
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ import {
   saveSettings,
   testIntegrationConnection,
 } from "./api/dashboard";
-import { fetchJson } from "./api/client";
+import { fetchJson, postJson } from "./api/client";
 import embyIcon from "./assets/services/emby.svg";
 import jellyfinIcon from "./assets/services/jellyfin.svg";
 import plexIcon from "./assets/services/plex.svg";
@@ -137,7 +137,6 @@ const SETTINGS_SECTION_ORDER = [
   "Calendar",
   "Lookahead",
   "Status Updates",
-  "Status Messages",
   "Advanced",
 ];
 const SETTINGS_SECTION_ICONS: Record<string, string> = {
@@ -148,7 +147,6 @@ const SETTINGS_SECTION_ICONS: Record<string, string> = {
   "Calendar": "calendar_month",
   "Lookahead": "fast_forward",
   "Status Updates": "edit_notifications",
-  "Status Messages": "edit_note",
   "Advanced": "tune",
 };
 const SETTINGS_SECTION_SLUGS: Record<string, string> = {
@@ -159,15 +157,15 @@ const SETTINGS_SECTION_SLUGS: Record<string, string> = {
   "Calendar": "calendar",
   "Lookahead": "lookahead",
   "Status Updates": "status-updates",
-  "Status Messages": "status-messages",
   "Advanced": "advanced",
 };
 
 /** Virtual settings sections backed by their own API endpoint, not `/api/settings/current`. */
-const VIRTUAL_SETTINGS_SECTIONS = new Set<string>(["Status Messages"]);
+const VIRTUAL_SETTINGS_SECTIONS = new Set<string>();
 
 function resolveSettingsSectionFromSlug(slug: string): string | undefined {
   if (!slug.trim()) return undefined;
+  if (slug === "status-messages") return "Status Updates";
   return SETTINGS_SECTION_ORDER.find((name) => SETTINGS_SECTION_SLUGS[name] === slug);
 }
 const BEHAVIOR_WIZARD_SECTIONS = [
@@ -548,6 +546,9 @@ export function App() {
   const [baselineValues, setBaselineValues] = useState<FieldValueMap>({});
   const [settingsFeedback, setSettingsFeedback] = useState("");
   const [settingsFeedbackKind, setSettingsFeedbackKind] = useState<"" | "success" | "error">("");
+  /** Status message templates (Settings → Status Updates) — separate API from fieldValues. */
+  const [statusMessagesMeta, setStatusMessagesMeta] = useState({ dirty: false, hasValidationErrors: false });
+  const statusMessagesSaveRef = useRef<(() => Promise<void>) | null>(null);
 
   const [setupStatus, setSetupStatus] = useState<{ setup_complete: boolean } | null>(null);
   const setupCompleteRef = useRef<boolean | undefined>(undefined);
@@ -611,7 +612,14 @@ export function App() {
     () => settingsValuesDirty(fieldValues, baselineValues, settingsPayload),
     [fieldValues, baselineValues, settingsPayload],
   );
+  const combinedSettingsDirty = hasUnsavedChanges || statusMessagesMeta.dirty;
   const hasUnsavedChangesRef = useRef(false);
+  const registerStatusMessagesSaveFlow = useCallback((fn: (() => Promise<void>) | null) => {
+    statusMessagesSaveRef.current = fn;
+  }, []);
+  const handleStatusMessagesMetaChange = useCallback((meta: { dirty: boolean; hasValidationErrors: boolean }) => {
+    setStatusMessagesMeta(meta);
+  }, []);
   const selectedCalendarItem = useMemo(
     () => findCalendarItem(calendar, calendarSelectedId),
     [calendar, calendarSelectedId],
@@ -648,8 +656,8 @@ export function App() {
   }, [library, titleSearch]);
 
   useEffect(() => {
-    hasUnsavedChangesRef.current = hasUnsavedChanges;
-  }, [hasUnsavedChanges]);
+    hasUnsavedChangesRef.current = combinedSettingsDirty;
+  }, [combinedSettingsDirty]);
 
   useEffect(() => {
     try {
@@ -668,13 +676,13 @@ export function App() {
 
   useEffect(() => {
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!hasUnsavedChanges) return;
+      if (!combinedSettingsDirty) return;
       event.preventDefault();
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
     return () => window.removeEventListener("beforeunload", onBeforeUnload);
-  }, [hasUnsavedChanges]);
+  }, [combinedSettingsDirty]);
 
   useEffect(() => {
     let stopped = false;
@@ -1141,7 +1149,7 @@ export function App() {
     setFieldValues(nextValues);
     setBaselineValues(nextValues);
 
-    // Must match `settingsSectionNames`: include virtual tabs (e.g. Status Messages) that are not in `/api/settings/current`.
+    // Must match `settingsSectionNames`: include any virtual tabs not returned by `/api/settings/current`.
     const apiSectionsForNav = payload.sections ?? [];
     const sections = SETTINGS_SECTION_ORDER.filter(
       (name) => VIRTUAL_SETTINGS_SECTIONS.has(name) || apiSectionsForNav.some((s) => s.name === name),
@@ -1208,7 +1216,7 @@ export function App() {
 
   function tryNavigate(path: string) {
     const stayingWithinSettings = currentTab === "settings" && path.startsWith("/settings");
-    if (!hasUnsavedChanges || currentTab !== "settings" || stayingWithinSettings) {
+    if (!combinedSettingsDirty || currentTab !== "settings" || stayingWithinSettings) {
       navigate(path);
       return;
     }
@@ -1418,30 +1426,91 @@ export function App() {
           payload={settingsPayload}
           activeSection={activeSettingsSection}
           values={fieldValues}
-          hasUnsavedChanges={hasUnsavedChanges}
+          hasUnsavedChanges={combinedSettingsDirty}
+          messagesSaveBlocked={statusMessagesMeta.dirty && statusMessagesMeta.hasValidationErrors}
           feedback={settingsFeedback}
           feedbackKind={settingsFeedbackKind}
           brand={brand}
           themeMode={themeMode}
           onValueChange={(key, value) => setFieldValues((prev) => ({ ...prev, [key]: value }))}
+          onStatusMessagesMetaChange={handleStatusMessagesMetaChange}
+          registerStatusMessagesSaveFlow={registerStatusMessagesSaveFlow}
           onSave={async () => {
             setSettingsFeedback("Saving...");
             setSettingsFeedbackKind("");
-            const result = await saveSettings(buildPersistableSettingsValues(fieldValues, settingsPayload));
-            if (!result.ok) {
-              const first = Object.entries(result.errors || {})[0];
-              setSettingsFeedback(first ? `${first[0]}: ${first[1]}` : "Unable to save settings");
+            if (statusMessagesMeta.dirty && statusMessagesMeta.hasValidationErrors) {
+              setSettingsFeedback("Fix status message template errors before saving.");
               setSettingsFeedbackKind("error");
               return;
             }
-            setBaselineValues(fieldValues);
-            const restartKeys = result.restart_required_keys || [];
-            setSettingsFeedback(restartKeys.length ? `Saved. Restart recommended for: ${restartKeys.join(", ")}` : "Saved and applied.");
-            setSettingsFeedbackKind("success");
-            const payload = await getSettingsCurrent();
-            setSettingsPayload(payload);
-            setSetupStatus(payload.status);
-            setOnboardingVisible(!payload.status.setup_complete);
+            let messageTemplatesSaved = false;
+            try {
+              /* Persist field-backed settings (incl. PLACEHOLDER_STATUS_PROJECTION_MODE) before saving templates +
+               * enqueueing nfo_refresh jobs. Otherwise workers can run with stale projection mode while message
+               * cache already has the new line.request — yielding summary-style titles and new plot brackets. */
+              if (hasUnsavedChanges) {
+                const result = await saveSettings(buildPersistableSettingsValues(fieldValues, settingsPayload));
+                if (!result.ok) {
+                  const first = Object.entries(result.errors || {})[0];
+                  setSettingsFeedback(first ? `${first[0]}: ${first[1]}` : "Unable to save settings");
+                  setSettingsFeedbackKind("error");
+                  return;
+                }
+                setBaselineValues(fieldValues);
+                const restartKeys = result.restart_required_keys || [];
+                const baseMsg =
+                  restartKeys.length ? `Saved. Restart recommended for: ${restartKeys.join(", ")}` : "Saved and applied.";
+                if (statusMessagesMeta.dirty && statusMessagesSaveRef.current) {
+                  try {
+                    await statusMessagesSaveRef.current();
+                    messageTemplatesSaved = true;
+                    setSettingsFeedback(`${baseMsg} Message templates saved.`);
+                  } catch (err: unknown) {
+                    const code =
+                      err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";
+                    if (code === "MESSAGES_SAVE_CANCELLED") {
+                      setSettingsFeedback("");
+                      setSettingsFeedbackKind("");
+                      return;
+                    }
+                    setSettingsFeedback(err instanceof Error ? err.message : "Message templates save failed");
+                    setSettingsFeedbackKind("error");
+                    return;
+                  }
+                } else {
+                  setSettingsFeedback(baseMsg);
+                }
+                setSettingsFeedbackKind("success");
+                const payload = await getSettingsCurrent();
+                setSettingsPayload(payload);
+                setSetupStatus(payload.status);
+                setOnboardingVisible(!payload.status.setup_complete);
+              } else if (statusMessagesMeta.dirty && statusMessagesSaveRef.current) {
+                try {
+                  await statusMessagesSaveRef.current();
+                  messageTemplatesSaved = true;
+                } catch (err: unknown) {
+                  const code =
+                    err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";
+                  if (code === "MESSAGES_SAVE_CANCELLED") {
+                    setSettingsFeedback("");
+                    setSettingsFeedbackKind("");
+                    return;
+                  }
+                  setSettingsFeedback(err instanceof Error ? err.message : "Message templates save failed");
+                  setSettingsFeedbackKind("error");
+                  return;
+                }
+                setSettingsFeedback("Message templates saved and applied.");
+                setSettingsFeedbackKind("success");
+              } else {
+                setSettingsFeedback("");
+                setSettingsFeedbackKind("");
+              }
+            } catch (e: unknown) {
+              setSettingsFeedback(e instanceof Error ? e.message : "Save failed");
+              setSettingsFeedbackKind("error");
+            }
           }}
           onTestConnection={async ({ service, urlKey, credentialKey }) => {
             const url = String(fieldValues[urlKey] || "").trim();
@@ -5816,12 +5885,16 @@ function SettingsPanel(props: {
   activeSection: string;
   values: FieldValueMap;
   hasUnsavedChanges: boolean;
+  /** When message templates are dirty but invalid, top Save stays disabled. */
+  messagesSaveBlocked: boolean;
   feedback: string;
   feedbackKind: "" | "success" | "error";
   brand: Brand;
   themeMode: ThemeMode;
   onValueChange: (key: string, value: unknown) => void;
   onSave: () => Promise<void>;
+  onStatusMessagesMetaChange: (meta: { dirty: boolean; hasValidationErrors: boolean }) => void;
+  registerStatusMessagesSaveFlow: (fn: (() => Promise<void>) | null) => void;
   onTestConnection: (input: { service: "plex" | "jellyfin" | "emby" | "radarr" | "sonarr"; urlKey: string; credentialKey: string }) => Promise<{ ok: boolean; message: string }>;
 }) {
   const [testResults, setTestResults] = useState<Record<string, { ok: boolean; message: string }>>({});
@@ -6056,9 +6129,14 @@ function SettingsPanel(props: {
             </span>
           )}
           {!isVirtualActive && (
-            <button type="button" onClick={() => props.onSave()}
-              className="flex items-center gap-2 px-5 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors"
-              style={{ backgroundColor: accent.hex }}>
+            <button
+              type="button"
+              onClick={() => props.onSave()}
+              disabled={!props.hasUnsavedChanges || props.messagesSaveBlocked}
+              title={props.messagesSaveBlocked ? "Fix status message template errors before saving" : undefined}
+              className="flex items-center gap-2 px-5 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{ backgroundColor: accent.hex }}
+            >
               <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
               Save Settings
             </button>
@@ -6449,11 +6527,23 @@ function SettingsPanel(props: {
                   intro: <LookaheadSectionIntro variant="onboarding" embedded />,
                 })
               ) : active.name === "Status Updates" ? (
-                renderOnboardingStyleSectionRows(active.fields, {
-                  intro: <StatusUpdatesSectionIntro variant="onboarding" embedded />,
-                })
-              ) : active.name === "Status Messages" ? (
-                <StatusMessagesPanel brand={props.brand} themeMode={props.themeMode} />
+                <>
+                  {renderOnboardingStyleSectionRows(active.fields, {
+                    intro: <StatusUpdatesSectionIntro variant="onboarding" embedded />,
+                  })}
+                  <StatusMessagesPanel
+                    brand={props.brand}
+                    themeMode={props.themeMode}
+                    statusUpdatesScope={String(props.values.PLACEHOLDER_STATUS_UPDATES ?? "ALL")}
+                    projectionDraft={{
+                      placeholder_status_updates: String(props.values.PLACEHOLDER_STATUS_UPDATES ?? "ALL"),
+                      projection_mode: String(props.values.PLACEHOLDER_STATUS_PROJECTION_MODE ?? "summary"),
+                    }}
+                    onMetaChange={props.onStatusMessagesMetaChange}
+                    registerSaveFlow={props.registerStatusMessagesSaveFlow}
+                    embedded
+                  />
+                </>
               ) : active.name === "Library sync" ? (
                 renderOnboardingStyleSectionRows(active.fields)
               ) : (
@@ -6489,6 +6579,7 @@ type StatusMessageRow = {
   has_override: boolean;
   allowed_tokens: string[];
   sample_render: string;
+  muted_under_request_scope?: boolean;
 };
 
 type StatusMessageTokenSpec = {
@@ -6521,8 +6612,8 @@ type StatusMessagePayload = {
 type ApplyScope = "now" | "next_full_sync" | "future";
 
 const STATUS_MESSAGE_GROUP_ORDER = [
-  "Request",
   "Title Suffix",
+  "Request",
   "Calendar Coming Soon",
   "Queue Monitor",
   "Import Grace",
@@ -6551,6 +6642,51 @@ function collectStatusTemplateTokenNames(template: string): string[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) out.push(m[1]);
   return out;
+}
+
+const TITLE_SUFFIX_ROW_KEYS = new Set([
+  "title.suffix.movie",
+  "title.suffix.series",
+  "title.suffix.season",
+  "title.suffix.episode",
+]);
+
+function isTitleSuffixRowKey(key: string): boolean {
+  return TITLE_SUFFIX_ROW_KEYS.has(key);
+}
+
+function normalizeTitleSuffixTemplate(rowKey: string, value: string): string {
+  const text = typeof value === "string" ? value : "";
+  const stripByKey: Record<string, RegExp> = {
+    "title.suffix.movie": /\{Title\}\s*/gi,
+    "title.suffix.series": /\{SeriesTitle\}\s*/gi,
+    "title.suffix.season": /\{Title\}\s*/gi,
+    "title.suffix.episode": /\{EpisodeTitle\}\s*/gi,
+  };
+  const re = stripByKey[rowKey];
+  const stripped = re ? text.replace(re, "") : text;
+  const withPlaceholderLiteral = stripped.replace(/\{Bracket\}/g, "(Placeholder)");
+  return withPlaceholderLiteral.replace(/^\+\s*/, "");
+}
+
+function titleSuffixHardPrefix(rowKey: string): string {
+  const m: Record<string, string> = {
+    "title.suffix.movie": "{Title}",
+    "title.suffix.series": "{SeriesTitle}",
+    "title.suffix.season": "{Title}",
+    "title.suffix.episode": "{EpisodeTitle}",
+  };
+  return m[rowKey] ?? "{Title}";
+}
+
+function titleSuffixPreviewBase(rowKey: string): string {
+  const m: Record<string, string> = {
+    "title.suffix.movie": "Inception",
+    "title.suffix.series": "Breaking Bad",
+    "title.suffix.season": "Breaking Bad S01",
+    "title.suffix.episode": "Cat's in the Bag...",
+  };
+  return m[rowKey] ?? "";
 }
 
 function validateStatusMessageTemplate(
@@ -6603,7 +6739,133 @@ function clientRenderStatusMessage(template: string, ctx: Record<string, string>
   return collapsed;
 }
 
-function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
+type StatusProjectionDraft = {
+  placeholder_status_updates: string;
+  projection_mode: string;
+};
+
+function deriveProjectionSurfacesFromDraft(d: StatusProjectionDraft | undefined): {
+  project_title: boolean;
+  project_summary: boolean;
+} {
+  const mode = String(d?.projection_mode ?? "summary").trim().toLowerCase();
+  if (mode === "both") return { project_title: true, project_summary: true };
+  if (mode === "title") return { project_title: true, project_summary: false };
+  return { project_title: false, project_summary: true };
+}
+
+type LineRequestPreviewResp = {
+  title_line: string;
+  summary_line: string;
+  empty_tokens: string[];
+  projection_title_enabled?: boolean;
+  projection_summary_enabled?: boolean;
+  projection_blocked?: boolean;
+};
+
+function LineRequestLivePreview(props: {
+  synopsisTemplate: string;
+  projectionDraft?: StatusProjectionDraft;
+  brand: Brand;
+  themeMode: ThemeMode;
+}) {
+  const [movie, setMovie] = useState<LineRequestPreviewResp | null>(null);
+  const [episode, setEpisode] = useState<LineRequestPreviewResp | null>(null);
+  const { project_title: draftTitle, project_summary: draftSummary } = deriveProjectionSurfacesFromDraft(
+    props.projectionDraft,
+  );
+  const scope = String(props.projectionDraft?.placeholder_status_updates ?? "ALL").trim().toUpperCase();
+
+  useEffect(() => {
+    let cancelled = false;
+    const syn = props.synopsisTemplate ?? "";
+    void (async () => {
+      try {
+        const base = {
+          template_synopsis: syn,
+          projection_mode: String(props.projectionDraft?.projection_mode ?? "summary"),
+          placeholder_status_updates: scope,
+        };
+        const [m, e] = await Promise.all([
+          postJson<LineRequestPreviewResp>("/api/messages/preview", { ...base, media: "movie" }),
+          postJson<LineRequestPreviewResp>("/api/messages/preview", { ...base, media: "episode" }),
+        ]);
+        if (!cancelled) {
+          setMovie(m);
+          setEpisode(e);
+        }
+      } catch {
+        if (!cancelled) {
+          setMovie(null);
+          setEpisode(null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [props.synopsisTemplate, draftTitle, draftSummary, scope]);
+
+  function renderSampleColumn(label: string, data: LineRequestPreviewResp | null) {
+    return (
+      <div>
+        <p className="text-slate-500 font-headline uppercase tracking-wider mb-1">{label}</p>
+        {data ? (
+          <>
+            {data.projection_blocked && (
+              <p className="text-amber-300/90 text-[12px] mb-2">Status updates Off — placeholders would not decorate text.</p>
+            )}
+            <p className={`text-slate-300 ${!data.projection_title_enabled ? "opacity-50" : ""}`}>
+              <span className="text-slate-500">Title:</span> {data.title_line}
+              {!data.projection_title_enabled && (
+                <span className="text-slate-500 text-[11px] ml-1"> (title projection off)</span>
+              )}
+            </p>
+            <p className={`text-slate-300 mt-1 ${!data.projection_summary_enabled ? "opacity-50" : ""}`}>
+              <span className="text-slate-500">Synopsis lead:</span> {data.summary_line}
+              {!data.projection_summary_enabled && (
+                <span className="text-slate-500 text-[11px] ml-1"> (synopsis projection off)</span>
+              )}
+            </p>
+            {(data.empty_tokens?.length ?? 0) > 0 && (
+              <p className="text-slate-500 mt-1">
+                Empty on synopsis sample: {(data.empty_tokens ?? []).map((t) => `{${t}}`).join(", ")}
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="text-slate-500">…</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${UI_SECTION_FRAME_CLASS} px-5 py-4 mb-4`}>
+      <h3 className="text-[14px] font-headline uppercase tracking-wider text-slate-400 mb-1">
+        Live preview (sample data · REQUEST placeholder)
+      </h3>
+      <p className="text-[12px] text-slate-500 mb-3">
+        Reflects projection targets and status-update scope from the section above (including unsaved changes). REQUEST text comes from
+        Request line (synopsis); movie and TV episode samples use Movie / Episode title suffix templates.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-[13px]">
+        {renderSampleColumn("Movie", movie)}
+        {renderSampleColumn("TV episode", episode)}
+      </div>
+    </div>
+  );
+}
+
+function StatusMessagesPanel(props: {
+  brand: Brand;
+  themeMode: ThemeMode;
+  statusUpdatesScope?: string;
+  projectionDraft?: StatusProjectionDraft;
+  embedded?: boolean;
+  onMetaChange?: (meta: { dirty: boolean; hasValidationErrors: boolean }) => void;
+  registerSaveFlow?: (fn: (() => Promise<void>) | null) => void;
+}) {
   const accent = getBrandAccent(props.brand, props.themeMode);
   const [payload, setPayload] = useState<StatusMessagePayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -6623,6 +6885,7 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
     placeholderCount: number;
     pending: boolean;
   }>(null);
+  const scopeFlowWaitersRef = useRef<{ resolve: () => void; reject: (e: unknown) => void } | null>(null);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -6641,8 +6904,10 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
       const next: Record<string, string> = {};
       const def: Record<string, string> = {};
       for (const row of data.registry) {
-        next[row.key] = row.has_override ? row.value : row.default;
-        def[row.key] = row.default;
+        const currentRaw = row.has_override ? row.value : row.default;
+        const defaultRaw = row.default;
+        next[row.key] = isTitleSuffixRowKey(row.key) ? normalizeTitleSuffixTemplate(row.key, currentRaw) : currentRaw;
+        def[row.key] = isTitleSuffixRowKey(row.key) ? normalizeTitleSuffixTemplate(row.key, defaultRaw) : defaultRaw;
       }
       setValues(next);
       setDefaults(def);
@@ -6717,30 +6982,55 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
     return false;
   }, [payload, values, knownTokenSet]);
 
+  useEffect(() => {
+    props.onMetaChange?.({ dirty, hasValidationErrors });
+  }, [props.onMetaChange, dirty, hasValidationErrors]);
+
+  useEffect(() => {
+    return () => {
+      props.onMetaChange?.({ dirty: false, hasValidationErrors: false });
+      const w = scopeFlowWaitersRef.current;
+      scopeFlowWaitersRef.current = null;
+      w?.reject(Object.assign(new Error("cancelled"), { code: "MESSAGES_SAVE_CANCELLED" }));
+    };
+  }, [props.onMetaChange]);
+
   function setRowValue(key: string, value: string) {
-    setValues((prev) => ({ ...prev, [key]: value }));
+    const nextValue = isTitleSuffixRowKey(key) ? normalizeTitleSuffixTemplate(key, value) : value;
+    setValues((prev) => ({ ...prev, [key]: nextValue }));
   }
 
   function resetRow(key: string) {
     setValues((prev) => ({ ...prev, [key]: defaults[key] ?? "" }));
   }
 
-  async function handleSavePressed() {
-    if (!payload || saving || !dirty || hasValidationErrors) return;
+  const runMessagesSaveFlow = useCallback(async () => {
+    if (!payload) return;
+    if (!dirty) return;
+    if (hasValidationErrors) {
+      throw new Error("Fix status message template validation errors before saving.");
+    }
     setFeedback(null);
+    let data: { placeholder_count?: number; pending_full_sync_backfill?: boolean };
     try {
-      const data = await fetchJson<{ placeholder_count: number; pending_full_sync_backfill: boolean }>(
-        "/api/messages/templates/apply_estimate",
-        { credentials: "same-origin" },
-      );
+      data = await fetchJson("/api/messages/templates/apply_estimate", { credentials: "same-origin" });
+    } catch {
+      data = { placeholder_count: 0, pending_full_sync_backfill: false };
+    }
+    await new Promise<void>((resolve, reject) => {
+      scopeFlowWaitersRef.current = { resolve, reject };
       setScopeModal({
         placeholderCount: Number(data?.placeholder_count ?? 0),
         pending: !!data?.pending_full_sync_backfill,
       });
-    } catch {
-      setScopeModal({ placeholderCount: 0, pending: false });
-    }
-  }
+    });
+  }, [payload, dirty, hasValidationErrors]);
+
+  useEffect(() => {
+    if (!props.registerSaveFlow) return;
+    props.registerSaveFlow(runMessagesSaveFlow);
+    return () => props.registerSaveFlow?.(null);
+  }, [props.registerSaveFlow, runMessagesSaveFlow]);
 
   async function handleSave(applyScope: ApplyScope) {
     if (!payload) return;
@@ -6749,7 +7039,8 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
     try {
       const overrides: Record<string, string> = {};
       for (const row of payload.registry ?? []) {
-        const v = values[row.key] ?? "";
+        const raw = values[row.key] ?? "";
+        const v = isTitleSuffixRowKey(row.key) ? normalizeTitleSuffixTemplate(row.key, raw) : raw;
         if (v.trim() && v !== row.default) overrides[row.key] = v;
       }
       const resp = await fetch("/api/messages/templates", {
@@ -6780,6 +7071,9 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
         const firstKey = Object.keys(errors)[0];
         const msg = firstKey ? `${firstKey}: ${errors[firstKey]}` : `Save failed (HTTP ${resp.status})`;
         setFeedback({ kind: "error", message: msg });
+        const w = scopeFlowWaitersRef.current;
+        scopeFlowWaitersRef.current = null;
+        w?.reject(new Error(msg));
         return;
       }
       let savedMsg = "Status messages saved";
@@ -6789,8 +7083,14 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
       setFeedback({ kind: "success", message: savedMsg });
       setScopeModal(null);
       await reload();
+      const w = scopeFlowWaitersRef.current;
+      scopeFlowWaitersRef.current = null;
+      w?.resolve();
     } catch (e: unknown) {
       setFeedback({ kind: "error", message: e instanceof Error ? e.message : "Save failed" });
+      const w = scopeFlowWaitersRef.current;
+      scopeFlowWaitersRef.current = null;
+      w?.reject(e);
     } finally {
       setSaving(false);
     }
@@ -6835,17 +7135,24 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
     );
   }
 
-  return (
-    <div className="min-h-[40vh] px-6 py-5 space-y-5">
-      {/* Top toolbar: separator + case + actions */}
+  const scopeUpper = String(props.statusUpdatesScope ?? "").toUpperCase();
+  const panelInner = (
+    <div className={props.embedded ? "min-h-[40vh] px-2 py-5 space-y-5" : "min-h-[40vh] px-6 py-5 space-y-5"}>
+      <LineRequestLivePreview
+        synopsisTemplate={values["line.request"] ?? ""}
+        projectionDraft={props.projectionDraft}
+        brand={props.brand}
+        themeMode={props.themeMode}
+      />
+      {/* Top toolbar: separator + case + wrapper + status + reset (one row, wraps on narrow viewports) */}
       <div className={`${UI_SECTION_FRAME_CLASS} px-5 py-4`}>
-        <div className="flex flex-wrap items-end gap-4 justify-between">
-          <div className="flex flex-wrap items-end gap-4">
-            <div>
-              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Separator</label>
+        <div className="flex flex-wrap items-end gap-x-4 gap-y-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] font-headline uppercase tracking-wider text-slate-400">Separator</label>
               <div className="flex items-center gap-2">
                 <select
-                  className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  className={`min-w-0 max-w-[13rem] shrink-0 rounded-lg border border-[#424753]/40 bg-[#0f1419] py-2 pl-3 pr-9 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  title="Separator preset"
                   value={payload.separator_presets.some((p) => p.value === separator) ? separator : "__custom__"}
                   onChange={(e) => {
                     if (e.target.value === "__custom__") return;
@@ -6858,17 +7165,19 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                   <option value="__custom__">Custom…</option>
                 </select>
                 <input
-                  className={`w-24 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  className={`w-24 shrink-0 rounded-lg border border-[#424753]/40 bg-[#0f1419] px-3 py-2 font-mono text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
                   value={separator}
                   onChange={(e) => setSeparator(e.target.value)}
                   maxLength={6}
+                  title="Custom separator character"
                 />
               </div>
             </div>
-            <div>
-              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Default Case</label>
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] font-headline uppercase tracking-wider text-slate-400">Default Case</label>
               <select
-                className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                className={`min-w-0 max-w-[13rem] shrink-0 rounded-lg border border-[#424753]/40 bg-[#0f1419] py-2 pl-3 pr-9 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                title="Default case for rendered messages"
                 value={caseMode}
                 onChange={(e) => setCaseMode(e.target.value)}
               >
@@ -6877,11 +7186,12 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                 ))}
               </select>
             </div>
-            <div>
-              <label className="block text-[12px] font-headline uppercase tracking-wider text-slate-400 mb-1">Wrapper</label>
-              <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] font-headline uppercase tracking-wider text-slate-400">Wrapper</label>
+              <div className="flex flex-wrap items-center gap-2">
                 <select
-                  className={`bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  className={`min-w-0 max-w-[13rem] shrink-0 rounded-lg border border-[#424753]/40 bg-[#0f1419] py-2 pl-3 pr-9 text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                  title="Status bracket wrapper preset"
                   value={wrapperPreset}
                   onChange={(e) => setWrapperPreset(e.target.value)}
                 >
@@ -6892,7 +7202,7 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                 {wrapperPreset === "custom" && (
                   <>
                     <input
-                      className={`w-16 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                      className={`w-16 rounded-lg border border-[#424753]/40 bg-[#0f1419] px-3 py-2 font-mono text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
                       value={wrapperOpen}
                       onChange={(e) => setWrapperOpen(e.target.value)}
                       maxLength={8}
@@ -6900,7 +7210,7 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                       title="Custom open text"
                     />
                     <input
-                      className={`w-16 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 outline-none font-mono ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                      className={`w-16 rounded-lg border border-[#424753]/40 bg-[#0f1419] px-3 py-2 font-mono text-[15px] text-slate-200 outline-none ${getBrandFocusClass(props.brand, props.themeMode)}`}
                       value={wrapperClose}
                       onChange={(e) => setWrapperClose(e.target.value)}
                       maxLength={8}
@@ -6910,26 +7220,15 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                   </>
                 )}
               </div>
-              <p className="text-[11px] text-slate-500 mt-1 font-mono">
-                Preview: {wrapperPair.open || ""}REQUEST{wrapperPair.close || ""}
-              </p>
             </div>
-          </div>
-          <div className="flex items-center gap-3">
-            {dirty && (
-              <span className="flex items-center gap-1.5 text-[14px] text-yellow-400 font-headline uppercase tracking-wider">
-                <div className="w-1.5 h-1.5 rounded-full bg-yellow-400" />
-                Unsaved changes
-              </span>
-            )}
             {payload.pending_full_sync_backfill && (
-              <span className="flex items-center gap-1.5 text-[13px] text-amber-300 font-headline uppercase tracking-wider" title="Earlier save chose Next full sync; the backfill runs at the next full sync.">
+              <span className="flex shrink-0 items-center gap-1.5 whitespace-nowrap text-[13px] font-headline uppercase tracking-wider text-amber-300" title="Earlier save chose Next full sync; the backfill runs at the next full sync.">
                 <span className="material-symbols-outlined" style={{ fontSize: 14 }}>schedule</span>
                 Backfill pending
               </span>
             )}
             {feedback && (
-              <span className={`text-[14px] font-headline uppercase tracking-wider ${feedback.kind === "success" ? "text-green-400" : "text-red-400"}`}>
+              <span className={`max-w-[14rem] shrink text-[14px] font-headline uppercase tracking-wider sm:max-w-xs ${feedback.kind === "success" ? "text-green-400" : "text-red-400"}`}>
                 {feedback.message}
               </span>
             )}
@@ -6937,25 +7236,16 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
               type="button"
               onClick={handleResetAll}
               disabled={saving}
-              className="text-[13px] font-headline uppercase tracking-wider text-slate-400 hover:text-slate-200 underline-offset-2 hover:underline disabled:opacity-50"
+              className="shrink-0 whitespace-nowrap text-[13px] font-headline uppercase tracking-wider text-slate-400 underline-offset-2 hover:text-slate-200 hover:underline disabled:opacity-50"
             >
               Reset all to defaults
             </button>
-            <button
-              type="button"
-              onClick={handleSavePressed}
-              disabled={saving || !dirty || hasValidationErrors}
-              title={hasValidationErrors ? "Fix validation errors before saving" : ""}
-              className="flex items-center gap-2 px-4 py-2 text-white text-[14px] font-headline uppercase tracking-wider rounded-lg transition-colors disabled:opacity-50"
-              style={{ backgroundColor: accent.hex }}
-            >
-              <span className="material-symbols-outlined" style={{ fontSize: 16 }}>save</span>
-              {saving ? "Saving…" : "Save Messages"}
-            </button>
-          </div>
         </div>
+        <p className="mt-2 font-mono text-[11px] text-slate-500">
+          Preview: {wrapperPair.open || ""}REQUEST{wrapperPair.close || ""}
+        </p>
         <p className="ui-field-description mt-3">
-          Customize the lines Placeholdarr writes into NFOs / projects to your media player. Each row is the inner text; the global <span className="font-mono">Wrapper</span> applies <span className="font-mono">{wrapperPair.open || "·"}{wrapperPair.close || "·"}</span> around it. Missing tokens auto-collapse so optional metadata is safe to include. Click a row's <span className="font-mono">{`{ }`}</span> button to browse tokens.
+          Customize the lines Placeholdarr writes into NFOs / projects to your media player. Use <span className="font-semibold">Save Settings</span> at the top of this page to persist templates and choose backfill timing. Each row is the inner text; the global <span className="font-mono">Wrapper</span> applies <span className="font-mono">{wrapperPair.open || "·"}{wrapperPair.close || "·"}</span> around it. Missing tokens auto-collapse so optional metadata is safe to include. Click a row's <span className="font-mono">{`{ }`}</span> button to browse tokens.
         </p>
       </div>
 
@@ -7002,18 +7292,28 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                       );
                       const innerPreview = validation.error
                         ? ""
-                        : clientRenderStatusMessage(value || row.default, sampleCtx, separator, caseMode, tokenSamplesByName);
+                        : isTitleSuffixRowKey(row.key)
+                          ? (value || row.default)
+                          : clientRenderStatusMessage(value || row.default, sampleCtx, separator, caseMode, tokenSamplesByName);
                       // Rows whose final Plex/NFO line is wrapped by the global preset show the wrapped form here too.
                       const isWrappedSituation =
                         row.key === "line.request" ||
                         row.key.startsWith("queue.") ||
                         row.key.startsWith("calendar.") ||
                         row.key.startsWith("import_grace.");
-                      const preview = innerPreview && isWrappedSituation
+                      const wrappedPreview = innerPreview && isWrappedSituation
                         ? `${wrapperPair.open}${innerPreview}${wrapperPair.close}`
                         : innerPreview;
+                      const preview = isTitleSuffixRowKey(row.key)
+                        ? `${titleSuffixPreviewBase(row.key)}${innerPreview || ""}`
+                        : wrappedPreview;
+                      const rowMuted = scopeUpper === "REQUEST" && !!row.muted_under_request_scope;
                       return (
-                        <div key={row.key} className="space-y-2">
+                        <div
+                          key={row.key}
+                          className={`space-y-2 ${rowMuted ? "opacity-40" : ""}`}
+                          title={rowMuted ? "Not used while placeholder status updates are limited to REQUEST." : undefined}
+                        >
                           <div className="flex items-baseline gap-2 flex-wrap">
                             <label className="text-[15px] font-semibold text-slate-100">{row.label}</label>
                             {isOverride && (
@@ -7025,21 +7325,38 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
                             <span className="ml-auto font-mono text-[12px] text-slate-500">{row.key}</span>
                           </div>
                           <div className="flex gap-2">
-                            <input
-                              className={`flex-1 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 placeholder-slate-600 outline-none transition-colors ${getBrandFocusClass(props.brand, props.themeMode)}`}
-                              value={value}
-                              maxLength={payload.max_template_length ?? 400}
-                              placeholder={row.default}
-                              onChange={(e) => setRowValue(row.key, e.target.value)}
-                            />
-                            <button
-                              type="button"
-                              onClick={() => setTokenModal({ rowKey: row.key })}
-                              className="px-3 py-2 bg-[#252e3a] hover:bg-[#30353b] border border-[#424753]/40 rounded-lg text-[14px] text-slate-300 font-mono transition-colors"
-                              title="Insert a token"
-                            >
-                              {`{ }`}
-                            </button>
+                            {isTitleSuffixRowKey(row.key) ? (
+                              <div className="flex-1 flex items-center bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 gap-2">
+                                <span className="text-[13px] font-mono text-slate-400 whitespace-nowrap">
+                                  {titleSuffixHardPrefix(row.key)}
+                                </span>
+                                <input
+                                  className={`flex-1 bg-transparent border-0 px-0 py-0 text-[15px] text-slate-200 placeholder-slate-600 outline-none transition-colors ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                                  value={value}
+                                  maxLength={payload.max_template_length ?? 400}
+                                  placeholder={row.default}
+                                  onChange={(e) => setRowValue(row.key, e.target.value)}
+                                />
+                              </div>
+                            ) : (
+                              <input
+                                className={`flex-1 bg-[#0f1419] border border-[#424753]/40 rounded-lg px-3 py-2 text-[15px] text-slate-200 placeholder-slate-600 outline-none transition-colors ${getBrandFocusClass(props.brand, props.themeMode)}`}
+                                value={value}
+                                maxLength={payload.max_template_length ?? 400}
+                                placeholder={row.default}
+                                onChange={(e) => setRowValue(row.key, e.target.value)}
+                              />
+                            )}
+                            {(row.allowed_tokens?.length ?? 0) > 0 && (
+                              <button
+                                type="button"
+                                onClick={() => setTokenModal({ rowKey: row.key })}
+                                className="px-3 py-2 bg-[#252e3a] hover:bg-[#30353b] border border-[#424753]/40 rounded-lg text-[14px] text-slate-300 font-mono transition-colors"
+                                title="Insert a token"
+                              >
+                                {`{ }`}
+                              </button>
+                            )}
                             <button
                               type="button"
                               onClick={() => resetRow(row.key)}
@@ -7099,7 +7416,12 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
           placeholderCount={scopeModal.placeholderCount}
           alreadyPending={scopeModal.pending}
           saving={saving}
-          onCancel={() => setScopeModal(null)}
+          onCancel={() => {
+            setScopeModal(null);
+            const w = scopeFlowWaitersRef.current;
+            scopeFlowWaitersRef.current = null;
+            w?.reject(Object.assign(new Error("cancelled"), { code: "MESSAGES_SAVE_CANCELLED" }));
+          }}
           onConfirm={(scope) => handleSave(scope)}
           brand={props.brand}
           themeMode={props.themeMode}
@@ -7107,6 +7429,25 @@ function StatusMessagesPanel(props: { brand: Brand; themeMode: ThemeMode }) {
       )}
     </div>
   );
+
+  if (props.embedded) {
+    return (
+      <details className="mt-2 group rounded-lg border border-[#424753]/40 bg-[#0b111b]/40">
+        <summary className="cursor-pointer select-none list-none px-4 py-3 text-[14px] font-headline uppercase tracking-wider text-slate-300 flex items-center gap-2">
+          <span
+            className="material-symbols-outlined text-slate-500 transition-transform group-open:rotate-90"
+            style={{ fontSize: 18 }}
+          >
+            chevron_right
+          </span>
+          Advanced — message templates
+        </summary>
+        <div className="px-0 pb-2 border-t border-[#424753]/30">{panelInner}</div>
+      </details>
+    );
+  }
+
+  return panelInner;
 }
 
 function StatusMessagesApplyScopeModal(props: {

--- a/main.py
+++ b/main.py
@@ -436,6 +436,10 @@ app = FastAPI(lifespan=lifespan)
 from routes.dashboard import router as dashboard_router
 app.include_router(dashboard_router)
 
+# Customizable status message templates
+from routes.messages import router as messages_router
+app.include_router(messages_router)
+
 @app.post("/webhook")
 async def webhook(request: Request, background_tasks: BackgroundTasks):
     try:

--- a/routes/messages.py
+++ b/routes/messages.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 
+from core.config import settings
 from core.logger import logger
 from services.messages import (
     DEFAULT_SEPARATOR,
@@ -14,6 +16,8 @@ from services.messages import (
     InvalidTemplateError,
     UnknownTemplateKeyError,
     WRAPPER_PRESETS,
+    apply_wrapper,
+    get_overrides,
     get_template_config,
     get_token_specs,
     render,
@@ -22,12 +26,42 @@ from services.messages import (
     save_template_config,
     validate_template_text,
 )
-from services.messages.registry import CASE_OPTIONS, SEPARATOR_PRESETS, get_message_key, get_registry_for_settings_ui
+from services.messages.context import sample_projection_context
+from services.messages.registry import CASE_OPTIONS, SEPARATOR_PRESETS, MessageKey, get_message_key, get_registry_for_settings_ui
 from services.messages.template_engine import MAX_TEMPLATE_LENGTH
+from services.status_projection import projection_surfaces
 
 
 _VALID_APPLY_SCOPES = {"now", "next_full_sync", "future"}
 _DEFAULT_APPLY_SCOPE = "next_full_sync"
+
+
+def _preview_placeholder_status_updates_scope(body: dict[str, Any]) -> str:
+    raw = body.get("placeholder_status_updates")
+    if isinstance(raw, str):
+        u = raw.strip().upper()
+        if u in ("OFF", "REQUEST", "ALL"):
+            return u
+    return str(getattr(settings, "PLACEHOLDER_STATUS_UPDATES", "ALL") or "ALL").strip().upper()
+
+
+def _preview_projection_surfaces(body: dict[str, Any]) -> tuple[bool, bool]:
+    mode = body.get("projection_mode")
+    if isinstance(mode, str):
+        value = mode.strip().lower()
+        if value == "both":
+            return (True, True)
+        if value == "title":
+            return (True, False)
+        if value == "summary":
+            return (False, True)
+    return projection_surfaces()
+
+
+def _empty_tokens_for_template(template_src: str, ctx: dict[str, Any]) -> list[str]:
+    used = re.findall(r"\{([A-Za-z][A-Za-z0-9_]*)\}", str(template_src or ""))
+    return [t for t in used if t != "Sep" and not str(ctx.get(t, "")).strip()]
+
 
 router = APIRouter(prefix="/api/messages", tags=["messages"])
 
@@ -41,6 +75,19 @@ def _serialize_token(token) -> dict[str, Any]:
         "sample": token.sample,
         "placeholder": token.placeholder,
     }
+
+
+def _muted_under_request_scope(msg: MessageKey) -> bool:
+    """Dim in UI when Placeholder status updates = Request only (non-REQUEST templates inactive)."""
+    g = str(msg.group or "")
+    if msg.key == "line.request" or g in ("Request", "Title Suffix"):
+        return False
+    return bool(
+        g.startswith("Calendar")
+        or "Coming Soon" in g
+        or g.startswith("Queue")
+        or g.startswith("Import Grace")
+    )
 
 
 def _serialize_message(msg) -> dict[str, Any]:
@@ -70,6 +117,7 @@ def _serialize_message(msg) -> dict[str, Any]:
         "has_override": has_override,
         "allowed_tokens": list(msg.allowed_tokens),
         "sample_render": sample,
+        "muted_under_request_scope": _muted_under_request_scope(msg),
     }
 
 
@@ -105,6 +153,76 @@ def get_templates() -> JSONResponse:
             "wrapper_presets": list(WRAPPER_PRESETS),
             "max_template_length": MAX_TEMPLATE_LENGTH,
             "pending_full_sync_backfill": pending_backfill,
+        }
+    )
+
+
+@router.post("/preview")
+def post_message_preview(body: dict[str, Any]) -> JSONResponse:
+    """Live preview for REQUEST lines; honors draft projection toggles and status-update scope."""
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="payload must be an object")
+
+    media_raw = str(body.get("media") or "movie").strip().lower()
+    is_episode = media_raw in ("episode", "tv", "show")
+    media_key = "episode" if is_episode else "movie"
+    ctx = sample_projection_context(media_key)
+    overrides = dict(get_overrides() or {})
+
+    spec_syn = get_message_key("line.request")
+    if spec_syn is None:
+        raise HTTPException(status_code=500, detail="missing line.request registry")
+
+    template_syn = body.get("template_synopsis")
+    if template_syn is None:
+        template_syn = body.get("template")
+    tmpl_src_syn: str
+    if isinstance(template_syn, str) and template_syn.strip():
+        syn_inner = render_template("line.request", template_syn.strip(), ctx)
+        tmpl_src_syn = template_syn.strip()
+    else:
+        syn_inner = render("line.request", ctx)
+        o = overrides.get("line.request")
+        tmpl_src_syn = o if isinstance(o, str) and o.strip() else spec_syn.default
+
+    syn_bracket = apply_wrapper(syn_inner)
+
+    scope = _preview_placeholder_status_updates_scope(body)
+    title_on, summary_on = _preview_projection_surfaces(body)
+    demo_status = str(body.get("demo_status") or "REQUEST").strip().upper()
+    request_demo = demo_status == "REQUEST"
+    projection_allowed = scope != "OFF" and (scope == "ALL" or (scope == "REQUEST" and request_demo))
+
+    sample_title = "Cat's in the Bag..." if is_episode else "Inception"
+    sample_plot = "Sample library overview text for preview."
+
+    title_line_final = sample_title
+    summary_line_final = sample_plot
+
+    if projection_allowed and title_on:
+        suffix_key = "title.suffix.episode" if is_episode else "title.suffix.movie"
+        title_suffix = render(suffix_key, ctx)
+        if title_suffix.strip():
+            normalized_suffix = title_suffix if title_suffix[:1].isspace() else f" {title_suffix}"
+            title_line_final = f"{sample_title}{normalized_suffix}".strip()
+        else:
+            title_line_final = sample_title
+    if projection_allowed and summary_on:
+        summary_line_final = f"{syn_bracket} {sample_plot}".strip()
+
+    empty_syn = _empty_tokens_for_template(tmpl_src_syn, ctx)
+    return JSONResponse(
+        {
+            "media": media_key,
+            "inner_synopsis": syn_inner,
+            "bracket_synopsis": syn_bracket,
+            "title_line": title_line_final,
+            "summary_line": summary_line_final,
+            "projection_title_enabled": bool(title_on),
+            "projection_summary_enabled": bool(summary_on),
+            "placeholder_status_updates": scope,
+            "projection_blocked": not projection_allowed,
+            "empty_tokens": empty_syn,
         }
     )
 

--- a/routes/messages.py
+++ b/routes/messages.py
@@ -1,0 +1,395 @@
+"""HTTP routes for the customizable status message templates feature."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+
+from core.logger import logger
+from services.messages import (
+    DEFAULT_SEPARATOR,
+    DEFAULT_WRAPPER_PRESET,
+    InvalidTemplateError,
+    UnknownTemplateKeyError,
+    WRAPPER_PRESETS,
+    get_template_config,
+    get_token_specs,
+    render,
+    render_template,
+    sample_render,
+    save_template_config,
+    validate_template_text,
+)
+from services.messages.registry import CASE_OPTIONS, SEPARATOR_PRESETS, get_message_key, get_registry_for_settings_ui
+from services.messages.template_engine import MAX_TEMPLATE_LENGTH
+
+
+_VALID_APPLY_SCOPES = {"now", "next_full_sync", "future"}
+_DEFAULT_APPLY_SCOPE = "next_full_sync"
+
+router = APIRouter(prefix="/api/messages", tags=["messages"])
+
+
+def _serialize_token(token) -> dict[str, Any]:
+    return {
+        "name": token.name,
+        "label": token.label,
+        "group": token.group,
+        "description": token.description,
+        "sample": token.sample,
+        "placeholder": token.placeholder,
+    }
+
+
+def _serialize_message(msg) -> dict[str, Any]:
+    """Build the API row for a single registered message key, with current value and sample render."""
+    config = get_template_config()
+    overrides = config["overrides"]
+    override = overrides.get(msg.key)
+    has_override = isinstance(override, str) and override.strip() != ""
+
+    try:
+        sample = sample_render(msg.key)
+    except Exception as exc:
+        logger.warning(
+            f"Sample render failed key={msg.key}: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+        sample = ""
+
+    return {
+        "key": msg.key,
+        "label": msg.label,
+        "group": msg.group,
+        "subgroup": msg.subgroup,
+        "tooltip": msg.tooltip,
+        "default": msg.default,
+        "value": override if has_override else msg.default,
+        "has_override": has_override,
+        "allowed_tokens": list(msg.allowed_tokens),
+        "sample_render": sample,
+    }
+
+
+@router.get("/templates")
+def get_templates() -> JSONResponse:
+    config = get_template_config()
+    registry = [_serialize_message(m) for m in get_registry_for_settings_ui()]
+    tokens = [_serialize_token(t) for t in get_token_specs()]
+    raw_ov = config.get("overrides") or {}
+    overrides_ui: dict[str, str] = {}
+    if isinstance(raw_ov, dict):
+        for k, v in raw_ov.items():
+            if not isinstance(k, str):
+                continue
+            spec = get_message_key(k)
+            if spec is not None and spec.settings_ui:
+                overrides_ui[k] = v
+
+    pending_backfill = bool(_get_pending_backfill_flag())
+
+    return JSONResponse(
+        {
+            "registry": registry,
+            "tokens": tokens,
+            "separator": config.get("separator", DEFAULT_SEPARATOR),
+            "case": config.get("case", "default"),
+            "wrapper_preset": config.get("wrapper_preset", DEFAULT_WRAPPER_PRESET),
+            "wrapper_open": config.get("wrapper_open", ""),
+            "wrapper_close": config.get("wrapper_close", ""),
+            "overrides": overrides_ui,
+            "separator_presets": list(SEPARATOR_PRESETS),
+            "case_options": list(CASE_OPTIONS),
+            "wrapper_presets": list(WRAPPER_PRESETS),
+            "max_template_length": MAX_TEMPLATE_LENGTH,
+            "pending_full_sync_backfill": pending_backfill,
+        }
+    )
+
+
+@router.post("/templates")
+def post_templates(body: dict[str, Any]) -> JSONResponse:
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="payload must be an object")
+
+    overrides_in = body.get("overrides")
+    if overrides_in is None:
+        overrides_in = {}
+    if not isinstance(overrides_in, dict):
+        raise HTTPException(status_code=400, detail="overrides must be an object")
+
+    sep = body.get("separator", DEFAULT_SEPARATOR)
+    if sep is None or not isinstance(sep, str) or sep == "":
+        sep = DEFAULT_SEPARATOR
+
+    case = body.get("case", "default")
+    if not isinstance(case, str):
+        case = "default"
+    if case not in {opt["value"] for opt in CASE_OPTIONS}:
+        case = "default"
+
+    wrapper_preset = body.get("wrapper_preset", DEFAULT_WRAPPER_PRESET)
+    wrapper_preset_values = {entry["value"] for entry in WRAPPER_PRESETS}
+    if not isinstance(wrapper_preset, str) or wrapper_preset.strip().lower() not in wrapper_preset_values:
+        wrapper_preset = DEFAULT_WRAPPER_PRESET
+    wrapper_preset = wrapper_preset.strip().lower()
+
+    wrapper_open = body.get("wrapper_open", "")
+    if not isinstance(wrapper_open, str):
+        wrapper_open = ""
+    wrapper_close = body.get("wrapper_close", "")
+    if not isinstance(wrapper_close, str):
+        wrapper_close = ""
+
+    apply_scope_raw = body.get("apply_scope", _DEFAULT_APPLY_SCOPE)
+    apply_scope = (
+        str(apply_scope_raw).strip().lower()
+        if isinstance(apply_scope_raw, str)
+        else _DEFAULT_APPLY_SCOPE
+    )
+    if apply_scope not in _VALID_APPLY_SCOPES:
+        apply_scope = _DEFAULT_APPLY_SCOPE
+
+    cleaned_overrides: dict[str, str] = {}
+    field_errors: dict[str, str] = {}
+
+    for key_raw, value_raw in overrides_in.items():
+        if not isinstance(key_raw, str):
+            continue
+
+        spec = get_message_key(key_raw)
+        if spec is None:
+            field_errors[key_raw] = "unknown message key"
+            continue
+
+        text = "" if value_raw is None else str(value_raw)
+        if text.strip() == "" or text == spec.default:
+            continue
+
+        try:
+            result = validate_template_text(spec.key, text)
+        except InvalidTemplateError as exc:
+            field_errors[spec.key] = str(exc)
+            continue
+
+        if not result["ok"]:
+            issues: list[str] = []
+            if result["unknown_tokens"]:
+                issues.append("unknown tokens: " + ", ".join(result["unknown_tokens"]))
+            if result["disallowed_tokens"]:
+                issues.append("not allowed in this scenario: " + ", ".join(result["disallowed_tokens"]))
+            field_errors[spec.key] = "; ".join(issues) if issues else "invalid template"
+            continue
+
+        cleaned_overrides[spec.key] = text
+
+    if field_errors:
+        raise HTTPException(
+            status_code=400,
+            detail={"errors": field_errors},
+        )
+
+    # Settings UI only submits user-visible keys. Preserve hidden keys (e.g. legacy status.label.*).
+    prior = dict(get_template_config().get("overrides") or {})
+    merged_overrides: dict[str, str] = {}
+    for pk, pv in prior.items():
+        sk = get_message_key(pk)
+        if sk is not None and not sk.settings_ui:
+            merged_overrides[pk] = pv
+    merged_overrides.update(cleaned_overrides)
+
+    saved = save_template_config({
+        "separator": sep,
+        "case": case,
+        "overrides": merged_overrides,
+        "wrapper_preset": wrapper_preset,
+        "wrapper_open": wrapper_open,
+        "wrapper_close": wrapper_close,
+    })
+
+    backfill_summary = _execute_apply_scope(apply_scope)
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "saved": saved,
+            "registry": [_serialize_message(m) for m in get_registry_for_settings_ui()],
+            "apply_scope": apply_scope,
+            "backfill": backfill_summary,
+        }
+    )
+
+
+def _get_pending_backfill_flag() -> bool:
+    """Read the ``PLACEHOLDER_TEMPLATE_BACKFILL_PENDING`` flag from app_config."""
+    try:
+        from services.postgres.db import get_session
+        from services.postgres.models import AppConfig
+        from services.source_of_truth.template_backfill import PENDING_FLAG_KEY
+    except Exception:
+        return False
+
+    session = get_session()
+    try:
+        row = session.query(AppConfig).filter(AppConfig.key == PENDING_FLAG_KEY).first()
+        return bool(row and row.value)
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+
+def _execute_apply_scope(apply_scope: str) -> dict[str, Any]:
+    """Materialize the user's chosen apply policy after a successful template save.
+
+    - ``now``: enqueue an immediate template-backfill job covering all active placeholders.
+    - ``next_full_sync``: set the pending flag so the next scheduled or manual full sync runs the job.
+    - ``future``: clear any pending flag and do nothing retroactive.
+    """
+    try:
+        from services.source_of_truth.template_backfill import (
+            clear_pending_template_backfill,
+            enqueue_template_backfill,
+            mark_template_backfill_pending,
+        )
+    except Exception as exc:
+        logger.warning(
+            f"Template backfill module unavailable: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+        return {"scope": apply_scope, "ok": False, "reason": "backfill_module_unavailable"}
+
+    if apply_scope == "now":
+        out = enqueue_template_backfill()
+        out.setdefault("scope", "now")
+        try:
+            clear_pending_template_backfill()
+        except Exception:
+            pass
+        return out
+
+    if apply_scope == "next_full_sync":
+        out = mark_template_backfill_pending()
+        out.setdefault("scope", "next_full_sync")
+        return out
+
+    out = clear_pending_template_backfill()
+    out.setdefault("scope", "future")
+    return out
+
+
+@router.get("/templates/apply_estimate")
+def get_apply_estimate() -> JSONResponse:
+    """How many placeholders an immediate ``Apply now`` save would refresh."""
+    try:
+        from services.source_of_truth.template_backfill import (
+            is_template_backfill_pending,
+            placeholder_count_for_apply_now,
+        )
+        count = placeholder_count_for_apply_now()
+        pending = is_template_backfill_pending()
+    except Exception as exc:
+        logger.warning(f"Apply estimate unavailable: {exc}", extra={"emoji_type": "warning"})
+        return JSONResponse({"placeholder_count": 0, "pending_full_sync_backfill": False})
+    return JSONResponse({"placeholder_count": int(count), "pending_full_sync_backfill": bool(pending)})
+
+
+@router.post("/templates/preview")
+def post_preview(body: dict[str, Any]) -> JSONResponse:
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="payload must be an object")
+
+    key = body.get("key")
+    template = body.get("template")
+    sep_override = body.get("separator")
+    case_override = body.get("case")
+
+    if not isinstance(key, str) or not key:
+        raise HTTPException(status_code=400, detail="key is required")
+
+    spec = get_message_key(key)
+    if spec is None:
+        raise HTTPException(status_code=400, detail=f"unknown message key: {key}")
+
+    if template is None:
+        template = spec.default
+    template_text = str(template)
+
+    try:
+        validation = validate_template_text(spec.key, template_text)
+    except InvalidTemplateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except UnknownTemplateKeyError:
+        raise HTTPException(status_code=400, detail=f"unknown message key: {key}")
+
+    ctx = dict(spec.sample_context)
+
+    try:
+        rendered = render_template(
+            spec.key,
+            template_text,
+            ctx,
+            separator=sep_override if isinstance(sep_override, str) and sep_override else None,
+            case_mode=case_override if isinstance(case_override, str) and case_override else None,
+        )
+    except Exception as exc:
+        logger.warning(
+            f"Template preview render failed key={spec.key}: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+        rendered = ""
+
+    return JSONResponse(
+        {
+            "key": spec.key,
+            "rendered": rendered,
+            "validation": validation,
+            "sample_context": ctx,
+        }
+    )
+
+
+@router.post("/templates/reset")
+def post_reset(body: dict[str, Any]) -> JSONResponse:
+    """Reset a single override (or all overrides) to their defaults.
+
+    Body: ``{"key": "..."}`` to reset one, ``{"all": true}`` to reset everything.
+    """
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="payload must be an object")
+
+    config = get_template_config()
+    overrides = dict(config["overrides"])
+
+    if body.get("all"):
+        overrides = {}
+    else:
+        key = body.get("key")
+        if not isinstance(key, str) or not key:
+            raise HTTPException(status_code=400, detail="key is required")
+        spec = get_message_key(key)
+        if spec is None:
+            raise HTTPException(status_code=400, detail=f"unknown message key: {key}")
+        overrides.pop(spec.key, None)
+
+    saved = save_template_config(
+        {
+            "separator": config.get("separator"),
+            "case": config.get("case"),
+            "overrides": overrides,
+            "wrapper_preset": config.get("wrapper_preset"),
+            "wrapper_open": config.get("wrapper_open"),
+            "wrapper_close": config.get("wrapper_close"),
+        }
+    )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "saved": saved,
+            "registry": [_serialize_message(m) for m in get_registry_for_settings_ui()],
+        }
+    )

--- a/services/app_config.py
+++ b/services/app_config.py
@@ -23,6 +23,8 @@ SETUP_COMPLETED_KEY = "APP_SETUP_COMPLETED_AT"
 REMOVED_SETTINGS_KEYS_IGNORED_ON_SAVE = frozenset(
     {
         "PLACEHOLDER_CREATE_NFO",
+        "PLACEHOLDER_STATUS_PROJECT_TITLE",
+        "PLACEHOLDER_STATUS_PROJECT_SUMMARY",
         "CHECK_INTERVAL",
         "QUEUE_MONITOR_POLL_INTERVAL_SECONDS",
         "QUEUE_MONITOR_REFRESH_MONITORED_DOWNLOADS_INTERVAL_SECONDS",
@@ -326,8 +328,8 @@ SETTINGS_SCHEMA: "OrderedDict[str, dict[str, Any]]" = OrderedDict(
             "PLACEHOLDER_STATUS_PROJECTION_MODE",
             {
                 "section": "Status Updates",
-                "label": "Placeholder status projection mode",
-                "description": "When status updates are on, choose whether bracketed status appears in summary text, title text, or both.",
+                "label": "Project status into",
+                "description": "Choose where bracketed placeholder status appears in media library metadata.",
                 "type": "choice",
                 "restart_required": True,
                 "options": [

--- a/services/media_servers/player_metadata_refresh.py
+++ b/services/media_servers/player_metadata_refresh.py
@@ -24,6 +24,7 @@ from services.media_servers.plex_identity import (
     persist_movie_plex_identity,
 )
 from services.media_servers.plex_lookup import find_episode_by_series_tvdb, find_movie_by_id
+from services.messages.context import build_projection_context
 from services.postgres.models import Episode, Movie, Placeholder, Season, Series
 from services.status_projection import project_summary, project_title
 
@@ -404,10 +405,21 @@ def _project_text(
     base_summary: str | None,
     status: str,
     *,
+    suffix_template_key: str = "title.suffix.movie",
     runtime_minutes: int | None = None,
+    media_context: dict | None = None,
 ) -> tuple[str, str]:
-    return project_title(base_title or "", status), project_summary(
-        base_summary or "", status, runtime_minutes=runtime_minutes
+    return project_title(
+        base_title or "",
+        status,
+        suffix_template_key=suffix_template_key,
+        runtime_minutes=runtime_minutes,
+        media_context=media_context,
+    ), project_summary(
+        base_summary or "",
+        status,
+        runtime_minutes=runtime_minutes,
+        media_context=media_context,
     )
 
 
@@ -490,11 +502,14 @@ def _push_movie(
 ) -> None:
     status = _projected_display_status(placeholder)
     runtime_minutes = _runtime_minutes_movie(movie) if status.strip().upper() == "REQUEST" else None
+    media_ctx = build_projection_context(movie=movie, runtime_minutes=runtime_minutes)
     projected_title, projected_summary = _project_text(
         getattr(movie, "title", None),
         getattr(movie, "radarr_overview", None),
         status,
+        suffix_template_key="title.suffix.movie",
         runtime_minutes=runtime_minutes,
+        media_context=media_ctx,
     )
 
     if getattr(settings, "jellyfin_enabled", False):
@@ -629,11 +644,19 @@ def _push_episode(
     runtime_minutes = (
         _runtime_minutes_episode(episode, series) if status.strip().upper() == "REQUEST" else None
     )
+    media_ctx = build_projection_context(
+        episode=episode,
+        season=season,
+        series=series,
+        runtime_minutes=runtime_minutes,
+    )
     projected_ep_title, projected_ep_summary = _project_text(
         getattr(episode, "title", None),
         getattr(episode, "sonarr_episode_overview", None),
         status,
+        suffix_template_key="title.suffix.episode",
         runtime_minutes=runtime_minutes,
+        media_context=media_ctx,
     )
     if getattr(settings, "jellyfin_enabled", False):
         jf_ep = _find_jellyfin_episode_item_id(series, season, episode)

--- a/services/messages/__init__.py
+++ b/services/messages/__init__.py
@@ -1,0 +1,76 @@
+"""Customizable status message templates for player projection.
+
+Public API:
+    - get_registry(): all MessageKey definitions (including internal keys)
+    - get_registry_for_settings_ui(): subset shown under Settings → Status Messages
+    - get_token_specs(): list of TokenSpec definitions for the UI / API
+    - render(key, ctx): render a registered key against a context dict
+    - render_template(key, template, ctx): render a free-form template (for preview)
+    - get_overrides(): current override dict from AppConfig
+    - get_separator(): currently configured separator
+    - get_case(): currently configured case mode
+    - save_template_config(payload): persist overrides + separator + case
+    - validate_template_text(key, text): static validation helper
+"""
+
+from services.messages.registry import (
+    DEFAULT_SEPARATOR,
+    DEFAULT_WRAPPER_PRESET,
+    SEPARATOR_PRESETS,
+    CASE_OPTIONS,
+    WRAPPER_PRESETS,
+    MessageKey,
+    TokenSpec,
+    get_message_key,
+    get_registry,
+    get_registry_for_settings_ui,
+    get_token_specs,
+    get_wrapper_presets,
+    get_wrapper_preset_pair,
+)
+from services.messages.template_engine import (
+    InvalidTemplateError,
+    UnknownTemplateKeyError,
+    apply_wrapper,
+    render,
+    render_template,
+    sample_render,
+    validate_template_text,
+)
+from services.messages.store import (
+    get_case,
+    get_overrides,
+    get_separator,
+    get_template_config,
+    get_wrapper,
+    save_template_config,
+)
+
+__all__ = [
+    "DEFAULT_SEPARATOR",
+    "DEFAULT_WRAPPER_PRESET",
+    "SEPARATOR_PRESETS",
+    "CASE_OPTIONS",
+    "WRAPPER_PRESETS",
+    "MessageKey",
+    "TokenSpec",
+    "get_message_key",
+    "get_registry",
+    "get_registry_for_settings_ui",
+    "get_token_specs",
+    "get_wrapper_presets",
+    "get_wrapper_preset_pair",
+    "InvalidTemplateError",
+    "UnknownTemplateKeyError",
+    "apply_wrapper",
+    "render",
+    "render_template",
+    "sample_render",
+    "validate_template_text",
+    "get_case",
+    "get_overrides",
+    "get_separator",
+    "get_template_config",
+    "get_wrapper",
+    "save_template_config",
+]

--- a/services/messages/context.py
+++ b/services/messages/context.py
@@ -1,0 +1,166 @@
+"""Build unified template context for placeholder status projection (NFO + players).
+
+Merges media tokens from Movie / Episode rows with optional runtime overlay so
+``line.request`` and related templates receive the same fields everywhere.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from services.messages.template_engine import (
+    media_tokens_for_episode,
+    media_tokens_for_movie,
+    media_tokens_for_season,
+    media_tokens_for_series,
+)
+
+
+def _rounded_minutes(value: int | float | str | None) -> int:
+    if value is None or value == "":
+        return 0
+    try:
+        return max(0, int(round(float(value))))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _format_duration_label(minutes: int) -> str:
+    """Match ``format_duration_label`` in status_projection without importing it (avoid cycles)."""
+    if minutes <= 0:
+        return ""
+    from services.messages import render
+
+    if minutes < 60:
+        return render("runtime.format.m", {"Minutes": str(minutes)})
+    h, m = divmod(minutes, 60)
+    if m == 0:
+        return render("runtime.format.h", {"Hours": str(h)})
+    return render("runtime.format.hm", {"Hours": str(h), "Minutes": str(m)})
+
+
+def augment_context_with_runtime(
+    base: dict[str, Any] | None,
+    runtime_minutes: int | None,
+) -> dict[str, Any]:
+    """Overlay formatted Runtime / Hours / Minutes / RuntimeMinutes from wall-clock minutes."""
+    out = dict(base or {})
+    if runtime_minutes is None:
+        return out
+    rm = _rounded_minutes(runtime_minutes)
+    if rm <= 0:
+        return out
+    dur = _format_duration_label(rm)
+    if dur:
+        out["Runtime"] = dur
+    h, m = divmod(rm, 60)
+    out["Hours"] = str(h) if h else ""
+    out["Minutes"] = str(m) if m else ""
+    out["RuntimeMinutes"] = str(rm)
+    return out
+
+
+def build_projection_context(
+    *,
+    movie: Any = None,
+    episode: Any = None,
+    season: Any = None,
+    series: Any = None,
+    runtime_minutes: int | None = None,
+) -> dict[str, Any]:
+    """Merge media tokens with runtime for ``line.request`` / bracket rendering."""
+    if movie is not None:
+        base = media_tokens_for_movie(movie)
+    elif episode is not None:
+        base = media_tokens_for_episode(episode, season, series)
+    elif season is not None:
+        base = media_tokens_for_season(season, series)
+    elif series is not None:
+        base = media_tokens_for_series(series)
+    else:
+        base = {}
+    return augment_context_with_runtime(base, runtime_minutes)
+
+
+def build_projection_context_from_session(
+    session: Any,
+    *,
+    movie_id: int | None = None,
+    episode_id: int | None = None,
+    runtime_minutes: int | None = None,
+) -> dict[str, Any]:
+    """Load ORM rows and build projection context (used from materializer / orchestrator)."""
+    from services.postgres.models import Episode, Movie, Season, Series
+
+    if movie_id is not None:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id)).first()
+        if movie:
+            rm = runtime_minutes
+            if rm is None:
+                rm = _runtime_minutes_from_movie(movie)
+            return build_projection_context(movie=movie, runtime_minutes=rm)
+        return {}
+    if episode_id is not None:
+        ep = session.query(Episode).filter(Episode.id == int(episode_id)).first()
+        if not ep:
+            return {}
+        season = session.query(Season).filter(Season.id == ep.season_id).first() if ep.season_id else None
+        series = session.query(Series).filter(Series.id == season.series_id).first() if season else None
+        rm = runtime_minutes
+        if rm is None:
+            rm = _runtime_minutes_from_episode(ep, series)
+        return build_projection_context(episode=ep, season=season, series=series, runtime_minutes=rm)
+    return {}
+
+
+def _runtime_minutes_from_movie(movie: Any) -> int | None:
+    try:
+        r = int(getattr(movie, "radarr_runtime", 0) or 0)
+        return r if r > 0 else None
+    except Exception:
+        return None
+
+
+def _runtime_minutes_from_episode(episode: Any, series: Any) -> int | None:
+    try:
+        r = int(getattr(episode, "sonarr_runtime", 0) or 0)
+        if r > 0:
+            return r
+    except Exception:
+        pass
+    if series is None:
+        return None
+    try:
+        r = int(getattr(series, "sonarr_runtime", 0) or 0)
+        return r if r > 0 else None
+    except Exception:
+        return None
+
+
+def sample_projection_context(media: str, *, runtime_minutes: int = 121) -> dict[str, Any]:
+    """Fixed demo context for Settings previews (`movie` vs `episode`)."""
+    m = str(media or "movie").strip().lower()
+    if m in ("episode", "tv", "show"):
+        base: dict[str, Any] = {
+            "Title": "Breaking Bad",
+            "SeriesTitle": "Breaking Bad",
+            "EpisodeTitle": "Cat's in the Bag...",
+            "Year": "2008",
+            "ReleaseYear": "2008",
+            "Genres": "Crime, Drama",
+            "Certification": "TV-MA",
+            "Studio": "AMC",
+            "SeasonNumber": "01",
+            "EpisodeNumber": "02",
+            "SXXEYY": "S01E02",
+        }
+    else:
+        base = {
+            "Title": "Inception",
+            "Year": "2010",
+            "ReleaseYear": "2010",
+            "Genres": "Action, Sci-Fi",
+            "Certification": "PG-13",
+            "Studio": "Warner Bros.",
+        }
+    return augment_context_with_runtime(base, runtime_minutes)

--- a/services/messages/registry.py
+++ b/services/messages/registry.py
@@ -1,0 +1,901 @@
+"""Registry of customizable player-projection messages.
+
+Each MessageKey describes one user-visible string we render in player title/summary
+brackets, NFO output, or related projection surfaces. Keys are grouped for the UI
+and declare which tokens are valid in their template.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ----- Tokens ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TokenSpec:
+    """Describes a single {Token} that templates may interpolate."""
+
+    name: str  # The bare token name without braces, e.g. "Title"
+    label: str  # Friendly label for the picker UI
+    group: str  # UI group: "Media", "Episode", "Status", "Calendar", "Queue", "Import Grace", "General"
+    description: str  # Tooltip text shown in the picker
+    sample: str  # Sample value shown in the picker chip and used for previews
+
+    @property
+    def placeholder(self) -> str:
+        return "{" + self.name + "}"
+
+
+_TOKEN_SPECS: tuple[TokenSpec, ...] = (
+    # General
+    TokenSpec(
+        name="Sep",
+        label="Separator",
+        group="General",
+        description="The configured separator character for this section. Defaults to a middle dot.",
+        sample="·",
+    ),
+    # Media
+    TokenSpec(
+        name="Title",
+        label="Title",
+        group="Media",
+        description="Movie or series title.",
+        sample="Inception",
+    ),
+    TokenSpec(
+        name="Year",
+        label="Year",
+        group="Media",
+        description="Release year of the movie or series.",
+        sample="2010",
+    ),
+    TokenSpec(
+        name="ReleaseYear",
+        label="Release Year",
+        group="Media",
+        description="Alias for the release year.",
+        sample="2010",
+    ),
+    TokenSpec(
+        name="Genres",
+        label="Genres",
+        group="Media",
+        description="Comma-separated list of genres reported by the ARR.",
+        sample="Action, Sci-Fi",
+    ),
+    TokenSpec(
+        name="Certification",
+        label="Certification",
+        group="Media",
+        description="Content rating reported by the ARR (e.g. PG-13, R, TV-MA).",
+        sample="PG-13",
+    ),
+    TokenSpec(
+        name="Studio",
+        label="Studio",
+        group="Media",
+        description="Studio or network reported by the ARR.",
+        sample="Warner Bros.",
+    ),
+    TokenSpec(
+        name="Runtime",
+        label="Runtime",
+        group="Media",
+        description="Formatted runtime, e.g. 1h 15m. Honors your runtime templates.",
+        sample="2h 28m",
+    ),
+    TokenSpec(
+        name="RuntimeMinutes",
+        label="Runtime (minutes)",
+        group="Media",
+        description="Raw runtime expressed in whole minutes.",
+        sample="148",
+    ),
+    TokenSpec(
+        name="Hours",
+        label="Hours",
+        group="Media",
+        description="Hour component of the runtime.",
+        sample="2",
+    ),
+    TokenSpec(
+        name="Minutes",
+        label="Minutes",
+        group="Media",
+        description="Minute component of the runtime (0-59).",
+        sample="28",
+    ),
+    # Episode
+    TokenSpec(
+        name="SeriesTitle",
+        label="Series Title",
+        group="Episode",
+        description="Title of the TV series this episode belongs to.",
+        sample="Breaking Bad",
+    ),
+    TokenSpec(
+        name="SeasonNumber",
+        label="Season Number",
+        group="Episode",
+        description="Two-digit season number, e.g. 02.",
+        sample="02",
+    ),
+    TokenSpec(
+        name="EpisodeNumber",
+        label="Episode Number",
+        group="Episode",
+        description="Two-digit episode number, e.g. 05.",
+        sample="05",
+    ),
+    TokenSpec(
+        name="EpisodeTitle",
+        label="Episode Title",
+        group="Episode",
+        description="Title of the episode.",
+        sample="Pilot",
+    ),
+    TokenSpec(
+        name="SXXEYY",
+        label="Season/Episode (SxxEyy)",
+        group="Episode",
+        description="Combined season and episode code.",
+        sample="S02E05",
+    ),
+    # Status
+    TokenSpec(
+        name="Status",
+        label="Status",
+        group="Status",
+        description=(
+            "Inside bracket templates: the short label Placeholdarr shows for that item in brackets "
+            "(same wording as in Plex for bracket-style lines)."
+        ),
+        sample="REQUEST",
+    ),
+    TokenSpec(
+        name="Bracket",
+        label="Bracket",
+        group="Status",
+        description="The full bracketed status text Placeholdarr would otherwise project (uses bracket templates).",
+        sample="[REQUEST]",
+    ),
+    # Calendar
+    TokenSpec(
+        name="DaysUntil",
+        label="Days Until",
+        group="Calendar",
+        description="Number of days until the upcoming release or air date.",
+        sample="5",
+    ),
+    TokenSpec(
+        name="ReleaseLabel",
+        label="Release Label",
+        group="Calendar",
+        description=(
+            "Resolves to the configured movie release type label: Theatrical, Digital, or Physical. "
+            "When no release type is configured it resolves to 'Coming Soon' to keep the message readable."
+        ),
+        sample="Theatrical",
+    ),
+    TokenSpec(
+        name="ReleaseDate",
+        label="Release Date",
+        group="Calendar",
+        description="Release or air date in YYYY-MM-DD form.",
+        sample="2026-12-25",
+    ),
+    # Queue
+    TokenSpec(
+        name="Progress",
+        label="Progress %",
+        group="Queue",
+        description="Whole-number download progress percentage, 0-100.",
+        sample="42",
+    ),
+    # Import grace
+    TokenSpec(
+        name="MinutesRemaining",
+        label="Minutes Remaining",
+        group="Import Grace",
+        description="Minutes remaining in the import-grace countdown (5, 4, 3, 2, or 1).",
+        sample="3",
+    ),
+)
+
+
+_TOKEN_BY_NAME: dict[str, TokenSpec] = {t.name: t for t in _TOKEN_SPECS}
+
+
+def get_token_specs() -> tuple[TokenSpec, ...]:
+    """Return all known token specs (read-only tuple)."""
+    return _TOKEN_SPECS
+
+
+def get_token_spec(name: str) -> TokenSpec | None:
+    return _TOKEN_BY_NAME.get(str(name or "").strip())
+
+
+# ----- Message keys ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MessageKey:
+    """One customizable message string.
+
+    Settings → Status Messages only exposes rows where ``settings_ui`` is True.
+    Hidden rows still resolve through the engine so legacy overrides keep working
+    (read-compat) until the user saves a new value through the new UI.
+    """
+
+    key: str
+    label: str
+    default: str
+    group: str  # Top-level UI group
+    subgroup: str | None  # Optional sub-group (e.g. Movie / TV inside Calendar)
+    tooltip: str
+    allowed_tokens: tuple[str, ...]
+    sample_context: dict[str, Any] = field(default_factory=dict)
+    # Internal-only defaults used when the engine needs an alternate phrasing.
+    # The user only edits ``default`` from the UI.
+    alt_defaults: dict[str, str] = field(default_factory=dict)
+    # If False, hidden from Settings → Status Messages (internal / plumbing keys).
+    settings_ui: bool = True
+
+
+# Token bundles reused across keys.
+_MEDIA_TOKENS = (
+    "Sep",
+    "Title",
+    "Year",
+    "ReleaseYear",
+    "Genres",
+    "Certification",
+    "Studio",
+    "Runtime",
+    "RuntimeMinutes",
+    "Hours",
+    "Minutes",
+)
+_EPISODE_TOKENS = (
+    "SeriesTitle",
+    "SeasonNumber",
+    "EpisodeNumber",
+    "EpisodeTitle",
+    "SXXEYY",
+)
+
+
+def _bracket_tokens() -> tuple[str, ...]:
+    return ("Sep", "Status", "Runtime", "Hours", "Minutes")
+
+
+def _request_line_tokens() -> tuple[str, ...]:
+    """Tokens allowed inside the customizable Request line template (line.request).
+
+    Excludes ``Status``/``Bracket`` because the Request line itself IS the bracket inner;
+    those nested tokens would create a confusing recursive context.
+    """
+    return (
+        "Sep",
+        "Runtime",
+        "RuntimeMinutes",
+        "Hours",
+        "Minutes",
+        "Title",
+        "Year",
+        "ReleaseYear",
+        "Genres",
+        "Certification",
+        "Studio",
+    )
+
+
+# Must match ``DisplayStatus`` in ``services/source_of_truth/status_intent.py`` (order + values).
+_DISPLAY_STATUS_ENUM_VALUES: tuple[str, ...] = (
+    "REQUEST",
+    "COMING_SOON",
+    "COMING_SOON_30",
+    "COMING_SOON_14",
+    "COMING_SOON_7",
+    "COMING_SOON_1",
+    "COMING_SOON_TODAY",
+    "SEARCHING",
+    "DOWNLOADING",
+    "IMPORT_IN_PROGRESS",
+    "NOT_FOUND",
+    "AVAILABLE",
+    "CLEANUP",
+    "DELETED",
+    "ARCHIVED",
+)
+
+
+# Tooltips: these strings are the *visible* word inside [ … ] for each internal stage (DisplayStatus).
+# Users edit wording here; bracket *shape* (e.g. runtime + separator) is under Bracket & Duration.
+_STATUS_LABEL_TOOLTIPS: dict[str, str] = {
+    "REQUEST": (
+        "Word inside [ … ] for the REQUEST stage. With runtime, combine with “Bracket format (with runtime)” "
+        "— e.g. default templates give [1h 5m · REQUEST]. Change only the word here unless you also edit bracket shape."
+    ),
+    "SEARCHING": "Word inside [ … ] when the item is searching and no queue line replaces the bracket.",
+    "DOWNLOADING": "Word inside [ … ] when downloading without a detailed queue progress line.",
+    "IMPORT_IN_PROGRESS": "Word inside [ … ] when import is in progress and no finer queue import line is shown.",
+    "NOT_FOUND": "Word inside [ … ] when no qualifying release was found.",
+    "AVAILABLE": "Word inside [ … ] when the file exists (rarely projected).",
+    "DELETED": "Word inside [ … ] briefly after removal from ARR.",
+    "ARCHIVED": "Reserved stage — rarely emitted; wording if it ever appears in brackets.",
+    "CLEANUP": "Reserved stage — rarely emitted; wording if it ever appears in brackets.",
+}
+
+
+# Plex/NFO usually show calendar countdown lines for these stages — not the raw COMING_SOON_* bracket word.
+# Hide those rows from Settings so users only edit templates that actually drive on-screen copy.
+_STAGES_WITHOUT_PLEX_BRACKET_WORD_SETTINGS: frozenset[str] = frozenset(
+    {
+        "COMING_SOON",
+        "COMING_SOON_30",
+        "COMING_SOON_14",
+        "COMING_SOON_7",
+        "COMING_SOON_1",
+        "COMING_SOON_TODAY",
+        "ARCHIVED",
+        "CLEANUP",
+    }
+)
+
+
+def _settings_ui_for_status_label(enum_value: str) -> bool:
+    return enum_value not in _STAGES_WITHOUT_PLEX_BRACKET_WORD_SETTINGS
+
+
+def _status_label_ui_name(enum_value: str) -> str:
+    special = {
+        "REQUEST": "Request label",
+        "SEARCHING": "Searching label",
+        "DOWNLOADING": "Downloading label",
+        "IMPORT_IN_PROGRESS": "Import in progress label",
+        "NOT_FOUND": "Not found label",
+        "AVAILABLE": "Available label",
+        "DELETED": "Deleted label",
+        "ARCHIVED": "Archived label",
+        "CLEANUP": "Cleanup label",
+        "COMING_SOON": "Coming soon label",
+        "COMING_SOON_30": "Coming soon (30+ days) label",
+        "COMING_SOON_14": "Coming soon (14–29 days) label",
+        "COMING_SOON_7": "Coming soon (7–13 days) label",
+        "COMING_SOON_1": "Coming soon (1–6 days) label",
+        "COMING_SOON_TODAY": "Release day label",
+        "RETRYING": "Retrying label",
+    }
+    return special.get(enum_value, f"{enum_value.replace('_', ' ').title()} label")
+
+
+def _iter_status_label_keys() -> tuple[MessageKey, ...]:
+    """Per-stage word fallbacks used by the engine when ``{Status}`` is rendered
+    inside a legacy bracket template. Hidden from Settings UI in the situation-first
+    model — users edit the visible Plex line directly via ``line.request`` and the
+    queue/calendar/import-grace situation rows.
+    """
+    rows: list[MessageKey] = []
+    for ev in _DISPLAY_STATUS_ENUM_VALUES:
+        rows.append(
+            MessageKey(
+                key=f"status.label.{ev}",
+                label=_status_label_ui_name(ev),
+                default=ev,
+                group="Internal: Stage labels",
+                subgroup=None,
+                tooltip=_STATUS_LABEL_TOOLTIPS.get(
+                    ev,
+                    f"Internal fallback word for stage {ev} (used by legacy bracket templates).",
+                ),
+                allowed_tokens=("Sep",),
+                sample_context={},
+                settings_ui=False,
+            )
+        )
+    rows.append(
+        MessageKey(
+            key="status.label.RETRYING",
+            label=_status_label_ui_name("RETRYING"),
+            default="RETRYING",
+            group="Internal: Stage labels",
+            subgroup=None,
+            tooltip=(
+                "Internal fallback word while the queue monitor is retrying after a transient queue failure "
+                "or after an item left the queue during the retry grace window."
+            ),
+            allowed_tokens=("Sep",),
+            sample_context={},
+            settings_ui=False,
+        )
+    )
+    return tuple(rows)
+
+
+def _build_registry() -> tuple[MessageKey, ...]:
+    keys: list[MessageKey] = []
+
+    # --- Bracket labels (word inside [ … ] per internal stage) ---
+    keys.extend(_iter_status_label_keys())
+
+    # --- Request line (situation-first; the inner text wrapped by the global preset) ---
+    keys.append(
+        MessageKey(
+            key="line.request",
+            label="Request line",
+            default="{Runtime} {Sep} REQUEST",
+            group="Request",
+            subgroup=None,
+            tooltip=(
+                "The bracketed line shown in Plex/NFO for newly requested items. The global "
+                "wrapper preset sandwiches it (e.g. [ ]). Empty tokens auto-collapse, so "
+                "without a runtime this renders as just \u201cREQUEST\u201d."
+            ),
+            allowed_tokens=_request_line_tokens(),
+            sample_context={"Runtime": "1h 5m"},
+        )
+    )
+
+    # --- Title suffix (kept; user-facing for title/both projection mode) ---
+    keys.append(
+        MessageKey(
+            key="title.suffix.format",
+            label="Title suffix format",
+            default="{Title} - {Bracket}",
+            group="Title Suffix",
+            subgroup=None,
+            tooltip=(
+                "How the projected status is appended to the player title when projection mode is set to "
+                "Title or Both. Use {Title} for the cleaned title and {Bracket} for the rendered bracket."
+            ),
+            allowed_tokens=("Title", "Bracket", "Sep"),
+            sample_context={"Title": "Inception", "Bracket": "[REQUEST]"},
+        )
+    )
+
+    # --- Internal: legacy bracket / runtime templates kept for read-compat fallback ---
+    # These are hidden from Settings UI. Users who customized them on a previous
+    # version keep their behavior until they save in the new UI; new users only see
+    # ``line.request`` + the global wrapper preset.
+    keys.append(
+        MessageKey(
+            key="bracket.format",
+            label="Bracket format",
+            default="[{Status}]",
+            group="Internal: Legacy bracket",
+            subgroup=None,
+            tooltip=(
+                "Legacy bracket shape used as a fallback when projecting non-REQUEST stages "
+                "without a situation-specific row. Hidden in the new UI."
+            ),
+            allowed_tokens=_bracket_tokens(),
+            sample_context={"Status": "REQUEST"},
+            settings_ui=False,
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="bracket.with_runtime",
+            label="Bracket format (with runtime)",
+            default="[{Runtime} {Sep} {Status}]",
+            group="Internal: Legacy bracket",
+            subgroup=None,
+            tooltip=(
+                "Legacy bracket-with-runtime template used during read-compat for users who "
+                "customized it before the situation-first redesign."
+            ),
+            allowed_tokens=_bracket_tokens(),
+            sample_context={"Status": "REQUEST", "Runtime": "1h 5m"},
+            settings_ui=False,
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="runtime.format.hm",
+            label="Runtime format (hours and minutes)",
+            default="{Hours}h {Minutes}m",
+            group="Internal: Runtime",
+            subgroup=None,
+            tooltip="Internal: how {Runtime} renders when both hours and minutes are non-zero.",
+            allowed_tokens=("Hours", "Minutes"),
+            sample_context={"Hours": "1", "Minutes": "5"},
+            settings_ui=False,
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="runtime.format.h",
+            label="Runtime format (hours only)",
+            default="{Hours}h",
+            group="Internal: Runtime",
+            subgroup=None,
+            tooltip="Internal: how {Runtime} renders when minutes are zero.",
+            allowed_tokens=("Hours",),
+            sample_context={"Hours": "2"},
+            settings_ui=False,
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="runtime.format.m",
+            label="Runtime format (minutes only)",
+            default="{Minutes}m",
+            group="Internal: Runtime",
+            subgroup=None,
+            tooltip="Internal: how {Runtime} renders when the runtime is under one hour.",
+            allowed_tokens=("Minutes",),
+            sample_context={"Minutes": "45"},
+            settings_ui=False,
+        )
+    )
+
+    # --- Calendar ---
+    cal_movie_tokens = ("Sep", "DaysUntil", "ReleaseLabel", "ReleaseDate") + _MEDIA_TOKENS
+    cal_tv_tokens = ("Sep", "DaysUntil", "ReleaseDate") + _MEDIA_TOKENS + _EPISODE_TOKENS
+
+    keys.append(
+        MessageKey(
+            key="calendar.movie.countdown.singular",
+            label="Movie countdown (1 day)",
+            default="{ReleaseLabel} release in 1 day",
+            group="Calendar Coming Soon",
+            subgroup="Movie",
+            tooltip=(
+                "Shown for movies the day before release. {ReleaseLabel} resolves to Theatrical / Digital / Physical "
+                "based on your preferred movie date type, or 'Coming Soon' when no release type is configured."
+            ),
+            allowed_tokens=cal_movie_tokens,
+            sample_context={"ReleaseLabel": "Theatrical", "DaysUntil": "1"},
+            alt_defaults={"no_release_type": "Coming Soon (1 day)"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.movie.countdown.plural",
+            label="Movie countdown (multiple days)",
+            default="{ReleaseLabel} release in {DaysUntil} days",
+            group="Calendar Coming Soon",
+            subgroup="Movie",
+            tooltip=(
+                "Shown for upcoming movies when more than one day remains. Use {DaysUntil} for the day count. "
+                "When no release type is configured Placeholdarr falls back to a parenthetical phrasing."
+            ),
+            allowed_tokens=cal_movie_tokens,
+            sample_context={"ReleaseLabel": "Theatrical", "DaysUntil": "5"},
+            alt_defaults={"no_release_type": "Coming Soon ({DaysUntil} days)"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.movie.today",
+            label="Movie release today",
+            default="{ReleaseLabel} release today",
+            group="Calendar Coming Soon",
+            subgroup="Movie",
+            tooltip=(
+                "Shown for movies on their release day. {ReleaseLabel} resolves to Theatrical / Digital / Physical "
+                "or 'Coming Soon' when no release type is configured."
+            ),
+            allowed_tokens=cal_movie_tokens,
+            sample_context={"ReleaseLabel": "Theatrical", "DaysUntil": "0"},
+            alt_defaults={"no_release_type": "Coming Soon (Today)"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.movie.generic",
+            label="Movie coming soon (countdown disabled)",
+            default="{ReleaseLabel} release coming soon",
+            group="Calendar Coming Soon",
+            subgroup="Movie",
+            tooltip=(
+                "Shown for upcoming movies when 'Enable Coming Soon countdown text' is off. "
+                "Falls back to 'Coming Soon' when no release type is configured."
+            ),
+            allowed_tokens=cal_movie_tokens,
+            sample_context={"ReleaseLabel": "Theatrical"},
+            alt_defaults={"no_release_type": "Coming Soon"},
+        )
+    )
+
+    keys.append(
+        MessageKey(
+            key="calendar.tv.countdown.singular",
+            label="TV countdown (1 day)",
+            default="Airing in 1 day",
+            group="Calendar Coming Soon",
+            subgroup="TV",
+            tooltip="Shown for TV episodes airing the next day.",
+            allowed_tokens=cal_tv_tokens,
+            sample_context={"DaysUntil": "1"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.tv.countdown.plural",
+            label="TV countdown (multiple days)",
+            default="Airing in {DaysUntil} days",
+            group="Calendar Coming Soon",
+            subgroup="TV",
+            tooltip="Shown for upcoming TV episodes when more than one day remains. Use {DaysUntil} for the day count.",
+            allowed_tokens=cal_tv_tokens,
+            sample_context={"DaysUntil": "5"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.tv.today",
+            label="TV airing today",
+            default="Airing today",
+            group="Calendar Coming Soon",
+            subgroup="TV",
+            tooltip="Shown for TV episodes airing today.",
+            allowed_tokens=cal_tv_tokens,
+            sample_context={"DaysUntil": "0"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.tv.generic",
+            label="TV coming soon (countdown disabled)",
+            default="Airing soon",
+            group="Calendar Coming Soon",
+            subgroup="TV",
+            tooltip="Shown for upcoming TV episodes when 'Enable Coming Soon countdown text' is off.",
+            allowed_tokens=cal_tv_tokens,
+            sample_context={},
+        )
+    )
+
+    # --- Queue monitor ---
+    queue_tokens = ("Sep", "Progress") + _MEDIA_TOKENS + _EPISODE_TOKENS
+
+    keys.append(
+        MessageKey(
+            key="queue.searching",
+            label="Searching for release",
+            default="Searching for release",
+            group="Queue Monitor",
+            subgroup=None,
+            tooltip=(
+                "Shown when the queue monitor is waiting for a download to enter the ARR queue. "
+                "If the search timeout elapses with nothing found, 'No qualifying release found' takes over."
+            ),
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.queued",
+            label="Queued",
+            default="Queued",
+            group="Queue Monitor",
+            subgroup=None,
+            tooltip="Shown when the ARR has queued the download but progress has not started yet.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.downloading",
+            label="Downloading (with progress)",
+            default="Downloading {Progress}%",
+            group="Queue Monitor",
+            subgroup=None,
+            tooltip="Shown while a download is in progress. Use {Progress} for the percent complete.",
+            allowed_tokens=queue_tokens,
+            sample_context={"Progress": "42"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.import.pending",
+            label="Import: waiting to import",
+            default="Waiting to import",
+            group="Queue Monitor",
+            subgroup="Import",
+            tooltip="Shown after a download completes while the ARR is preparing to import it.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.import.importing",
+            label="Import: importing",
+            default="Importing",
+            group="Queue Monitor",
+            subgroup="Import",
+            tooltip="Shown while the ARR is actively importing the completed download into your library.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.import.blocked",
+            label="Import: blocked",
+            default="Import blocked",
+            group="Queue Monitor",
+            subgroup="Import",
+            tooltip="Shown when the ARR has blocked the import (e.g. permissions, missing files, mismatched media).",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.import.failed_pending",
+            label="Import: waiting for retry",
+            default="Waiting for import retry",
+            group="Queue Monitor",
+            subgroup="Import",
+            tooltip="Shown when the ARR's import attempt failed and another retry is pending.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.import.processing",
+            label="Import: processing",
+            default="Processing import",
+            group="Queue Monitor",
+            subgroup="Import",
+            tooltip="Generic fallback shown for the 'completed' queue state when no specific tracked state applies.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.retry.queue_failure",
+            label="Retry after queue failure",
+            default="Retrying after queue failure",
+            group="Queue Monitor",
+            subgroup="Retry",
+            tooltip="Shown when the ARR queue reports the download as warning/error/failed and Placeholdarr is waiting for the next attempt.",
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.retry.left_queue",
+            label="Retry after queue exit",
+            default="Retrying; waiting for another qualifying release",
+            group="Queue Monitor",
+            subgroup="Retry",
+            tooltip=(
+                "Shown when a download exited the ARR queue (canceled, removed, or failed) and Placeholdarr "
+                "is waiting for another release. After the retry grace period ends, 'No qualifying release found' takes over."
+            ),
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="queue.not_found",
+            label="No qualifying release found",
+            default="NO QUALIFYING RELEASE FOUND",
+            group="Queue Monitor",
+            subgroup=None,
+            tooltip=(
+                "Shown when the search timeout or retry grace expires and no qualifying release was found. "
+                "This is the terminal state for queue monitoring."
+            ),
+            allowed_tokens=queue_tokens,
+            sample_context={},
+        )
+    )
+
+    # --- Import grace ---
+    keys.append(
+        MessageKey(
+            key="import_grace.countdown",
+            label="Import grace countdown",
+            default="NOW IN LIBRARY - RETIRING PLACEHOLDER IN {MinutesRemaining} MIN",
+            group="Import Grace",
+            subgroup=None,
+            tooltip=(
+                "Shown each minute during the import-grace countdown after the file is imported into your "
+                "library. {MinutesRemaining} resolves to 5, 4, 3, 2, or 1."
+            ),
+            allowed_tokens=("Sep", "MinutesRemaining"),
+            sample_context={"MinutesRemaining": "3"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="import_grace.countdown_lt_1_min",
+            label="Import grace final tick",
+            default="NOW IN LIBRARY - RETIRING PLACEHOLDER IN LESS THAN A MINUTE",
+            group="Import Grace",
+            subgroup=None,
+            tooltip="Final import-grace tick shown just before the placeholder is retired.",
+            allowed_tokens=("Sep",),
+            sample_context={},
+        )
+    )
+
+    return tuple(keys)
+
+
+_REGISTRY: tuple[MessageKey, ...] = _build_registry()
+_REGISTRY_BY_KEY: dict[str, MessageKey] = {k.key: k for k in _REGISTRY}
+
+
+def get_registry() -> tuple[MessageKey, ...]:
+    return _REGISTRY
+
+
+def get_registry_for_settings_ui() -> tuple[MessageKey, ...]:
+    """Templates exposed under Settings → Status Messages (user-facing copy only)."""
+    return tuple(m for m in _REGISTRY if m.settings_ui)
+
+
+def get_message_key(key: str) -> MessageKey | None:
+    return _REGISTRY_BY_KEY.get(str(key or "").strip())
+
+
+# ----- Separator / case presets --------------------------------------------
+
+
+DEFAULT_SEPARATOR = "·"
+
+SEPARATOR_PRESETS: tuple[dict[str, str], ...] = (
+    {"value": "·", "label": "Middle dot (·)"},
+    {"value": "•", "label": "Bullet (•)"},
+    {"value": "-", "label": "Dash (-)"},
+    {"value": "–", "label": "En dash (–)"},
+    {"value": "—", "label": "Em dash (—)"},
+    {"value": "_", "label": "Underscore (_)"},
+    {"value": " ", "label": "Space"},
+    {"value": "/", "label": "Slash (/)"},
+    {"value": "|", "label": "Pipe (|)"},
+    {"value": ":", "label": "Colon (:)"},
+)
+
+CASE_OPTIONS: tuple[dict[str, str], ...] = (
+    {"value": "default", "label": "Default Case"},
+    {"value": "upper", "label": "UPPERCASE"},
+    {"value": "lower", "label": "lowercase"},
+    {"value": "title", "label": "Title Case"},
+)
+
+
+# ----- Wrapper presets (global presentation chrome around inner lines) -----
+
+DEFAULT_WRAPPER_PRESET = "brackets"
+
+WRAPPER_PRESETS: tuple[dict[str, str], ...] = (
+    {"value": "brackets", "label": "Brackets [ ]", "open": "[", "close": "]"},
+    {"value": "parens", "label": "Parentheses ( )", "open": "(", "close": ")"},
+    {"value": "curly", "label": "Curly braces { }", "open": "{", "close": "}"},
+    {"value": "angle", "label": "Angle brackets < >", "open": "<", "close": ">"},
+    {"value": "none", "label": "No wrapper", "open": "", "close": ""},
+    {"value": "custom", "label": "Custom\u2026", "open": "", "close": ""},
+)
+
+
+def get_wrapper_presets() -> tuple[dict[str, str], ...]:
+    return WRAPPER_PRESETS
+
+
+def get_wrapper_preset_pair(preset: str | None) -> tuple[str, str] | None:
+    """Return the ``(open, close)`` pair for a non-custom preset, or ``None`` if unknown / custom."""
+    name = str(preset or "").strip().lower()
+    if not name or name == "custom":
+        return None
+    for entry in WRAPPER_PRESETS:
+        if entry["value"] == name:
+            return (entry["open"], entry["close"])
+    return None

--- a/services/messages/registry.py
+++ b/services/messages/registry.py
@@ -43,7 +43,10 @@ _TOKEN_SPECS: tuple[TokenSpec, ...] = (
         name="Title",
         label="Title",
         group="Media",
-        description="Movie or series title.",
+        description=(
+            "Movies: the film title. TV: series title when known, otherwise the episode title. "
+            "Use {SeriesTitle} and {EpisodeTitle} when you want explicit control on TV."
+        ),
         sample="Inception",
     ),
     TokenSpec(
@@ -144,24 +147,6 @@ _TOKEN_SPECS: tuple[TokenSpec, ...] = (
         group="Episode",
         description="Combined season and episode code.",
         sample="S02E05",
-    ),
-    # Status
-    TokenSpec(
-        name="Status",
-        label="Status",
-        group="Status",
-        description=(
-            "Inside bracket templates: the short label Placeholdarr shows for that item in brackets "
-            "(same wording as in Plex for bracket-style lines)."
-        ),
-        sample="REQUEST",
-    ),
-    TokenSpec(
-        name="Bracket",
-        label="Bracket",
-        group="Status",
-        description="The full bracketed status text Placeholdarr would otherwise project (uses bracket templates).",
-        sample="[REQUEST]",
     ),
     # Calendar
     TokenSpec(
@@ -269,15 +254,10 @@ _EPISODE_TOKENS = (
 )
 
 
-def _bracket_tokens() -> tuple[str, ...]:
-    return ("Sep", "Status", "Runtime", "Hours", "Minutes")
-
-
 def _request_line_tokens() -> tuple[str, ...]:
     """Tokens allowed inside the customizable Request line template (line.request).
 
-    Excludes ``Status``/``Bracket`` because the Request line itself IS the bracket inner;
-    those nested tokens would create a confusing recursive context.
+    Episode-only tokens resolve empty for movies; single-template UX with dual previews.
     """
     return (
         "Sep",
@@ -291,209 +271,92 @@ def _request_line_tokens() -> tuple[str, ...]:
         "Genres",
         "Certification",
         "Studio",
+        "SeriesTitle",
+        "SeasonNumber",
+        "EpisodeNumber",
+        "EpisodeTitle",
+        "SXXEYY",
     )
-
-
-# Must match ``DisplayStatus`` in ``services/source_of_truth/status_intent.py`` (order + values).
-_DISPLAY_STATUS_ENUM_VALUES: tuple[str, ...] = (
-    "REQUEST",
-    "COMING_SOON",
-    "COMING_SOON_30",
-    "COMING_SOON_14",
-    "COMING_SOON_7",
-    "COMING_SOON_1",
-    "COMING_SOON_TODAY",
-    "SEARCHING",
-    "DOWNLOADING",
-    "IMPORT_IN_PROGRESS",
-    "NOT_FOUND",
-    "AVAILABLE",
-    "CLEANUP",
-    "DELETED",
-    "ARCHIVED",
-)
-
-
-# Tooltips: these strings are the *visible* word inside [ … ] for each internal stage (DisplayStatus).
-# Users edit wording here; bracket *shape* (e.g. runtime + separator) is under Bracket & Duration.
-_STATUS_LABEL_TOOLTIPS: dict[str, str] = {
-    "REQUEST": (
-        "Word inside [ … ] for the REQUEST stage. With runtime, combine with “Bracket format (with runtime)” "
-        "— e.g. default templates give [1h 5m · REQUEST]. Change only the word here unless you also edit bracket shape."
-    ),
-    "SEARCHING": "Word inside [ … ] when the item is searching and no queue line replaces the bracket.",
-    "DOWNLOADING": "Word inside [ … ] when downloading without a detailed queue progress line.",
-    "IMPORT_IN_PROGRESS": "Word inside [ … ] when import is in progress and no finer queue import line is shown.",
-    "NOT_FOUND": "Word inside [ … ] when no qualifying release was found.",
-    "AVAILABLE": "Word inside [ … ] when the file exists (rarely projected).",
-    "DELETED": "Word inside [ … ] briefly after removal from ARR.",
-    "ARCHIVED": "Reserved stage — rarely emitted; wording if it ever appears in brackets.",
-    "CLEANUP": "Reserved stage — rarely emitted; wording if it ever appears in brackets.",
-}
-
-
-# Plex/NFO usually show calendar countdown lines for these stages — not the raw COMING_SOON_* bracket word.
-# Hide those rows from Settings so users only edit templates that actually drive on-screen copy.
-_STAGES_WITHOUT_PLEX_BRACKET_WORD_SETTINGS: frozenset[str] = frozenset(
-    {
-        "COMING_SOON",
-        "COMING_SOON_30",
-        "COMING_SOON_14",
-        "COMING_SOON_7",
-        "COMING_SOON_1",
-        "COMING_SOON_TODAY",
-        "ARCHIVED",
-        "CLEANUP",
-    }
-)
-
-
-def _settings_ui_for_status_label(enum_value: str) -> bool:
-    return enum_value not in _STAGES_WITHOUT_PLEX_BRACKET_WORD_SETTINGS
-
-
-def _status_label_ui_name(enum_value: str) -> str:
-    special = {
-        "REQUEST": "Request label",
-        "SEARCHING": "Searching label",
-        "DOWNLOADING": "Downloading label",
-        "IMPORT_IN_PROGRESS": "Import in progress label",
-        "NOT_FOUND": "Not found label",
-        "AVAILABLE": "Available label",
-        "DELETED": "Deleted label",
-        "ARCHIVED": "Archived label",
-        "CLEANUP": "Cleanup label",
-        "COMING_SOON": "Coming soon label",
-        "COMING_SOON_30": "Coming soon (30+ days) label",
-        "COMING_SOON_14": "Coming soon (14–29 days) label",
-        "COMING_SOON_7": "Coming soon (7–13 days) label",
-        "COMING_SOON_1": "Coming soon (1–6 days) label",
-        "COMING_SOON_TODAY": "Release day label",
-        "RETRYING": "Retrying label",
-    }
-    return special.get(enum_value, f"{enum_value.replace('_', ' ').title()} label")
-
-
-def _iter_status_label_keys() -> tuple[MessageKey, ...]:
-    """Per-stage word fallbacks used by the engine when ``{Status}`` is rendered
-    inside a legacy bracket template. Hidden from Settings UI in the situation-first
-    model — users edit the visible Plex line directly via ``line.request`` and the
-    queue/calendar/import-grace situation rows.
-    """
-    rows: list[MessageKey] = []
-    for ev in _DISPLAY_STATUS_ENUM_VALUES:
-        rows.append(
-            MessageKey(
-                key=f"status.label.{ev}",
-                label=_status_label_ui_name(ev),
-                default=ev,
-                group="Internal: Stage labels",
-                subgroup=None,
-                tooltip=_STATUS_LABEL_TOOLTIPS.get(
-                    ev,
-                    f"Internal fallback word for stage {ev} (used by legacy bracket templates).",
-                ),
-                allowed_tokens=("Sep",),
-                sample_context={},
-                settings_ui=False,
-            )
-        )
-    rows.append(
-        MessageKey(
-            key="status.label.RETRYING",
-            label=_status_label_ui_name("RETRYING"),
-            default="RETRYING",
-            group="Internal: Stage labels",
-            subgroup=None,
-            tooltip=(
-                "Internal fallback word while the queue monitor is retrying after a transient queue failure "
-                "or after an item left the queue during the retry grace window."
-            ),
-            allowed_tokens=("Sep",),
-            sample_context={},
-            settings_ui=False,
-        )
-    )
-    return tuple(rows)
 
 
 def _build_registry() -> tuple[MessageKey, ...]:
     keys: list[MessageKey] = []
 
-    # --- Bracket labels (word inside [ … ] per internal stage) ---
-    keys.extend(_iter_status_label_keys())
-
     # --- Request line (situation-first; the inner text wrapped by the global preset) ---
     keys.append(
         MessageKey(
             key="line.request",
-            label="Request line",
+            label="Request line (synopsis)",
             default="{Runtime} {Sep} REQUEST",
             group="Request",
             subgroup=None,
             tooltip=(
-                "The bracketed line shown in Plex/NFO for newly requested items. The global "
-                "wrapper preset sandwiches it (e.g. [ ]). Empty tokens auto-collapse, so "
-                "without a runtime this renders as just \u201cREQUEST\u201d."
+                "Inner text placed inside the global wrapper when showing REQUEST status at the "
+                "start of the synopsis/overview field (rich line: runtime + metadata tokens). Empty tokens collapse."
             ),
             allowed_tokens=_request_line_tokens(),
             sample_context={"Runtime": "1h 5m"},
         )
     )
 
-    # --- Title suffix (kept; user-facing for title/both projection mode) ---
+    # --- Title suffix (fixed base title + customizable suffix per library kind) ---
+    _suffix_tooltip = (
+        "Suffix appended when status projection targets the title field. "
+        "The base title shown in the UI is fixed and is not part of this template."
+    )
     keys.append(
         MessageKey(
-            key="title.suffix.format",
-            label="Title suffix format",
-            default="{Title} - {Bracket}",
+            key="title.suffix.movie",
+            label="Movie title suffix",
+            default=" (Placeholder)",
             group="Title Suffix",
             subgroup=None,
-            tooltip=(
-                "How the projected status is appended to the player title when projection mode is set to "
-                "Title or Both. Use {Title} for the cleaned title and {Bracket} for the rendered bracket."
-            ),
-            allowed_tokens=("Title", "Bracket", "Sep"),
-            sample_context={"Title": "Inception", "Bracket": "[REQUEST]"},
+            tooltip=_suffix_tooltip + " Uses the movie title as the hard prefix.",
+            allowed_tokens=(),
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="title.suffix.series",
+            label="Series title suffix",
+            default=" (Placeholder)",
+            group="Title Suffix",
+            subgroup=None,
+            tooltip=_suffix_tooltip
+            + " Uses the series (show) title as the hard prefix (tvshow.nfo and episode showtitle).",
+            allowed_tokens=(),
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="title.suffix.season",
+            label="Season title suffix",
+            default=" (Placeholder)",
+            group="Title Suffix",
+            subgroup=None,
+            tooltip=_suffix_tooltip
+            + " Uses the season display name as the hard prefix (e.g. “Show S01”). "
+            "Reserved for season-level surfaces; preview uses sample data.",
+            allowed_tokens=(),
+            sample_context={},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="title.suffix.episode",
+            label="Episode title suffix",
+            default=" (Placeholder)",
+            group="Title Suffix",
+            subgroup=None,
+            tooltip=_suffix_tooltip + " Uses the episode title as the hard prefix.",
+            allowed_tokens=(),
+            sample_context={},
         )
     )
 
-    # --- Internal: legacy bracket / runtime templates kept for read-compat fallback ---
-    # These are hidden from Settings UI. Users who customized them on a previous
-    # version keep their behavior until they save in the new UI; new users only see
-    # ``line.request`` + the global wrapper preset.
-    keys.append(
-        MessageKey(
-            key="bracket.format",
-            label="Bracket format",
-            default="[{Status}]",
-            group="Internal: Legacy bracket",
-            subgroup=None,
-            tooltip=(
-                "Legacy bracket shape used as a fallback when projecting non-REQUEST stages "
-                "without a situation-specific row. Hidden in the new UI."
-            ),
-            allowed_tokens=_bracket_tokens(),
-            sample_context={"Status": "REQUEST"},
-            settings_ui=False,
-        )
-    )
-    keys.append(
-        MessageKey(
-            key="bracket.with_runtime",
-            label="Bracket format (with runtime)",
-            default="[{Runtime} {Sep} {Status}]",
-            group="Internal: Legacy bracket",
-            subgroup=None,
-            tooltip=(
-                "Legacy bracket-with-runtime template used during read-compat for users who "
-                "customized it before the situation-first redesign."
-            ),
-            allowed_tokens=_bracket_tokens(),
-            sample_context={"Status": "REQUEST", "Runtime": "1h 5m"},
-            settings_ui=False,
-        )
-    )
+    # --- Internal runtime formatting helpers (no status/bracket semantics) ---
     keys.append(
         MessageKey(
             key="runtime.format.hm",
@@ -501,7 +364,7 @@ def _build_registry() -> tuple[MessageKey, ...]:
             default="{Hours}h {Minutes}m",
             group="Internal: Runtime",
             subgroup=None,
-            tooltip="Internal: how {Runtime} renders when both hours and minutes are non-zero.",
+            tooltip="Internal runtime formatting helper.",
             allowed_tokens=("Hours", "Minutes"),
             sample_context={"Hours": "1", "Minutes": "5"},
             settings_ui=False,
@@ -514,7 +377,7 @@ def _build_registry() -> tuple[MessageKey, ...]:
             default="{Hours}h",
             group="Internal: Runtime",
             subgroup=None,
-            tooltip="Internal: how {Runtime} renders when minutes are zero.",
+            tooltip="Internal runtime formatting helper.",
             allowed_tokens=("Hours",),
             sample_context={"Hours": "2"},
             settings_ui=False,
@@ -527,12 +390,13 @@ def _build_registry() -> tuple[MessageKey, ...]:
             default="{Minutes}m",
             group="Internal: Runtime",
             subgroup=None,
-            tooltip="Internal: how {Runtime} renders when the runtime is under one hour.",
+            tooltip="Internal runtime formatting helper.",
             allowed_tokens=("Minutes",),
             sample_context={"Minutes": "45"},
             settings_ui=False,
         )
     )
+
 
     # --- Calendar ---
     cal_movie_tokens = ("Sep", "DaysUntil", "ReleaseLabel", "ReleaseDate") + _MEDIA_TOKENS

--- a/services/messages/request_line_render.py
+++ b/services/messages/request_line_render.py
@@ -1,0 +1,16 @@
+"""REQUEST ``line.request`` rendering helpers (kept out of status_projection to avoid import cycles)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from services.messages import render
+from services.messages.context import augment_context_with_runtime
+
+
+def request_inner_line_synopsis(
+    runtime_minutes: int | None,
+    media_context: dict[str, Any] | None = None,
+) -> str:
+    ctx = augment_context_with_runtime(dict(media_context or {}), runtime_minutes)
+    return render("line.request", ctx)

--- a/services/messages/store.py
+++ b/services/messages/store.py
@@ -57,6 +57,35 @@ def _empty_config() -> dict[str, Any]:
 
 _WRAPPER_PRESET_VALUES = {entry["value"] for entry in WRAPPER_PRESETS}
 
+_TITLE_SUFFIX_KEYS = frozenset(
+    {
+        "title.suffix.movie",
+        "title.suffix.series",
+        "title.suffix.season",
+        "title.suffix.episode",
+    }
+)
+
+
+def _coerce_title_suffix_value(key: str, raw: str) -> str:
+    """Title suffix templates are literal-only (no {Tokens}). Invalid stored values fall back to default."""
+    spec = get_message_key(key)
+    if spec is None:
+        return raw
+    text = str(raw) if raw is not None else ""
+    if not text.strip():
+        return str(spec.default)
+    # Import here: template_engine imports store at module load.
+    from services.messages.template_engine import validate_template_text
+
+    try:
+        vr = validate_template_text(key, text)
+        if vr.get("ok"):
+            return text
+    except Exception:
+        pass
+    return str(spec.default)
+
 
 def _normalize(payload: Any) -> dict[str, Any]:
     """Coerce raw stored payload into the canonical shape used in memory."""
@@ -85,13 +114,21 @@ def _normalize(payload: Any) -> dict[str, Any]:
 
     overrides_raw = payload.get("overrides") or {}
     if isinstance(overrides_raw, dict):
+        migrated = dict(overrides_raw)
+        legacy = migrated.get("title.suffix.format")
+        if isinstance(legacy, str) and legacy.strip():
+            for nk in _TITLE_SUFFIX_KEYS:
+                if nk not in migrated:
+                    migrated[nk] = legacy
         clean: dict[str, str] = {}
-        for k, v in overrides_raw.items():
+        for k, v in migrated.items():
             if not isinstance(k, str):
                 continue
             if get_message_key(k) is None:
                 continue
             text = "" if v is None else str(v)
+            if k in _TITLE_SUFFIX_KEYS:
+                text = _coerce_title_suffix_value(k, text)
             clean[k] = text
         base["overrides"] = clean
 

--- a/services/messages/store.py
+++ b/services/messages/store.py
@@ -1,0 +1,215 @@
+"""Persistence for customizable status message templates.
+
+Stores a single JSON document in the ``app_config`` table under the key
+``PLACEHOLDER_MESSAGE_TEMPLATES``:
+
+    {
+        "separator": "\u00b7",
+        "case": "default",
+        "overrides": { "<message-key>": "<template string>", ... }
+    }
+
+Reads are cached in process for fast hot-path access from the projection
+engine. Writes go straight through to the database.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from services.messages.registry import (
+    CASE_OPTIONS,
+    DEFAULT_SEPARATOR,
+    DEFAULT_WRAPPER_PRESET,
+    SEPARATOR_PRESETS,
+    WRAPPER_PRESETS,
+    get_message_key,
+)
+from services.postgres.db import get_session
+from services.postgres.models import AppConfig
+
+
+CONFIG_KEY = "PLACEHOLDER_MESSAGE_TEMPLATES"
+
+_CACHE_LOCK = threading.Lock()
+_CACHE_LOADED = False
+_CACHE: dict[str, Any] = {
+    "separator": DEFAULT_SEPARATOR,
+    "case": "default",
+    "overrides": {},
+    "wrapper_preset": DEFAULT_WRAPPER_PRESET,
+    "wrapper_open": "",
+    "wrapper_close": "",
+}
+
+
+def _empty_config() -> dict[str, Any]:
+    return {
+        "separator": DEFAULT_SEPARATOR,
+        "case": "default",
+        "overrides": {},
+        "wrapper_preset": DEFAULT_WRAPPER_PRESET,
+        "wrapper_open": "",
+        "wrapper_close": "",
+    }
+
+
+_WRAPPER_PRESET_VALUES = {entry["value"] for entry in WRAPPER_PRESETS}
+
+
+def _normalize(payload: Any) -> dict[str, Any]:
+    """Coerce raw stored payload into the canonical shape used in memory."""
+    base = _empty_config()
+    if not isinstance(payload, dict):
+        return base
+
+    sep = payload.get("separator")
+    if isinstance(sep, str) and sep:
+        base["separator"] = sep
+
+    case = payload.get("case")
+    if isinstance(case, str) and case in {opt["value"] for opt in CASE_OPTIONS}:
+        base["case"] = case
+
+    wp = payload.get("wrapper_preset")
+    if isinstance(wp, str) and wp.strip().lower() in _WRAPPER_PRESET_VALUES:
+        base["wrapper_preset"] = wp.strip().lower()
+
+    wo = payload.get("wrapper_open")
+    if isinstance(wo, str):
+        base["wrapper_open"] = wo[:8]
+    wc = payload.get("wrapper_close")
+    if isinstance(wc, str):
+        base["wrapper_close"] = wc[:8]
+
+    overrides_raw = payload.get("overrides") or {}
+    if isinstance(overrides_raw, dict):
+        clean: dict[str, str] = {}
+        for k, v in overrides_raw.items():
+            if not isinstance(k, str):
+                continue
+            if get_message_key(k) is None:
+                continue
+            text = "" if v is None else str(v)
+            clean[k] = text
+        base["overrides"] = clean
+
+    return base
+
+
+def _load_locked() -> dict[str, Any]:
+    """Caller must hold _CACHE_LOCK."""
+    session = get_session()
+    try:
+        row = session.query(AppConfig).filter(AppConfig.key == CONFIG_KEY).first()
+        return _normalize(row.value if row else None)
+    finally:
+        session.close()
+
+
+def _ensure_loaded() -> None:
+    global _CACHE_LOADED
+    if _CACHE_LOADED:
+        return
+    with _CACHE_LOCK:
+        if _CACHE_LOADED:
+            return
+        try:
+            _CACHE.update(_load_locked())
+        except Exception:
+            _CACHE.update(_empty_config())
+        _CACHE_LOADED = True
+
+
+def reload_cache() -> None:
+    """Force a re-read from the database; useful after external migrations."""
+    global _CACHE_LOADED
+    with _CACHE_LOCK:
+        try:
+            _CACHE.update(_load_locked())
+        except Exception:
+            _CACHE.update(_empty_config())
+        _CACHE_LOADED = True
+
+
+def get_template_config() -> dict[str, Any]:
+    """Return a defensive copy of the current template config."""
+    _ensure_loaded()
+    with _CACHE_LOCK:
+        return {
+            "separator": _CACHE.get("separator", DEFAULT_SEPARATOR),
+            "case": _CACHE.get("case", "default"),
+            "overrides": dict(_CACHE.get("overrides", {})),
+            "wrapper_preset": _CACHE.get("wrapper_preset", DEFAULT_WRAPPER_PRESET),
+            "wrapper_open": _CACHE.get("wrapper_open", ""),
+            "wrapper_close": _CACHE.get("wrapper_close", ""),
+        }
+
+
+def get_overrides() -> dict[str, str]:
+    return get_template_config()["overrides"]
+
+
+def get_separator() -> str:
+    return get_template_config()["separator"]
+
+
+def get_case() -> str:
+    return get_template_config()["case"]
+
+
+def get_wrapper() -> dict[str, str]:
+    """Return the current wrapper config as a dict with ``preset``/``open``/``close``."""
+    cfg = get_template_config()
+    return {
+        "preset": str(cfg.get("wrapper_preset") or DEFAULT_WRAPPER_PRESET),
+        "open": str(cfg.get("wrapper_open") or ""),
+        "close": str(cfg.get("wrapper_close") or ""),
+    }
+
+
+def save_template_config(payload: dict[str, Any]) -> dict[str, Any]:
+    """Persist a new config payload. Caller is expected to have validated entries."""
+    normalized = _normalize(payload)
+    session = get_session()
+    try:
+        row = session.query(AppConfig).filter(AppConfig.key == CONFIG_KEY).first()
+        if row is None:
+            row = AppConfig(
+                key=CONFIG_KEY,
+                value=normalized,
+                value_type="json",
+                description="Customizable player projection message templates.",
+            )
+            session.add(row)
+        else:
+            row.value = normalized
+            row.value_type = "json"
+        session.commit()
+    finally:
+        session.close()
+
+    with _CACHE_LOCK:
+        _CACHE["separator"] = normalized["separator"]
+        _CACHE["case"] = normalized["case"]
+        _CACHE["overrides"] = dict(normalized["overrides"])
+        _CACHE["wrapper_preset"] = normalized["wrapper_preset"]
+        _CACHE["wrapper_open"] = normalized["wrapper_open"]
+        _CACHE["wrapper_close"] = normalized["wrapper_close"]
+        global _CACHE_LOADED
+        _CACHE_LOADED = True
+
+    return normalized
+
+
+def get_separator_presets() -> tuple[dict[str, str], ...]:
+    return SEPARATOR_PRESETS
+
+
+def get_case_options() -> tuple[dict[str, str], ...]:
+    return CASE_OPTIONS
+
+
+def get_wrapper_preset_options() -> tuple[dict[str, str], ...]:
+    return WRAPPER_PRESETS

--- a/services/messages/template_engine.py
+++ b/services/messages/template_engine.py
@@ -1,0 +1,431 @@
+"""Template engine for customizable status messages.
+
+Renders ``{Token}``-style placeholders against a context dictionary, applying
+the configured separator and case. Templates are looked up in the registry by
+key with override-or-default resolution.
+
+Usage:
+    rendered = render("calendar.tv.countdown.plural", {"DaysUntil": 5})
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from core.logger import logger
+from services.messages.registry import (
+    DEFAULT_SEPARATOR,
+    MessageKey,
+    get_message_key,
+    get_token_spec,
+    get_token_specs,
+    get_registry,
+    get_wrapper_preset_pair,
+)
+from services.messages import store
+
+
+_TOKEN_PATTERN = re.compile(r"\{([A-Za-z][A-Za-z0-9_]*)\}")
+_LITERAL_BRACE = re.compile(r"\{\{|\}\}")  # Not currently used but reserved for escaping.
+
+# Internal sentinel used in place of the configured separator during substitution.
+# After all tokens render, ``_collapse_separators`` splits on the sentinel, drops
+# empty segments, and rejoins with `" {separator} "`. This means a template like
+# ``{Runtime} {Sep} REQUEST`` collapses cleanly to ``REQUEST`` when Runtime is empty.
+_SEP_SENTINEL = "\x00\x01SEP\x01\x00"
+
+MAX_TEMPLATE_LENGTH = 400
+
+
+class InvalidTemplateError(ValueError):
+    """Raised when a template cannot be parsed (unbalanced / oversized / bad token)."""
+
+
+class UnknownTemplateKeyError(KeyError):
+    """Raised when a key is not in the registry."""
+
+
+# ----- Static validation ----------------------------------------------------
+
+
+def _scan_tokens(template: str) -> list[str]:
+    return [m.group(1) for m in _TOKEN_PATTERN.finditer(template)]
+
+
+def _check_brace_balance(template: str) -> None:
+    """Reject templates with stray ``{`` or ``}`` that weren't matched as tokens."""
+    stripped = _TOKEN_PATTERN.sub("", template)
+    if "{" in stripped or "}" in stripped:
+        raise InvalidTemplateError("template has unbalanced or stray braces")
+
+
+def validate_template_text(
+    key: str,
+    template: str,
+    *,
+    max_length: int = MAX_TEMPLATE_LENGTH,
+) -> dict[str, Any]:
+    """Validate a free-form template string for a registered key.
+
+    Returns a dict with ``ok``, ``unknown_tokens``, ``disallowed_tokens``, ``warnings``,
+    and ``error`` fields. Raises ``UnknownTemplateKeyError`` for unknown registry keys
+    and ``InvalidTemplateError`` for fatal problems (length / brace balance).
+    """
+    spec = get_message_key(key)
+    if spec is None:
+        raise UnknownTemplateKeyError(key)
+
+    text = "" if template is None else str(template)
+    if len(text) > max_length:
+        raise InvalidTemplateError(f"template exceeds maximum length of {max_length} characters")
+
+    _check_brace_balance(text)
+
+    used = _scan_tokens(text)
+    allowed = set(spec.allowed_tokens)
+    known = {t.name for t in get_token_specs()}
+
+    unknown = sorted({t for t in used if t not in known})
+    disallowed = sorted({t for t in used if t in known and t not in allowed})
+
+    warnings: list[str] = []
+    # Friendly nudges for common mistakes.
+    if spec.key.endswith(".plural") and "{DaysUntil}" not in text:
+        warnings.append("Consider including {DaysUntil} in plural countdown templates so users see the day count.")
+    if spec.key == "queue.downloading" and "{Progress}" not in text:
+        warnings.append("Consider including {Progress} so users see the download progress.")
+    if spec.key.startswith("import_grace.countdown") and spec.key.endswith("countdown") and "{MinutesRemaining}" not in text:
+        warnings.append("Consider including {MinutesRemaining} so the countdown shows the remaining minutes.")
+
+    return {
+        "ok": not unknown and not disallowed,
+        "unknown_tokens": unknown,
+        "disallowed_tokens": disallowed,
+        "warnings": warnings,
+    }
+
+
+# ----- Rendering ------------------------------------------------------------
+
+
+def _apply_case(text: str, case_mode: str) -> str:
+    mode = (case_mode or "default").strip().lower()
+    if mode == "upper":
+        return text.upper()
+    if mode == "lower":
+        return text.lower()
+    if mode == "title":
+        return text.title()
+    return text
+
+
+def _resolve_token(
+    name: str,
+    ctx: dict[str, Any],
+    *,
+    separator: str,
+    case_mode: str,
+    nesting: tuple[str, ...],
+) -> str:
+    if name == "Sep":
+        # Emit a sentinel; it is resolved (or collapsed away) by ``_collapse_separators``
+        # after all tokens have been substituted.
+        return _SEP_SENTINEL
+
+    if name in ctx and ctx[name] is not None:
+        text = str(ctx[name])
+        return text  # already a string; engine treats empty/missing identically
+
+    if name == "Status":
+        status_value = str(ctx.get("__status_enum__", "") or "").strip()
+        if status_value:
+            label_key = f"status.label.{status_value}"
+            try:
+                # render() already applies case for status.label keys.
+                return render(label_key, ctx, _nesting=nesting + ("Status",))
+            except UnknownTemplateKeyError:
+                return _apply_case(status_value, case_mode)
+        return ""
+
+    if name == "Bracket":
+        bracket_key = "bracket.with_runtime" if ctx.get("__has_runtime__") else "bracket.format"
+        try:
+            return render(bracket_key, ctx, _nesting=nesting + ("Bracket",))
+        except UnknownTemplateKeyError:
+            return ""
+
+    if name == "Runtime":
+        runtime = ctx.get("__runtime_text__")
+        if isinstance(runtime, str):
+            return runtime
+        hours = ctx.get("Hours")
+        minutes = ctx.get("Minutes")
+        try:
+            h = int(hours or 0)
+            m = int(minutes or 0)
+        except (TypeError, ValueError):
+            return ""
+        if h > 0 and m > 0:
+            return render("runtime.format.hm", {"Hours": str(h), "Minutes": str(m)}, _nesting=nesting + ("Runtime",))
+        if h > 0:
+            return render("runtime.format.h", {"Hours": str(h)}, _nesting=nesting + ("Runtime",))
+        if m > 0:
+            return render("runtime.format.m", {"Minutes": str(m)}, _nesting=nesting + ("Runtime",))
+        return ""
+
+    return ""
+
+
+def _resolve_template_text(spec: MessageKey, ctx: dict[str, Any], overrides: dict[str, str]) -> str:
+    """Pick an override or default, with movie-no-release-type alt-default support."""
+    override = overrides.get(spec.key)
+    if isinstance(override, str) and override.strip():
+        return override
+
+    if spec.alt_defaults:
+        if not str(ctx.get("ReleaseLabel") or "").strip() and "no_release_type" in spec.alt_defaults:
+            return spec.alt_defaults["no_release_type"]
+
+    return spec.default
+
+
+def render(
+    key: str,
+    ctx: dict[str, Any] | None = None,
+    *,
+    overrides: dict[str, str] | None = None,
+    separator: str | None = None,
+    case_mode: str | None = None,
+    _nesting: tuple[str, ...] = (),
+) -> str:
+    """Render a registered key against ``ctx``.
+
+    ``ctx`` may carry standard tokens (``Title``, ``DaysUntil``, ...) plus the
+    internal helpers ``__status_enum__``, ``__has_runtime__``, ``__runtime_text__``
+    used when chaining bracket templates.
+    """
+    spec = get_message_key(key)
+    if spec is None:
+        raise UnknownTemplateKeyError(key)
+
+    if len(_nesting) > 6:
+        logger.warning(
+            f"Template render aborted due to deep nesting key={key} chain={_nesting}",
+            extra={"emoji_type": "warning"},
+        )
+        return ""
+
+    if ctx is None:
+        ctx = {}
+
+    config = store.get_template_config()
+    overrides = overrides if overrides is not None else config["overrides"]
+    sep = separator if separator is not None else (config.get("separator") or DEFAULT_SEPARATOR)
+    case = case_mode if case_mode is not None else (config.get("case") or "default")
+
+    template = _resolve_template_text(spec, ctx, overrides)
+
+    def _replace(match: re.Match[str]) -> str:
+        token_name = match.group(1)
+        if get_token_spec(token_name) is None:
+            return ""
+        return _resolve_token(
+            token_name,
+            ctx,
+            separator=sep,
+            case_mode=case,
+            nesting=_nesting + (key,),
+        )
+
+    rendered = _TOKEN_PATTERN.sub(_replace, template)
+    rendered = _collapse_separators(rendered, sep)
+
+    if key.startswith("status.label."):
+        rendered = _apply_case(rendered, case)
+
+    return _normalize_whitespace(rendered)
+
+
+def render_template(
+    key: str,
+    template: str,
+    ctx: dict[str, Any] | None = None,
+    *,
+    separator: str | None = None,
+    case_mode: str | None = None,
+) -> str:
+    """Render an arbitrary template string under ``key``'s rules (used for previews)."""
+    spec = get_message_key(key)
+    if spec is None:
+        raise UnknownTemplateKeyError(key)
+
+    overrides = {**store.get_overrides(), key: template}
+    return render(key, ctx or {}, overrides=overrides, separator=separator, case_mode=case_mode)
+
+
+def sample_render(key: str, *, override_text: str | None = None) -> str:
+    """Render a registered key against its registered ``sample_context``."""
+    spec = get_message_key(key)
+    if spec is None:
+        raise UnknownTemplateKeyError(key)
+
+    ctx = dict(spec.sample_context)
+    overrides_in_use = store.get_overrides()
+    if override_text is not None:
+        overrides_in_use = {**overrides_in_use, key: override_text}
+
+    return render(key, ctx, overrides=overrides_in_use)
+
+
+def _collapse_separators(text: str, separator: str) -> str:
+    """Replace separator sentinels with the configured separator, dropping empty segments.
+
+    Splitting on the sentinel and discarding empty/whitespace-only segments ensures
+    that templates like ``{Runtime} {Sep} REQUEST`` become just ``REQUEST`` when
+    runtime is missing — no orphaned " · " on the front. Adjacent separators with
+    nothing between them are likewise collapsed into a single one.
+    """
+    if not text:
+        return ""
+    if _SEP_SENTINEL not in text:
+        return text
+    parts = text.split(_SEP_SENTINEL)
+    cleaned: list[str] = []
+    for part in parts:
+        stripped = part.strip()
+        if stripped:
+            cleaned.append(stripped)
+    if not cleaned:
+        return ""
+    sep = separator if separator else DEFAULT_SEPARATOR
+    return f" {sep} ".join(cleaned)
+
+
+def _normalize_whitespace(text: str) -> str:
+    """Collapse runs of spaces and tidy up spacing around brackets/parens produced by
+    optional/empty token resolution."""
+    if not text:
+        return ""
+    out = re.sub(r"[ \t]+", " ", text)
+    out = re.sub(r"\(\s+", "(", out)
+    out = re.sub(r"\s+\)", ")", out)
+    # Drop empty bracket/paren islands left behind when every token inside collapsed.
+    out = re.sub(r"\(\s*\)", "", out)
+    out = re.sub(r"\[\s*\]", "", out)
+    out = re.sub(r"\{\s*\}", "", out)
+    out = re.sub(r"\s+([,.;:!?])", r"\1", out)
+    out = re.sub(r"[ \t]+", " ", out)
+    return out.strip()
+
+
+def apply_wrapper(inner: str, *, preset: str | None = None, open_text: str | None = None, close_text: str | None = None) -> str:
+    """Wrap ``inner`` in the configured global presentation chrome.
+
+    Resolution order:
+      1. Explicit ``open_text`` / ``close_text`` arguments (used by previews).
+      2. Resolved preset pair (e.g. ``brackets``).
+      3. Custom open/close from the saved store config.
+      4. Default brackets ``[ ]``.
+
+    An empty inner string returns empty (no naked wrapper).
+    """
+    inner_text = (inner or "").strip()
+    if not inner_text:
+        return ""
+
+    if open_text is not None or close_text is not None:
+        o = "" if open_text is None else str(open_text)
+        c = "" if close_text is None else str(close_text)
+        return f"{o}{inner_text}{c}"
+
+    config = store.get_template_config()
+    preset_name = preset if preset is not None else str(config.get("wrapper_preset") or "")
+    preset_name = preset_name.strip().lower() or "brackets"
+
+    if preset_name == "custom":
+        o = str(config.get("wrapper_open") or "")
+        c = str(config.get("wrapper_close") or "")
+        return f"{o}{inner_text}{c}"
+
+    pair = get_wrapper_preset_pair(preset_name)
+    if pair is None:
+        # Unknown preset → fall back to default brackets to keep output readable.
+        pair = ("[", "]")
+    o, c = pair
+    return f"{o}{inner_text}{c}"
+
+
+# ----- Convenience: render lists of media tokens ---------------------------
+
+
+def media_tokens_for_movie(movie: Any) -> dict[str, Any]:
+    """Map a Movie ORM row to the standard media token namespace."""
+    if movie is None:
+        return {}
+    title = str(getattr(movie, "title", "") or "").strip()
+    year = getattr(movie, "year", None)
+    runtime_min = getattr(movie, "radarr_runtime", None)
+    cert = str(getattr(movie, "radarr_certification", "") or "").strip()
+    studio = str(getattr(movie, "radarr_studio", "") or "").strip()
+    genres = getattr(movie, "radarr_genres", None)
+    if isinstance(genres, list):
+        genres_text = ", ".join(str(g) for g in genres if g)
+    elif isinstance(genres, str):
+        genres_text = genres
+    else:
+        genres_text = ""
+
+    hours, minutes = _split_minutes(runtime_min)
+    return {
+        "Title": title,
+        "Year": str(year) if year else "",
+        "ReleaseYear": str(year) if year else "",
+        "Genres": genres_text,
+        "Certification": cert,
+        "Studio": studio,
+        "RuntimeMinutes": str(int(runtime_min)) if isinstance(runtime_min, (int, float)) and int(runtime_min) > 0 else "",
+        "Hours": str(hours) if hours else "",
+        "Minutes": str(minutes) if minutes else "",
+    }
+
+
+def media_tokens_for_episode(episode: Any, season: Any = None, series: Any = None) -> dict[str, Any]:
+    if episode is None:
+        return {}
+    if season is None:
+        season = getattr(episode, "season", None)
+    if series is None and season is not None:
+        series = getattr(season, "series", None)
+
+    series_title = str(getattr(series, "title", "") or "").strip() if series else ""
+    sn = int(getattr(season, "season_number", 0) or 0) if season else 0
+    en = int(getattr(episode, "episode_number", 0) or 0)
+    ep_title = str(getattr(episode, "title", "") or "").strip()
+
+    runtime_min = getattr(episode, "sonarr_runtime", None)
+    if not runtime_min and series is not None:
+        runtime_min = getattr(series, "sonarr_runtime", None)
+
+    hours, minutes = _split_minutes(runtime_min)
+    return {
+        "Title": series_title or ep_title,
+        "SeriesTitle": series_title,
+        "EpisodeTitle": ep_title,
+        "SeasonNumber": f"{sn:02d}",
+        "EpisodeNumber": f"{en:02d}",
+        "SXXEYY": f"S{sn:02d}E{en:02d}",
+        "RuntimeMinutes": str(int(runtime_min)) if isinstance(runtime_min, (int, float)) and int(runtime_min) > 0 else "",
+        "Hours": str(hours) if hours else "",
+        "Minutes": str(minutes) if minutes else "",
+    }
+
+
+def _split_minutes(runtime_min: Any) -> tuple[int, int]:
+    try:
+        total = int(runtime_min) if runtime_min is not None else 0
+    except (TypeError, ValueError):
+        total = 0
+    if total <= 0:
+        return 0, 0
+    return total // 60, total % 60

--- a/services/messages/template_engine.py
+++ b/services/messages/template_engine.py
@@ -125,7 +125,6 @@ def _resolve_token(
     ctx: dict[str, Any],
     *,
     separator: str,
-    case_mode: str,
     nesting: tuple[str, ...],
 ) -> str:
     if name == "Sep":
@@ -215,14 +214,13 @@ def render(
             token_name,
             ctx,
             separator=sep,
-            case_mode=case,
             nesting=_nesting + (key,),
         )
 
     rendered = _TOKEN_PATTERN.sub(_replace, template)
     rendered = _collapse_separators(rendered, sep)
-
-    return _normalize_whitespace(rendered)
+    rendered = _normalize_whitespace(rendered)
+    return _apply_case(rendered, case)
 
 
 def render_template(

--- a/services/messages/template_engine.py
+++ b/services/messages/template_engine.py
@@ -137,24 +137,6 @@ def _resolve_token(
         text = str(ctx[name])
         return text  # already a string; engine treats empty/missing identically
 
-    if name == "Status":
-        status_value = str(ctx.get("__status_enum__", "") or "").strip()
-        if status_value:
-            label_key = f"status.label.{status_value}"
-            try:
-                # render() already applies case for status.label keys.
-                return render(label_key, ctx, _nesting=nesting + ("Status",))
-            except UnknownTemplateKeyError:
-                return _apply_case(status_value, case_mode)
-        return ""
-
-    if name == "Bracket":
-        bracket_key = "bracket.with_runtime" if ctx.get("__has_runtime__") else "bracket.format"
-        try:
-            return render(bracket_key, ctx, _nesting=nesting + ("Bracket",))
-        except UnknownTemplateKeyError:
-            return ""
-
     if name == "Runtime":
         runtime = ctx.get("__runtime_text__")
         if isinstance(runtime, str):
@@ -167,11 +149,11 @@ def _resolve_token(
         except (TypeError, ValueError):
             return ""
         if h > 0 and m > 0:
-            return render("runtime.format.hm", {"Hours": str(h), "Minutes": str(m)}, _nesting=nesting + ("Runtime",))
+            return f"{h}h {m}m"
         if h > 0:
-            return render("runtime.format.h", {"Hours": str(h)}, _nesting=nesting + ("Runtime",))
+            return f"{h}h"
         if m > 0:
-            return render("runtime.format.m", {"Minutes": str(m)}, _nesting=nesting + ("Runtime",))
+            return f"{m}m"
         return ""
 
     return ""
@@ -201,9 +183,8 @@ def render(
 ) -> str:
     """Render a registered key against ``ctx``.
 
-    ``ctx`` may carry standard tokens (``Title``, ``DaysUntil``, ...) plus the
-    internal helpers ``__status_enum__``, ``__has_runtime__``, ``__runtime_text__``
-    used when chaining bracket templates.
+    ``ctx`` may carry standard tokens (``Title``, ``DaysUntil``, ...) plus
+    ``__runtime_text__`` used by REQUEST runtime formatting.
     """
     spec = get_message_key(key)
     if spec is None:
@@ -240,9 +221,6 @@ def render(
 
     rendered = _TOKEN_PATTERN.sub(_replace, template)
     rendered = _collapse_separators(rendered, sep)
-
-    if key.startswith("status.label."):
-        rendered = _apply_case(rendered, case)
 
     return _normalize_whitespace(rendered)
 
@@ -390,6 +368,85 @@ def media_tokens_for_movie(movie: Any) -> dict[str, Any]:
     }
 
 
+def media_tokens_for_series(series: Any) -> dict[str, Any]:
+    """Map a Series ORM row to the media token namespace (series-level surfaces)."""
+    if series is None:
+        return {}
+    title = str(getattr(series, "title", "") or "").strip()
+    year_val = getattr(series, "year", None)
+    runtime_min = getattr(series, "sonarr_runtime", None)
+    cert = str(getattr(series, "sonarr_certification", "") or "").strip()
+    studio = str(getattr(series, "sonarr_network", "") or "").strip()
+    genres = getattr(series, "sonarr_genres", None)
+    if isinstance(genres, list):
+        genres_text = ", ".join(str(g) for g in genres if g)
+    elif isinstance(genres, str):
+        genres_text = genres
+    else:
+        genres_text = ""
+
+    hours, minutes = _split_minutes(runtime_min)
+    return {
+        "Title": title,
+        "SeriesTitle": title,
+        "EpisodeTitle": "",
+        "SeasonNumber": "",
+        "EpisodeNumber": "",
+        "SXXEYY": "",
+        "Year": str(year_val) if year_val else "",
+        "ReleaseYear": str(year_val) if year_val else "",
+        "Genres": genres_text,
+        "Certification": cert,
+        "Studio": studio,
+        "RuntimeMinutes": str(int(runtime_min)) if isinstance(runtime_min, (int, float)) and int(runtime_min) > 0 else "",
+        "Hours": str(hours) if hours else "",
+        "Minutes": str(minutes) if minutes else "",
+    }
+
+
+def media_tokens_for_season(season: Any, series: Any = None) -> dict[str, Any]:
+    """Map Season (+ optional Series) for season-level title suffix templates."""
+    if season is None:
+        return {}
+    if series is None:
+        series = getattr(season, "series", None)
+    st = str(getattr(season, "title", "") or "").strip()
+    series_title = str(getattr(series, "title", "") or "").strip() if series else ""
+    sn = int(getattr(season, "season_number", 0) or 0)
+    year_val = getattr(season, "year", None)
+    if year_val is None and series is not None:
+        year_val = getattr(series, "year", None)
+    runtime_min = getattr(series, "sonarr_runtime", None) if series is not None else None
+    hours, minutes = _split_minutes(runtime_min)
+    genres_text = ""
+    cert = ""
+    studio = ""
+    if series is not None:
+        genres = getattr(series, "sonarr_genres", None)
+        if isinstance(genres, list):
+            genres_text = ", ".join(str(g) for g in genres if g)
+        elif isinstance(genres, str):
+            genres_text = genres
+        cert = str(getattr(series, "sonarr_certification", "") or "").strip()
+        studio = str(getattr(series, "sonarr_network", "") or "").strip()
+    return {
+        "Title": st,
+        "SeriesTitle": series_title,
+        "EpisodeTitle": "",
+        "SeasonNumber": f"{sn:02d}",
+        "EpisodeNumber": "",
+        "SXXEYY": "",
+        "Year": str(year_val) if year_val else "",
+        "ReleaseYear": str(year_val) if year_val else "",
+        "Genres": genres_text,
+        "Certification": cert,
+        "Studio": studio,
+        "RuntimeMinutes": str(int(runtime_min)) if isinstance(runtime_min, (int, float)) and int(runtime_min) > 0 else "",
+        "Hours": str(hours) if hours else "",
+        "Minutes": str(minutes) if minutes else "",
+    }
+
+
 def media_tokens_for_episode(episode: Any, season: Any = None, series: Any = None) -> dict[str, Any]:
     if episode is None:
         return {}
@@ -408,6 +465,22 @@ def media_tokens_for_episode(episode: Any, season: Any = None, series: Any = Non
         runtime_min = getattr(series, "sonarr_runtime", None)
 
     hours, minutes = _split_minutes(runtime_min)
+
+    year_val = getattr(episode, "year", None)
+    if year_val is None and series is not None:
+        year_val = getattr(series, "year", None)
+    genres_text = ""
+    cert = ""
+    studio = ""
+    if series is not None:
+        genres = getattr(series, "sonarr_genres", None)
+        if isinstance(genres, list):
+            genres_text = ", ".join(str(g) for g in genres if g)
+        elif isinstance(genres, str):
+            genres_text = genres
+        cert = str(getattr(series, "sonarr_certification", "") or "").strip()
+        studio = str(getattr(series, "sonarr_network", "") or "").strip()
+
     return {
         "Title": series_title or ep_title,
         "SeriesTitle": series_title,
@@ -415,6 +488,11 @@ def media_tokens_for_episode(episode: Any, season: Any = None, series: Any = Non
         "SeasonNumber": f"{sn:02d}",
         "EpisodeNumber": f"{en:02d}",
         "SXXEYY": f"S{sn:02d}E{en:02d}",
+        "Year": str(year_val) if year_val else "",
+        "ReleaseYear": str(year_val) if year_val else "",
+        "Genres": genres_text,
+        "Certification": cert,
+        "Studio": studio,
         "RuntimeMinutes": str(int(runtime_min)) if isinstance(runtime_min, (int, float)) and int(runtime_min) > 0 else "",
         "Hours": str(hours) if hours else "",
         "Minutes": str(minutes) if minutes else "",

--- a/services/placeholders.py
+++ b/services/placeholders.py
@@ -10,6 +10,7 @@ from typing import Any
 from xml.sax.saxutils import escape
 
 from core.config import settings
+from services.messages.context import build_projection_context
 from services.status_projection import project_summary, project_title
 
 
@@ -467,11 +468,26 @@ def _append_people_as_tag(lines: list[str], tag_name: str, values: Any) -> None:
 def _movie_nfo_xml(movie: Any) -> str:
     status = str(getattr(movie, "placeholder_status", "") or "REQUEST")
     raw_title = str(getattr(movie, "title", "") or "")
-    title = escape(project_title(raw_title, status))
     year = getattr(movie, "year", None)
     runtime = _to_int(getattr(movie, "radarr_runtime", None))
+    rm = runtime if runtime is not None and runtime > 0 else None
+    media_ctx = build_projection_context(movie=movie, runtime_minutes=rm)
+    title = escape(
+        project_title(
+            raw_title,
+            status,
+            suffix_template_key="title.suffix.movie",
+            runtime_minutes=rm,
+            media_context=media_ctx,
+        )
+    )
     overview = escape(
-        project_summary(str(getattr(movie, "radarr_overview", "") or ""), status, runtime_minutes=runtime)
+        project_summary(
+            str(getattr(movie, "radarr_overview", "") or ""),
+            status,
+            runtime_minutes=rm,
+            media_context=media_ctx,
+        )
     )
     tmdbid = getattr(movie, "tmdbid", None)
     imdbid = getattr(movie, "imdbid", None)
@@ -503,7 +519,7 @@ def _movie_nfo_xml(movie: Any) -> str:
     if overview:
         lines.append(f"  <plot>{overview}</plot>")
     else:
-        lines.append(f"  <plot>{escape(project_summary('', status, runtime_minutes=runtime))}</plot>")
+        lines.append(f"  <plot>{escape(project_summary('', status, runtime_minutes=rm, media_context=media_ctx))}</plot>")
     if ratings:
         lines.append("  <ratings>")
         for name, value_text, votes_text, is_default in ratings:
@@ -574,16 +590,37 @@ def _movie_nfo_xml(movie: Any) -> str:
 
 
 def _episode_nfo_xml(episode: Any, season: Any, series: Any) -> str:
-    show_title = escape(str(getattr(series, "title", "") or ""))
     status = str(getattr(episode, "placeholder_status", "") or "REQUEST")
+    raw_series_title = str(getattr(series, "title", "") or "")
     raw_episode_title = str(getattr(episode, "title", "") or "")
-    episode_title = escape(project_title(raw_episode_title, status))
     runtime = _to_int(getattr(episode, "sonarr_runtime", None)) or _to_int(getattr(series, "sonarr_runtime", None))
+    rm = runtime if runtime is not None and runtime > 0 else None
+    media_ctx = build_projection_context(episode=episode, season=season, series=series, runtime_minutes=rm)
+    series_ctx = build_projection_context(series=series, runtime_minutes=rm)
+    show_title = escape(
+        project_title(
+            raw_series_title,
+            status,
+            suffix_template_key="title.suffix.series",
+            runtime_minutes=rm,
+            media_context=series_ctx,
+        )
+    )
+    episode_title = escape(
+        project_title(
+            raw_episode_title,
+            status,
+            suffix_template_key="title.suffix.episode",
+            runtime_minutes=rm,
+            media_context=media_ctx,
+        )
+    )
     plot = escape(
         project_summary(
             str(getattr(episode, "sonarr_episode_overview", "") or ""),
             status,
-            runtime_minutes=runtime,
+            runtime_minutes=rm,
+            media_context=media_ctx,
         )
     )
     season_number = int(getattr(season, "season_number", 0) or 0)
@@ -615,7 +652,7 @@ def _episode_nfo_xml(episode: Any, season: Any, series: Any) -> str:
     if plot:
         lines.append(f"  <plot>{plot}</plot>")
     else:
-        lines.append(f"  <plot>{escape(project_summary('', status, runtime_minutes=runtime))}</plot>")
+        lines.append(f"  <plot>{escape(project_summary('', status, runtime_minutes=rm, media_context=media_ctx))}</plot>")
     if tvdbid:
         lines.append(f"  <tvdbid>{escape(str(tvdbid))}</tvdbid>")
         # uniqueid lets Emby/Jellyfin match this episode to their databases
@@ -651,7 +688,20 @@ def ensure_episode_nfo(media_path: str, episode: Any, season: Any, series: Any) 
 
 def _series_nfo_xml(series: Any) -> str:
     """Render a tvshow.nfo XML for a series object."""
-    title = escape(str(getattr(series, "title", "") or ""))
+    status = str(getattr(series, "placeholder_status", "") or "REQUEST")
+    raw_title = str(getattr(series, "title", "") or "")
+    runtime = _to_int(getattr(series, "sonarr_runtime", None))
+    rm = runtime if runtime is not None and runtime > 0 else None
+    media_ctx = build_projection_context(series=series, runtime_minutes=rm)
+    title = escape(
+        project_title(
+            raw_title,
+            status,
+            suffix_template_key="title.suffix.series",
+            runtime_minutes=rm,
+            media_context=media_ctx,
+        )
+    )
     overview = escape(str(getattr(series, "sonarr_series_overview", "") or ""))
     tvdbid = getattr(series, "tvdbid", None)
     imdbid = getattr(series, "imdbid", None)
@@ -666,7 +716,6 @@ def _series_nfo_xml(series: Any) -> str:
     poster_url = escape(str(getattr(series, "remote_poster", "") or ""))
     fanart_url = escape(str(getattr(series, "remote_fanart", "") or ""))
     banner_url = escape(str(getattr(series, "remote_banner", "") or ""))
-    runtime = _to_int(getattr(series, "sonarr_runtime", None))
 
     lines = [
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>",

--- a/services/source_of_truth/calendar_phase.py
+++ b/services/source_of_truth/calendar_phase.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from core.config import settings
 from core.logger import logger
+from services.messages import render as render_message
 from services.placeholders import ensure_placeholder_file, resolve_calendar_variant_dummy_path
 from services.postgres.db import get_session
 from services.postgres.models import Episode, Movie, Placeholder
@@ -143,11 +144,13 @@ def _compute_calendar_decision(
             release_type_preferred=release_type_preferred,
         )
 
+    cal_ctx_movie = {"ReleaseLabel": release_label} if release_type else {}
+
     if not countdown_enabled:
-        if media_type == "movie" and release_type:
-            label = f"{release_label} release coming soon"
+        if media_type == "movie":
+            label = render_message("calendar.movie.generic", cal_ctx_movie)
         else:
-            label = "Coming Soon" if media_type == "movie" else "Airing soon"
+            label = render_message("calendar.tv.generic", {})
         return CalendarDecision(
             status=DisplayStatus.COMING_SOON.value,
             reason=label,
@@ -157,10 +160,10 @@ def _compute_calendar_decision(
         )
 
     if days_until == 0:
-        if media_type == "movie" and release_type:
-            label = f"{release_label} release today"
+        if media_type == "movie":
+            label = render_message("calendar.movie.today", cal_ctx_movie)
         else:
-            label = "Coming Soon (Today)" if media_type == "movie" else "Airing today"
+            label = render_message("calendar.tv.today", {})
         return CalendarDecision(
             status=DisplayStatus.COMING_SOON_TODAY.value,
             reason=label,
@@ -170,16 +173,21 @@ def _compute_calendar_decision(
         )
 
     if media_type == "movie":
-        if release_type:
-            label = (
-                f"{release_label} release in 1 day"
-                if days_until == 1
-                else f"{release_label} release in {days_until} days"
-            )
-        else:
-            label = "Coming Soon (1 day)" if days_until == 1 else f"Coming Soon ({days_until} days)"
+        movie_ctx = {**cal_ctx_movie, "DaysUntil": str(days_until)}
+        countdown_key = (
+            "calendar.movie.countdown.singular"
+            if days_until == 1
+            else "calendar.movie.countdown.plural"
+        )
+        label = render_message(countdown_key, movie_ctx)
     else:
-        label = "Airing in 1 day" if days_until == 1 else f"Airing in {days_until} days"
+        tv_ctx = {"DaysUntil": str(days_until)}
+        countdown_key = (
+            "calendar.tv.countdown.singular"
+            if days_until == 1
+            else "calendar.tv.countdown.plural"
+        )
+        label = render_message(countdown_key, tv_ctx)
 
     if days_until <= 6:
         status = DisplayStatus.COMING_SOON_1.value

--- a/services/source_of_truth/import_grace.py
+++ b/services/source_of_truth/import_grace.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from core.config import settings
+from services.messages import render as render_message
 from services.placeholders import episode_placeholder_path, movie_placeholder_path
 from services.placeholder_activity_log import (
     append_placeholder_activity_status,
@@ -19,14 +20,31 @@ from services.status_projection import projected_status_display
 
 IMPORT_GRACE_JOB_TYPE = "import_grace"
 IMPORT_GRACE_REASON = "import_grace_countdown"
-COUNTDOWN_STATUSES = [
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN 5 MIN",
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN 4 MIN",
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN 3 MIN",
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN 2 MIN",
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN 1 MIN",
-    "NOW IN LIBRARY - RETIRING PLACEHOLDER IN LESS THAN A MINUTE",
-]
+# Number of countdown ticks before the final "less than a minute" tick.
+# Historically: 5, 4, 3, 2, 1 minutes remaining, plus a "less than a minute" final.
+COUNTDOWN_MINUTES_DECREASING = (5, 4, 3, 2, 1)
+
+
+def _countdown_status_text(minutes_remaining: int) -> str:
+    """Render the customizable countdown status text for a given minutes-remaining tick."""
+    return render_message("import_grace.countdown", {"MinutesRemaining": str(int(minutes_remaining))})
+
+
+def _countdown_lt_1_min_status_text() -> str:
+    return render_message("import_grace.countdown_lt_1_min", {})
+
+
+def _all_countdown_status_texts() -> list[str]:
+    """Render all countdown status strings in display order."""
+    return [_countdown_status_text(m) for m in COUNTDOWN_MINUTES_DECREASING] + [_countdown_lt_1_min_status_text()]
+
+
+# Backwards-compatible shim for any consumer still importing the static list.
+# Generated lazily so it picks up template overrides at scheduling time.
+def __getattr__(name: str):  # pragma: no cover - simple compatibility shim
+    if name == "COUNTDOWN_STATUSES":
+        return _all_countdown_status_texts()
+    raise AttributeError(name)
 
 
 def _import_grace_step_seconds() -> int:
@@ -43,8 +61,9 @@ def build_import_grace_schedule(base_time: datetime | None = None, step_seconds:
     now = base_time or datetime.now(timezone.utc)
     step = max(1, int(step_seconds or _import_grace_step_seconds()))
 
+    countdown_texts = _all_countdown_status_texts()
     scheduled: list[dict[str, Any]] = []
-    for step_index, status_text in enumerate(COUNTDOWN_STATUSES):
+    for step_index, status_text in enumerate(countdown_texts):
         scheduled.append(
             {
                 "step_index": step_index,
@@ -56,8 +75,8 @@ def build_import_grace_schedule(base_time: datetime | None = None, step_seconds:
 
     scheduled.append(
         {
-            "step_index": len(COUNTDOWN_STATUSES),
-            "run_after": now + timedelta(seconds=len(COUNTDOWN_STATUSES) * step),
+            "step_index": len(countdown_texts),
+            "run_after": now + timedelta(seconds=len(countdown_texts) * step),
             "status_text": None,
             "finalize": True,
         }

--- a/services/source_of_truth/materializer.py
+++ b/services/source_of_truth/materializer.py
@@ -37,6 +37,7 @@ from services.source_of_truth.placeholder_cleanup import (
 )
 from services.source_of_truth.refresh_throttle import try_acquire_refresh_lease
 from services.source_of_truth.status_orchestrator import StatusOrchestrator
+from services.messages.context import build_projection_context_from_session
 from services.status_projection import projected_status_display
 
 
@@ -317,10 +318,18 @@ def _mark_placeholder_row_active(
     row.lifecycle_status = "ACTIVE"
     row.display_status = REQUEST_STATUS
     row.display_reason = REQUEST_REASON
+    _rm = _placeholder_runtime_minutes(session, movie_id=movie_id, episode_id=episode_id)
+    _media_ctx = build_projection_context_from_session(
+        session,
+        movie_id=movie_id,
+        episode_id=episode_id,
+        runtime_minutes=_rm,
+    )
     row.display_status_projected = projected_status_display(
         REQUEST_STATUS,
         reason=REQUEST_REASON,
-        runtime_minutes=_placeholder_runtime_minutes(session, movie_id=movie_id, episode_id=episode_id),
+        runtime_minutes=_rm,
+        media_context=_media_ctx,
     )
     row.display_progress = 0
     # Reset observation-tracking keys in extra so stale state from a previous

--- a/services/source_of_truth/queue_monitor_producer.py
+++ b/services/source_of_truth/queue_monitor_producer.py
@@ -11,6 +11,7 @@ from core.config import settings
 from core.logger import logger
 from sqlalchemy.orm.attributes import flag_modified
 
+from services.messages import render as render_message
 from services.postgres.db import get_session
 from services.postgres.models import Episode, Movie, Placeholder
 from services.activity_snapshot import clear_queue_download_snapshot, set_queue_download_snapshot
@@ -509,36 +510,37 @@ class QueueMonitorProducer:
                 progress = self._extract_progress(queue_item)
                 if progress > 0:
                     target_status = DisplayStatus.DOWNLOADING.value
-                    target_reason = f"Downloading {progress}%"
+                    target_reason = render_message("queue.downloading", {"Progress": str(progress)})
                     target_progress = progress
                 else:
                     target_status = DisplayStatus.SEARCHING.value
-                    target_reason = "Queued"
+                    target_reason = render_message("queue.queued", {})
                     target_progress = None
             elif queue_status in {"queued", "delay", "paused"}:
                 target_status = DisplayStatus.SEARCHING.value
-                target_reason = "Queued"
+                target_reason = render_message("queue.queued", {})
                 target_progress = None
             elif queue_status == "completed":
                 # Completed means download is done; tracked import states add clarity.
                 target_status = DisplayStatus.IMPORT_IN_PROGRESS.value
                 if tracked_state == "importpending":
-                    target_reason = "Waiting to import"
+                    target_reason = render_message("queue.import.pending", {})
                 elif tracked_state == "importing":
-                    target_reason = "Importing"
+                    target_reason = render_message("queue.import.importing", {})
                 elif tracked_state == "importblocked":
-                    target_reason = "Import blocked"
+                    target_reason = render_message("queue.import.blocked", {})
                 elif tracked_state == "failedpending":
-                    target_reason = "Waiting for import retry"
+                    target_reason = render_message("queue.import.failed_pending", {})
                 else:
-                    target_reason = "Processing import"
+                    target_reason = render_message("queue.import.processing", {})
                 target_progress = None
             elif queue_status in {"warning", "error", "failed"}:
                 target_status = "RETRYING"
-                target_reason = "Retrying after queue failure"
+                target_reason = render_message("queue.retry.queue_failure", {})
                 target_progress = None
             else:
                 target_status = DisplayStatus.SEARCHING.value
+                # Operator-fallback line stays in English for diagnostics.
                 target_reason = f"Queue status: {queue_status or 'unknown'}"
                 target_progress = None
         else:
@@ -550,7 +552,7 @@ class QueueMonitorProducer:
                 elapsed = (now - left_queue_at).total_seconds() if left_queue_at else 0
                 if elapsed < self._retry_grace_seconds:
                     target_status = "RETRYING"
-                    target_reason = "Retrying; waiting for another qualifying release"
+                    target_reason = render_message("queue.retry.left_queue", {})
                     target_progress = None
                     if _should_emit_wait_log(qm, "left_queue_wait_last_log_at", now, period_seconds=60):
                         remaining = max(0, int(self._retry_grace_seconds - elapsed))
@@ -562,7 +564,7 @@ class QueueMonitorProducer:
                         )
                 else:
                     target_status = DisplayStatus.NOT_FOUND.value
-                    target_reason = "NO QUALIFYING RELEASE FOUND"
+                    target_reason = render_message("queue.not_found", {})
                     target_progress = None
                     qm["left_queue_wait_last_log_at"] = None
                     logger.info(
@@ -580,7 +582,7 @@ class QueueMonitorProducer:
                 elapsed_search = (now - search_start).total_seconds() if search_start else 0.0
                 if elapsed_search >= float(self._search_timeout_seconds):
                     target_status = DisplayStatus.NOT_FOUND.value
-                    target_reason = "NO QUALIFYING RELEASE FOUND"
+                    target_reason = render_message("queue.not_found", {})
                     qm["empty_queue_search_started_at"] = None
                     qm["search_wait_last_log_at"] = None
                     logger.info(
@@ -592,7 +594,7 @@ class QueueMonitorProducer:
                     )
                 else:
                     target_status = DisplayStatus.SEARCHING.value
-                    target_reason = "Searching for release"
+                    target_reason = render_message("queue.searching", {})
                     target_progress = None
                     if _should_emit_wait_log(qm, "search_wait_last_log_at", now, period_seconds=60):
                         remaining = max(0, int(float(self._search_timeout_seconds) - elapsed_search))

--- a/services/source_of_truth/status_orchestrator.py
+++ b/services/source_of_truth/status_orchestrator.py
@@ -27,6 +27,7 @@ from core.config import settings
 from services.source_of_truth.status_intent import StatusIntent, StatusSource, DisplayStatus
 from services.postgres.models import Placeholder, Movie, Series, Season, Episode, EventLog
 from services.postgres.db import get_session
+from services.messages.context import build_projection_context_from_session
 from services.status_projection import projected_status_display
 
 logger = logging.getLogger(__name__)
@@ -532,10 +533,18 @@ class StatusOrchestrator:
             old_status = ph.display_status
             ph.display_status = intent.new_status
             ph.display_reason = intent.reason
+            _rm = _runtime_minutes_for_placeholder(session, ph)
+            _media_ctx = build_projection_context_from_session(
+                session,
+                movie_id=getattr(ph, "movie_id", None),
+                episode_id=getattr(ph, "episode_id", None),
+                runtime_minutes=_rm,
+            )
             ph.display_status_projected = projected_status_display(
                 intent.new_status,
                 reason=intent.reason,
-                runtime_minutes=_runtime_minutes_for_placeholder(session, ph),
+                runtime_minutes=_rm,
+                media_context=_media_ctx,
             )
             if intent.progress is not None:
                 try:

--- a/services/source_of_truth/status_reconciler.py
+++ b/services/source_of_truth/status_reconciler.py
@@ -284,6 +284,55 @@ def _refresh_episode_nfo(session, placeholder: Placeholder, episode: Episode) ->
     return bool(episode_written or series_written)
 
 
+def _nfo_refresh_completion_scan_if_last_batch(
+    session,
+    job: Job,
+    *,
+    run_id: str,
+    payload_run_id_key: str,
+    log_prefix: str,
+    only_if: Any = None,
+    after_refresh: Any = None,
+) -> None:
+    """After batched NFO jobs sharing ``run_id``, refresh library sections once (Plex force=1).
+
+    ``only_if`` / ``after_refresh`` are optional hooks used by template backfill so superseded runs
+    never trigger a library refresh, and the active run clears its marker after the final batch.
+    """
+    pending_same_run = (
+        session.query(Job.id)
+        .filter(
+            Job.job_type == NFO_REFRESH_JOB_TYPE,
+            Job.status.in_(["PENDING", "CLAIMED", "WORKING"]),
+            Job.id != job.id,
+            Job.payload[payload_run_id_key].as_string() == run_id,
+        )
+        .first()
+    )
+    if pending_same_run:
+        return
+    if only_if is not None and not only_if():
+        return
+    try:
+        refresh_stats = refresh_all_sections(
+            has_movies=True,
+            has_episodes=True,
+            plex_force_metadata_refresh=True,
+        )
+        logger.info(
+            f"{log_prefix} run complete; triggered one library section refresh "
+            f"run_id={run_id} refreshed={int(refresh_stats.get('refreshed', 0) or 0)} "
+            f"failed={int(refresh_stats.get('failed', 0) or 0)}",
+            extra={"emoji_type": "success"},
+        )
+    except Exception as ex:
+        logger.warning(
+            f"{log_prefix} completion refresh failed run_id={run_id}: {ex}",
+            extra={"emoji_type": "warning"},
+        )
+    finally:
+        if after_refresh is not None:
+            after_refresh()
 
 
 def process_nfo_refresh_job(session, job: Job) -> dict:
@@ -293,6 +342,16 @@ def process_nfo_refresh_job(session, job: Job) -> dict:
     ids = [int(pid) for pid in placeholder_ids if pid is not None]
     if not ids:
         return {"ok": False, "reason": "no_placeholder_ids"}
+
+    # Large coordinated backfills (template apply-now, REQUEST NFO backfill) may be enqueued while in-process
+    # settings/messages were mid-save. Reload persisted projection settings + message templates from DB so NFO
+    # writes match committed config even if the UI/API ordering was imperfect.
+    if payload.get("template_backfill_source") or payload.get("request_backfill_run_id"):
+        from services.app_config import apply_persisted_settings
+        from services.messages import store as message_store
+
+        apply_persisted_settings()
+        message_store.reload_cache()
 
     placeholders = session.query(Placeholder).filter(Placeholder.id.in_(ids)).all()
     refreshed = 0
@@ -325,6 +384,8 @@ def process_nfo_refresh_job(session, job: Job) -> dict:
     do_player = _job_player_metadata_refresh(job)
     run_id = str(payload.get("request_backfill_run_id") or "").strip()
     completion_refresh = bool(payload.get("request_backfill_refresh_on_completion"))
+    template_run_id = str(payload.get("template_backfill_run_id") or "").strip()
+    template_completion_refresh = bool(payload.get("template_backfill_refresh_on_completion"))
     subject = _nfo_refresh_subject_summary(session, placeholders)
     subj_part = f" · {subject}" if subject else ""
     logger.debug(
@@ -358,34 +419,27 @@ def process_nfo_refresh_job(session, job: Job) -> dict:
                 extra={"emoji_type": "warning"},
             )
     elif completion_refresh and run_id:
-        pending_same_run = (
-            session.query(Job.id)
-            .filter(
-                Job.job_type == NFO_REFRESH_JOB_TYPE,
-                Job.status.in_(["PENDING", "CLAIMED", "WORKING"]),
-                Job.id != job.id,
-                Job.payload["request_backfill_run_id"].astext == run_id,
-            )
-            .first()
+        _nfo_refresh_completion_scan_if_last_batch(
+            session,
+            job,
+            run_id=run_id,
+            payload_run_id_key="request_backfill_run_id",
+            log_prefix="REQUEST NFO backfill",
         )
-        if not pending_same_run:
-            try:
-                refresh_stats = refresh_all_sections(
-                    has_movies=True,
-                    has_episodes=True,
-                    plex_force_metadata_refresh=True,
-                )
-                logger.info(
-                    "REQUEST NFO backfill run complete; triggered one library section refresh "
-                    f"run_id={run_id} refreshed={int(refresh_stats.get('refreshed', 0) or 0)} "
-                    f"failed={int(refresh_stats.get('failed', 0) or 0)}",
-                    extra={"emoji_type": "success"},
-                )
-            except Exception as ex:
-                logger.warning(
-                    f"REQUEST NFO backfill completion refresh failed run_id={run_id}: {ex}",
-                    extra={"emoji_type": "warning"},
-                )
+    elif template_completion_refresh and template_run_id:
+        from services.source_of_truth import template_backfill as template_backfill_mod
+
+        _nfo_refresh_completion_scan_if_last_batch(
+            session,
+            job,
+            run_id=template_run_id,
+            payload_run_id_key="template_backfill_run_id",
+            log_prefix="Template backfill",
+            only_if=lambda: template_backfill_mod.is_active_template_backfill_run(session, template_run_id),
+            after_refresh=lambda: template_backfill_mod.clear_active_template_backfill_run_if_matches(
+                session, template_run_id
+            ),
+        )
 
     return {
         "ok": True,

--- a/services/source_of_truth/sync_runner.py
+++ b/services/source_of_truth/sync_runner.py
@@ -771,6 +771,17 @@ def run_full_sync(
         elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
         stats['duration_seconds'] = round(elapsed, 2)
         logger.info(f"Source-of-truth fullsync complete: {stats}", extra={'emoji_type': 'success'})
+        # If the user saved Status Message changes with "Next full sync", materialize them
+        # now so existing placeholders pick up the new templates.
+        try:
+            from services.source_of_truth.template_backfill import run_pending_backfill_if_set
+            backfill = run_pending_backfill_if_set(source='full_sync')
+            stats['template_backfill'] = backfill
+        except Exception as bf_exc:
+            logger.warning(
+                f"Pending template backfill skipped after fullsync: {bf_exc}",
+                extra={'emoji_type': 'warning'},
+            )
         return stats
     except Exception as e:
         session.rollback()

--- a/services/source_of_truth/template_backfill.py
+++ b/services/source_of_truth/template_backfill.py
@@ -1,0 +1,225 @@
+"""Backfill machinery for template-config changes.
+
+When a user saves customized status messages (or wrapper / separator / case settings),
+existing placeholders may already be on disk with the old projected text in their NFOs
+and Plex/player metadata. This module wires the three apply-scope choices the Settings
+UI offers into concrete actions:
+
+- ``now``: enqueue a single ``nfo_refresh`` follow-up job covering every active
+  placeholder. Reuses the existing job pipeline so the worker rewrites NFOs and pushes
+  player metadata refreshes for each title.
+- ``next_full_sync``: set the ``PLACEHOLDER_TEMPLATE_BACKFILL_PENDING`` AppConfig flag.
+  The next full sync (scheduled or manual) consumes it via ``run_pending_backfill_if_set``.
+- ``future``: clear the pending flag (no retroactive work).
+
+The pending flag is also honored at startup as a safety net so a deploy followed by a
+sync does not silently skip the queued backfill.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func
+
+from core.logger import logger
+from services.postgres.db import get_session
+from services.postgres.models import AppConfig, Placeholder
+from services.source_of_truth.status_reconciler import enqueue_nfo_refresh
+
+
+PENDING_FLAG_KEY = "PLACEHOLDER_TEMPLATE_BACKFILL_PENDING"
+
+
+def _collect_active_placeholder_ids(session) -> list[int]:
+    """Return ids for every ``has_placeholder = true`` row, ordered ascending.
+
+    Backfill scope is "all active placeholders" in v1; per-key affected-stage filtering
+    is a future optimization.
+    """
+    rows = (
+        session.query(Placeholder.id)
+        .filter(Placeholder.has_placeholder == True)  # noqa: E712
+        .order_by(Placeholder.id.asc())
+        .all()
+    )
+    return [int(r[0]) for r in rows if r and r[0] is not None]
+
+
+def _set_pending_flag(session, pending: bool) -> None:
+    row = session.query(AppConfig).filter(AppConfig.key == PENDING_FLAG_KEY).first()
+    if row is None:
+        if pending:
+            session.add(
+                AppConfig(
+                    key=PENDING_FLAG_KEY,
+                    value=True,
+                    value_type="bool",
+                    restart_required=False,
+                    description=(
+                        "Internal flag: a Status Messages save asked for backfill on the next full sync."
+                    ),
+                )
+            )
+    else:
+        row.value = bool(pending)
+        row.value_type = "bool"
+        session.add(row)
+
+
+def _read_pending_flag(session) -> bool:
+    row = session.query(AppConfig).filter(AppConfig.key == PENDING_FLAG_KEY).first()
+    return bool(row and row.value)
+
+
+def is_template_backfill_pending() -> bool:
+    """True when a template-backfill is queued to run on the next full sync."""
+    session = get_session()
+    try:
+        return _read_pending_flag(session)
+    except Exception as exc:
+        logger.debug(f"Template backfill pending check failed: {exc}", extra={"emoji_type": "debug"})
+        return False
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+
+def mark_template_backfill_pending() -> dict[str, Any]:
+    """Persist the ``next_full_sync`` decision so subsequent syncs see the flag."""
+    session = get_session()
+    try:
+        _set_pending_flag(session, True)
+        session.commit()
+        logger.info(
+            "Template backfill scheduled for the next full sync (Status Messages save).",
+            extra={"emoji_type": "calendar"},
+        )
+        return {"ok": True, "pending": True}
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        logger.warning(f"Failed to mark template backfill pending: {exc}", extra={"emoji_type": "warning"})
+        return {"ok": False, "reason": str(exc)}
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+
+def clear_pending_template_backfill() -> dict[str, Any]:
+    """Reset the pending flag (used by ``future`` and after ``now`` runs)."""
+    session = get_session()
+    try:
+        _set_pending_flag(session, False)
+        session.commit()
+        return {"ok": True, "pending": False}
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        logger.warning(f"Failed to clear template backfill flag: {exc}", extra={"emoji_type": "warning"})
+        return {"ok": False, "reason": str(exc)}
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+
+def enqueue_template_backfill(*, source: str = "user_save") -> dict[str, Any]:
+    """Queue an NFO refresh covering every active placeholder.
+
+    Returns a small status dict describing how many placeholders were enqueued. The actual
+    NFO rewrite + projection refresh is performed asynchronously by the worker.
+    """
+    session = get_session()
+    try:
+        ids = _collect_active_placeholder_ids(session)
+        if not ids:
+            logger.info(
+                f"Template backfill ({source}): no active placeholders to refresh.",
+                extra={"emoji_type": "info"},
+            )
+            return {"ok": True, "placeholder_count": 0, "enqueued": False, "source": source}
+
+        out = enqueue_nfo_refresh(
+            ids,
+            session=session,
+            merge_into_pending=False,
+            payload_extras={
+                "template_backfill_source": source,
+                "template_backfill_started_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        if not isinstance(out, dict) or not out.get("ok"):
+            return out if isinstance(out, dict) else {"ok": False, "reason": "enqueue_failed"}
+
+        out["placeholder_count"] = len(ids)
+        out["enqueued"] = True
+        out["source"] = source
+        logger.info(
+            f"Template backfill ({source}) queued for {len(ids)} placeholders.",
+            extra={"emoji_type": "processing"},
+        )
+        return out
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        logger.warning(f"Template backfill ({source}) failed to enqueue: {exc}", extra={"emoji_type": "warning"})
+        return {"ok": False, "reason": str(exc), "source": source}
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass
+
+
+def run_pending_backfill_if_set(*, source: str = "full_sync") -> dict[str, Any]:
+    """If the pending flag is set, enqueue the backfill and clear the flag.
+
+    Called from ``run_full_sync`` (and at startup as a safety net) so user saves that
+    chose ``next_full_sync`` get materialized exactly once per scheduled / manual sync.
+    """
+    if not is_template_backfill_pending():
+        return {"ok": True, "ran": False, "reason": "no_pending_flag"}
+
+    out = enqueue_template_backfill(source=source)
+    if out.get("ok"):
+        clear_pending_template_backfill()
+        out["ran"] = True
+    else:
+        out["ran"] = False
+    return out
+
+
+def placeholder_count_for_apply_now() -> int:
+    """How many placeholders an immediate-now backfill would currently cover.
+
+    Cheap helper exposed so the Settings UI modal can show a precise number when asking
+    the user to confirm the apply-scope.
+    """
+    session = get_session()
+    try:
+        n = (
+            session.query(func.count(Placeholder.id))
+            .filter(Placeholder.has_placeholder == True)  # noqa: E712
+            .scalar()
+        )
+        return int(n or 0)
+    except Exception:
+        return 0
+    finally:
+        try:
+            session.close()
+        except Exception:
+            pass

--- a/services/source_of_truth/template_backfill.py
+++ b/services/source_of_truth/template_backfill.py
@@ -5,9 +5,10 @@ existing placeholders may already be on disk with the old projected text in thei
 and Plex/player metadata. This module wires the three apply-scope choices the Settings
 UI offers into concrete actions:
 
-- ``now``: enqueue a single ``nfo_refresh`` follow-up job covering every active
-  placeholder. Reuses the existing job pipeline so the worker rewrites NFOs and pushes
-  player metadata refreshes for each title.
+- ``now``: enqueue batched ``nfo_refresh`` jobs for every active placeholder (same as
+  REQUEST NFO backfill). The worker rewrites NFOs only; the last batch triggers one
+  library section refresh with Plex ``force=1`` so players pick up changes without
+  per-title direct projection.
 - ``next_full_sync``: set the ``PLACEHOLDER_TEMPLATE_BACKFILL_PENDING`` AppConfig flag.
   The next full sync (scheduled or manual) consumes it via ``run_pending_backfill_if_set``.
 - ``future``: clear the pending flag (no retroactive work).
@@ -18,18 +19,23 @@ sync does not silently skip the queued backfill.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import func
+from sqlalchemy import func, text
 
 from core.logger import logger
 from services.postgres.db import get_session
-from services.postgres.models import AppConfig, Placeholder
-from services.source_of_truth.status_reconciler import enqueue_nfo_refresh
+from services.postgres.models import AppConfig, Job, Placeholder
+from services.source_of_truth.status_reconciler import NFO_REFRESH_JOB_TYPE, enqueue_nfo_refresh
 
 
 PENDING_FLAG_KEY = "PLACEHOLDER_TEMPLATE_BACKFILL_PENDING"
+# Latest template_backfill_run_id allowed to trigger the one-shot library refresh (Plex force).
+# New immediate enqueue supersedes pending jobs; in-flight older batches still write NFOs but skip
+# refresh_all_sections unless AppConfig still matches their payload run id.
+ACTIVE_TEMPLATE_RUN_KEY = "PLACEHOLDER_TEMPLATE_BACKFILL_ACTIVE_RUN_ID"
 
 
 def _collect_active_placeholder_ids(session) -> list[int]:
@@ -113,6 +119,75 @@ def mark_template_backfill_pending() -> dict[str, Any]:
             pass
 
 
+def supersede_pending_template_nfo_jobs(session) -> int:
+    """Mark pending immediate template backfill ``nfo_refresh`` jobs as done without processing.
+
+    Prevents stacked full-library sweeps when the user saves ``Apply now`` repeatedly.
+    """
+    now = datetime.now(timezone.utc)
+    rows = (
+        session.query(Job)
+        .filter(
+            Job.job_type == NFO_REFRESH_JOB_TYPE,
+            Job.status == "PENDING",
+            text("(job.payload::jsonb) ? 'template_backfill_source'"),
+        )
+        .with_for_update(skip_locked=True)
+        .all()
+    )
+    for job in rows:
+        job.status = "DONE"
+        job.error_message = "superseded_by_newer_template_backfill"
+        job.updated_at = now
+        session.add(job)
+    return len(rows)
+
+
+def _set_active_template_run_id(session, run_id: str) -> None:
+    row = session.query(AppConfig).filter(AppConfig.key == ACTIVE_TEMPLATE_RUN_KEY).first()
+    if row is None:
+        session.add(
+            AppConfig(
+                key=ACTIVE_TEMPLATE_RUN_KEY,
+                value=str(run_id),
+                value_type="string",
+                restart_required=False,
+                description=(
+                    "Internal: template apply-now run id allowed to trigger the completion library refresh."
+                ),
+            )
+        )
+    else:
+        row.value = str(run_id)
+        row.value_type = "string"
+        session.add(row)
+
+
+def is_active_template_backfill_run(session, run_id: str) -> bool:
+    """True if ``run_id`` is still the authoritative immediate template backfill run."""
+    rid = str(run_id or "").strip()
+    if not rid:
+        return False
+    row = session.query(AppConfig).filter(AppConfig.key == ACTIVE_TEMPLATE_RUN_KEY).first()
+    active = str(row.value or "").strip() if row else ""
+    return bool(active) and active == rid
+
+
+def clear_active_template_backfill_run_if_matches(session, run_id: str) -> None:
+    """Clear active run marker after the completion refresh for that run (compare-and-clear)."""
+    rid = str(run_id or "").strip()
+    if not rid:
+        return
+    row = session.query(AppConfig).filter(AppConfig.key == ACTIVE_TEMPLATE_RUN_KEY).first()
+    if row is None:
+        return
+    if str(row.value or "").strip() != rid:
+        return
+    row.value = ""
+    row.value_type = "string"
+    session.add(row)
+
+
 def clear_pending_template_backfill() -> dict[str, Any]:
     """Reset the pending flag (used by ``future`` and after ``now`` runs)."""
     session = get_session()
@@ -137,26 +212,48 @@ def clear_pending_template_backfill() -> dict[str, Any]:
 def enqueue_template_backfill(*, source: str = "user_save") -> dict[str, Any]:
     """Queue an NFO refresh covering every active placeholder.
 
-    Returns a small status dict describing how many placeholders were enqueued. The actual
-    NFO rewrite + projection refresh is performed asynchronously by the worker.
+    Returns a small status dict describing how many placeholders were enqueued. The worker
+    rewrites NFOs in batches; the final batch schedules one library refresh (see
+    ``status_reconciler.process_nfo_refresh_job``), matching REQUEST NFO backfill behavior.
     """
     session = get_session()
     try:
+        superseded = supersede_pending_template_nfo_jobs(session)
+        if superseded:
+            logger.info(
+                f"Template backfill ({source}): superseded {superseded} pending nfo_refresh job(s) from a prior apply-now.",
+                extra={"emoji_type": "processing"},
+            )
+
         ids = _collect_active_placeholder_ids(session)
         if not ids:
             logger.info(
                 f"Template backfill ({source}): no active placeholders to refresh.",
                 extra={"emoji_type": "info"},
             )
-            return {"ok": True, "placeholder_count": 0, "enqueued": False, "source": source}
+            session.commit()
+            return {
+                "ok": True,
+                "placeholder_count": 0,
+                "enqueued": False,
+                "source": source,
+                "superseded_pending_jobs": superseded,
+            }
+
+        run_id = uuid.uuid4().hex
+        started = datetime.now(timezone.utc).isoformat()
+        _set_active_template_run_id(session, run_id)
 
         out = enqueue_nfo_refresh(
             ids,
             session=session,
             merge_into_pending=False,
+            player_metadata_refresh={int(pid): False for pid in ids},
             payload_extras={
                 "template_backfill_source": source,
-                "template_backfill_started_at": datetime.now(timezone.utc).isoformat(),
+                "template_backfill_started_at": started,
+                "template_backfill_run_id": run_id,
+                "template_backfill_refresh_on_completion": True,
             },
         )
         if not isinstance(out, dict) or not out.get("ok"):
@@ -165,8 +262,9 @@ def enqueue_template_backfill(*, source: str = "user_save") -> dict[str, Any]:
         out["placeholder_count"] = len(ids)
         out["enqueued"] = True
         out["source"] = source
+        out["superseded_pending_jobs"] = superseded
         logger.info(
-            f"Template backfill ({source}) queued for {len(ids)} placeholders.",
+            f"Template backfill ({source}) queued for {len(ids)} placeholders (run_id={run_id}).",
             extra={"emoji_type": "processing"},
         )
         return out

--- a/services/status_projection.py
+++ b/services/status_projection.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from core.config import settings
 
+from services.source_of_truth.status_intent import DisplayStatus
+
 
 VALID_PROJECTION_MODES = {"summary", "title", "both"}
+
+# Canonical DB/display statuses whose bracket text should resolve via ``status.label.*``
+# (plus queue-monitor synthetic ``RETRYING``). Anything else is treated as free-form text.
+_CANONICAL_DISPLAY_STATUSES: frozenset[str] = frozenset(s.value for s in DisplayStatus) | {"RETRYING"}
+
+# Legacy override keys that, when present, indicate the user customized things in the pre-
+# situation-first model. Read-compat: until they save in the new UI, projection follows
+# the legacy bracket pipeline so their existing wording stays visible.
+_LEGACY_REQUEST_OVERRIDE_KEYS: tuple[str, ...] = (
+    "bracket.format",
+    "bracket.with_runtime",
+    "status.label.REQUEST",
+    "runtime.format.hm",
+    "runtime.format.h",
+    "runtime.format.m",
+)
+_LEGACY_REASON_OVERRIDE_KEYS: tuple[str, ...] = ("bracket.format",)
 
 
 def get_projection_mode() -> str:
@@ -70,24 +90,122 @@ def format_duration_label(minutes: int) -> str:
     """Human-readable duration from whole minutes (e.g. 45m, 1h, 1h 5m)."""
     if minutes <= 0:
         return ""
+
+    # Defer to the customizable template engine so users can localize duration formatting.
+    from services.messages import render
+
     if minutes < 60:
-        return f"{minutes}m"
+        return render("runtime.format.m", {"Minutes": str(minutes)})
     h, m = divmod(minutes, 60)
     if m == 0:
-        return f"{h}h"
-    return f"{h}h {m}m"
+        return render("runtime.format.h", {"Hours": str(h)})
+    return render("runtime.format.hm", {"Hours": str(h), "Minutes": str(m)})
+
+
+def _bracket_context_for_status(clean_status: str, runtime_minutes: int | None) -> dict[str, Any]:
+    """Context for legacy ``bracket.format`` / ``bracket.with_runtime`` rendering.
+
+    Canonical enum values use ``__status_enum__`` so ``{Status}`` resolves through the user's
+    ``status.label.<ENUM>`` templates. Free-form strings (import-grace lines, queue reason text)
+    pass ``Status`` literally.
+    """
+    text = str(clean_status or "").strip()
+    if not text:
+        return {}
+
+    upper = text.upper()
+    if upper not in _CANONICAL_DISPLAY_STATUSES:
+        return {"Status": text}
+
+    ctx: dict[str, Any] = {"__status_enum__": upper}
+
+    if upper == "REQUEST" and runtime_minutes is not None:
+        rm = _rounded_minutes(runtime_minutes)
+        if rm > 0:
+            duration = format_duration_label(rm)
+            if duration:
+                ctx["Runtime"] = duration
+
+    return ctx
+
+
+def _has_legacy_overrides(overrides: dict[str, Any], keys: tuple[str, ...]) -> bool:
+    """True when at least one of ``keys`` has a non-empty saved override."""
+    if not isinstance(overrides, dict):
+        return False
+    for k in keys:
+        v = overrides.get(k)
+        if isinstance(v, str) and v.strip():
+            return True
+    return False
+
+
+def _request_inner_line(runtime_minutes: int | None) -> str:
+    """Render the situation-first ``line.request`` inner text for REQUEST placeholders."""
+    from services.messages import render
+
+    ctx: dict[str, Any] = {}
+    if runtime_minutes is not None:
+        rm = _rounded_minutes(runtime_minutes)
+        if rm > 0:
+            duration = format_duration_label(rm)
+            if duration:
+                ctx["Runtime"] = duration
+    return render("line.request", ctx)
 
 
 def _summary_status_bracket(clean_status: str, runtime_minutes: int | None) -> str:
-    """Build [REQUEST] or [1h 5m · REQUEST] when runtime is known (REQUEST only)."""
-    status_upper = clean_status.upper()
-    if status_upper == "REQUEST" and runtime_minutes is not None:
-        rm = _rounded_minutes(runtime_minutes)
-        if rm > 0:
-            dur = format_duration_label(rm)
-            if dur:
-                return f"[{dur} · {clean_status}]"
-    return f"[{clean_status}]"
+    """Build the wrapped status text shown in Plex/NFO summaries.
+
+    Pipeline (situation-first): render an inner line per situation, then apply the
+    global wrapper preset (``[ ]`` by default) post-render.
+
+    Read-compat: when the user customized the legacy bracket templates and has not yet
+    saved a value through the new UI, fall back to the legacy bracket renderer that
+    bakes its own brackets in via the saved override. ``status.label.*`` overrides
+    keep working for canonical non-REQUEST stages because they resolve via the
+    engine when we render the inner word.
+    """
+    from services.messages import apply_wrapper, render
+    from services.messages.store import get_overrides
+    from services.messages.template_engine import UnknownTemplateKeyError
+
+    text = str(clean_status or "").strip()
+    if not text:
+        return ""
+
+    upper = text.upper()
+    overrides = get_overrides()
+
+    if upper == "REQUEST":
+        if not overrides.get("line.request") and _has_legacy_overrides(overrides, _LEGACY_REQUEST_OVERRIDE_KEYS):
+            ctx = _bracket_context_for_status(text, runtime_minutes)
+            if ctx.get("Runtime"):
+                return render("bracket.with_runtime", ctx)
+            return render("bracket.format", ctx)
+        inner = _request_inner_line(runtime_minutes)
+        return apply_wrapper(inner)
+
+    if upper in _CANONICAL_DISPLAY_STATUSES:
+        # Legacy bracket override always wins (read-compat for users who customized shape).
+        if _has_legacy_overrides(overrides, _LEGACY_REASON_OVERRIDE_KEYS):
+            ctx = _bracket_context_for_status(text, runtime_minutes)
+            return render("bracket.format", ctx)
+        # New path: resolve the canonical word via ``status.label.*`` so hidden customizations
+        # (kept for read-compat) still affect on-screen text, then wrap globally.
+        try:
+            inner = render(f"status.label.{upper}", {})
+        except UnknownTemplateKeyError:
+            inner = text
+        return apply_wrapper(inner)
+
+    if _has_legacy_overrides(overrides, _LEGACY_REASON_OVERRIDE_KEYS):
+        ctx = _bracket_context_for_status(text, runtime_minutes)
+        if not ctx:
+            return ""
+        return render("bracket.format", ctx)
+
+    return apply_wrapper(text)
 
 
 def projected_status_display(
@@ -128,7 +246,14 @@ def project_title(title: str | None, status: str | None) -> str:
     clean_status = str(status or "").strip()
     if not clean_status or not should_project_status(clean_status) or get_projection_mode() not in {"title", "both"}:
         return clean_title
-    return f"{clean_title} - [{clean_status}]".strip()
+
+    from services.messages import render
+
+    bracket = _summary_status_bracket(clean_status, None)
+    return render(
+        "title.suffix.format",
+        {"Title": clean_title, "Bracket": bracket},
+    ).strip()
 
 
 def project_summary(

--- a/services/status_projection.py
+++ b/services/status_projection.py
@@ -5,27 +5,8 @@ from typing import Any
 
 from core.config import settings
 
-from services.source_of_truth.status_intent import DisplayStatus
-
 
 VALID_PROJECTION_MODES = {"summary", "title", "both"}
-
-# Canonical DB/display statuses whose bracket text should resolve via ``status.label.*``
-# (plus queue-monitor synthetic ``RETRYING``). Anything else is treated as free-form text.
-_CANONICAL_DISPLAY_STATUSES: frozenset[str] = frozenset(s.value for s in DisplayStatus) | {"RETRYING"}
-
-# Legacy override keys that, when present, indicate the user customized things in the pre-
-# situation-first model. Read-compat: until they save in the new UI, projection follows
-# the legacy bracket pipeline so their existing wording stays visible.
-_LEGACY_REQUEST_OVERRIDE_KEYS: tuple[str, ...] = (
-    "bracket.format",
-    "bracket.with_runtime",
-    "status.label.REQUEST",
-    "runtime.format.hm",
-    "runtime.format.h",
-    "runtime.format.m",
-)
-_LEGACY_REASON_OVERRIDE_KEYS: tuple[str, ...] = ("bracket.format",)
 
 
 def get_projection_mode() -> str:
@@ -35,6 +16,16 @@ def get_projection_mode() -> str:
     if raw in VALID_PROJECTION_MODES:
         return raw
     return "summary"
+
+
+def projection_surfaces() -> tuple[bool, bool]:
+    """Return (apply_status_to_title, apply_status_to_summary) from projection mode."""
+    mode = get_projection_mode()
+    if mode == "title":
+        return (True, False)
+    if mode == "both":
+        return (True, True)
+    return (False, True)
 
 
 def _updates_scope() -> str:
@@ -62,8 +53,11 @@ def strip_status_from_title(title: str | None) -> str:
     while text != previous:
         previous = text
         text = re.sub(r"^\[[^\]]+\]\s*", "", text).strip()
+        text = re.sub(r"^\<[^>]+\>\s*", "", text).strip()
         text = re.sub(r"\s*-\s*\[[^\]]+\]\s*$", "", text).strip()
+        text = re.sub(r"\s*-\s*\<[^>]+\>\s*$", "", text).strip()
         text = re.sub(r"\s*\[[^\]]+\]\s*$", "", text).strip()
+        text = re.sub(r"\s*\<[^>]+\>\s*$", "", text).strip()
 
     return re.sub(r"\s+", " ", text).strip()
 
@@ -74,6 +68,7 @@ def strip_status_from_summary(summary: str | None) -> str:
     # Legacy: "~45m · " before "[REQUEST]" (older NFO / summaries)
     text = re.sub(r"^~(?:\d+h(?:\s+\d+m)?|\d+m)\s*·\s*", "", text, flags=re.IGNORECASE)
     text = re.sub(r"^\[[^\]]+\]\s*", "", text).strip()
+    text = re.sub(r"^\<[^>]+\>\s*", "", text).strip()
     return text
 
 
@@ -102,108 +97,32 @@ def format_duration_label(minutes: int) -> str:
     return render("runtime.format.hm", {"Hours": str(h), "Minutes": str(m)})
 
 
-def _bracket_context_for_status(clean_status: str, runtime_minutes: int | None) -> dict[str, Any]:
-    """Context for legacy ``bracket.format`` / ``bracket.with_runtime`` rendering.
+def _summary_status_bracket(
+    clean_status: str,
+    runtime_minutes: int | None,
+    media_context: dict[str, Any] | None = None,
+    *,
+    for_title_surface: bool = False,
+) -> str:
+    """Build the wrapped status bracket for synopsis or title surfaces.
 
-    Canonical enum values use ``__status_enum__`` so ``{Status}`` resolves through the user's
-    ``status.label.<ENUM>`` templates. Free-form strings (import-grace lines, queue reason text)
-    pass ``Status`` literally.
-    """
-    text = str(clean_status or "").strip()
-    if not text:
-        return {}
-
-    upper = text.upper()
-    if upper not in _CANONICAL_DISPLAY_STATUSES:
-        return {"Status": text}
-
-    ctx: dict[str, Any] = {"__status_enum__": upper}
-
-    if upper == "REQUEST" and runtime_minutes is not None:
-        rm = _rounded_minutes(runtime_minutes)
-        if rm > 0:
-            duration = format_duration_label(rm)
-            if duration:
-                ctx["Runtime"] = duration
-
-    return ctx
-
-
-def _has_legacy_overrides(overrides: dict[str, Any], keys: tuple[str, ...]) -> bool:
-    """True when at least one of ``keys`` has a non-empty saved override."""
-    if not isinstance(overrides, dict):
-        return False
-    for k in keys:
-        v = overrides.get(k)
-        if isinstance(v, str) and v.strip():
-            return True
-    return False
-
-
-def _request_inner_line(runtime_minutes: int | None) -> str:
-    """Render the situation-first ``line.request`` inner text for REQUEST placeholders."""
-    from services.messages import render
-
-    ctx: dict[str, Any] = {}
-    if runtime_minutes is not None:
-        rm = _rounded_minutes(runtime_minutes)
-        if rm > 0:
-            duration = format_duration_label(rm)
-            if duration:
-                ctx["Runtime"] = duration
-    return render("line.request", ctx)
-
-
-def _summary_status_bracket(clean_status: str, runtime_minutes: int | None) -> str:
-    """Build the wrapped status text shown in Plex/NFO summaries.
+    REQUEST placeholders use ``line.request`` for both synopsis and title surfaces.
 
     Pipeline (situation-first): render an inner line per situation, then apply the
     global wrapper preset (``[ ]`` by default) post-render.
-
-    Read-compat: when the user customized the legacy bracket templates and has not yet
-    saved a value through the new UI, fall back to the legacy bracket renderer that
-    bakes its own brackets in via the saved override. ``status.label.*`` overrides
-    keep working for canonical non-REQUEST stages because they resolve via the
-    engine when we render the inner word.
     """
-    from services.messages import apply_wrapper, render
-    from services.messages.store import get_overrides
-    from services.messages.template_engine import UnknownTemplateKeyError
+    from services.messages import apply_wrapper
+    from services.messages.request_line_render import request_inner_line_synopsis
 
     text = str(clean_status or "").strip()
     if not text:
         return ""
 
     upper = text.upper()
-    overrides = get_overrides()
 
     if upper == "REQUEST":
-        if not overrides.get("line.request") and _has_legacy_overrides(overrides, _LEGACY_REQUEST_OVERRIDE_KEYS):
-            ctx = _bracket_context_for_status(text, runtime_minutes)
-            if ctx.get("Runtime"):
-                return render("bracket.with_runtime", ctx)
-            return render("bracket.format", ctx)
-        inner = _request_inner_line(runtime_minutes)
+        inner = request_inner_line_synopsis(runtime_minutes, media_context)
         return apply_wrapper(inner)
-
-    if upper in _CANONICAL_DISPLAY_STATUSES:
-        # Legacy bracket override always wins (read-compat for users who customized shape).
-        if _has_legacy_overrides(overrides, _LEGACY_REASON_OVERRIDE_KEYS):
-            ctx = _bracket_context_for_status(text, runtime_minutes)
-            return render("bracket.format", ctx)
-        # New path: resolve the canonical word via ``status.label.*`` so hidden customizations
-        # (kept for read-compat) still affect on-screen text, then wrap globally.
-        try:
-            inner = render(f"status.label.{upper}", {})
-        except UnknownTemplateKeyError:
-            inner = text
-        return apply_wrapper(inner)
-
-    if _has_legacy_overrides(overrides, _LEGACY_REASON_OVERRIDE_KEYS):
-        ctx = _bracket_context_for_status(text, runtime_minutes)
-        if not ctx:
-            return ""
-        return render("bracket.format", ctx)
 
     return apply_wrapper(text)
 
@@ -213,6 +132,7 @@ def projected_status_display(
     *,
     reason: str | None = None,
     runtime_minutes: int | None = None,
+    media_context: dict[str, Any] | None = None,
 ) -> str | None:
     """Return persisted user-facing status label for display surfaces."""
     raw_status = str(status or "").strip()
@@ -237,23 +157,32 @@ def projected_status_display(
 
     eff_upper = str(effective).strip().upper()
     if eff_upper == "REQUEST":
-        return _summary_status_bracket("REQUEST", runtime_minutes)
+        # Single stored snapshot: synopsis-style bracket (what dashboards treat as canonical).
+        return _summary_status_bracket("REQUEST", runtime_minutes, media_context, for_title_surface=False)
     return str(effective).strip() or None
 
 
-def project_title(title: str | None, status: str | None) -> str:
+def project_title(
+    title: str | None,
+    status: str | None,
+    *,
+    suffix_template_key: str = "title.suffix.movie",
+    runtime_minutes: int | None = None,
+    media_context: dict[str, Any] | None = None,
+) -> str:
     clean_title = strip_status_from_title(title)
     clean_status = str(status or "").strip()
-    if not clean_status or not should_project_status(clean_status) or get_projection_mode() not in {"title", "both"}:
+    _title_on, _sum_on = projection_surfaces()
+    if not clean_status or not should_project_status(clean_status) or not _title_on:
         return clean_title
 
     from services.messages import render
 
-    bracket = _summary_status_bracket(clean_status, None)
-    return render(
-        "title.suffix.format",
-        {"Title": clean_title, "Bracket": bracket},
-    ).strip()
+    suffix = render(suffix_template_key, dict(media_context or {}))
+    if not suffix.strip():
+        return clean_title
+    normalized_suffix = suffix if suffix[:1].isspace() else f" {suffix}"
+    return f"{clean_title}{normalized_suffix}".strip()
 
 
 def project_summary(
@@ -261,10 +190,14 @@ def project_summary(
     status: str | None,
     *,
     runtime_minutes: int | None = None,
+    media_context: dict[str, Any] | None = None,
 ) -> str:
     clean_summary = strip_status_from_summary(summary)
     clean_status = str(status or "").strip()
-    if not clean_status or not should_project_status(clean_status) or get_projection_mode() not in {"summary", "both"}:
+    _title_on, _sum_on = projection_surfaces()
+    if not clean_status or not should_project_status(clean_status) or not _sum_on:
         return clean_summary
-    bracket = _summary_status_bracket(clean_status, runtime_minutes)
+    bracket = _summary_status_bracket(
+        clean_status, runtime_minutes, media_context, for_title_surface=False
+    )
     return f"{bracket} {clean_summary}".strip()


### PR DESCRIPTION
feat: Implement customizable status message templates and rendering engine

- Added persistence layer for status message templates in store.py, allowing for configuration of separators, case options, and message overrides.
- Introduced a template engine in template_engine.py to render messages with dynamic placeholders, supporting various formatting options and token resolution.
- Created backfill machinery in template_backfill.py to handle updates to existing placeholders when template configurations change, ensuring metadata consistency across the application.