### PR TITLE
Update version to 0.9.11 and document new features and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
-## [0.9.10] - 2026-05-16
+## [0.9.11] - 2026-05-18
 
 ### Added
 
@@ -63,18 +63,39 @@ Operators: job NOTIFY uses modern Postgres trigger syntax; **Postgres 11+** is r
 ### Calendar and status
 
 - **Scope:** `run_calendar_phase` uses a release-date window (with TBA / coming-soon handling) instead of scanning all on-disk placeholders; **`CALENDAR_PHASE_BATCH_SIZE`** commits per batch with per-chunk logging and `chunks_committed` in stats.
-- **Library “Future”:** filters and `/api/stats` align with `CALENDAR_LOOKAHEAD_DAYS` / determination; policy-only `not_needed` (e.g. filtered specials) no longer count as Future.
-
-### Webhooks, backfill, and projection
-
-- **Webhooks:** `Grab` treated as informational; `movie_imported` aligns with `movie_added` and can self-heal missing rows from Radarr.
-- **REQUEST backfill:** bulk NFO-only mode; run-tagged jobs; isolated enqueue; completion triggers one `movies + episodes` refresh; Plex `force=1` on that completion refresh.
-- **Display:** `placeholder.display_status_projected` for persisted user-facing status text (including REQUEST runtime-in-bracket formatting).
 
 ### Reliability fixes
 
 - **Plex metadata:** skip heavy `find_movie_by_id` when the expected placeholder file is missing on disk.
-- **Webhooks:** `_upsert_movie` / `_upsert_episode` flush immediately after insert so `movie_id` is valid before `process_movie_add_event` uses it.
+
+## [0.9.10] - 2026-05-05
+
+### Changed
+
+- **Radarr/Sonarr webhooks**: `Grab` is recognized as informational (`movie_grab` / `episode_grab`) and skipped without warnings; `movie_imported` uses the same ARR instance resolution as `movie_added` and can **self-heal** by upserting from the Radarr API when the DB row is missing (e.g. after a failed `MovieAdded` job).
+- **Library "Future" matches calendar lookahead (not plain `not_needed`)**
+  - Movies/TV library filters and `/api/stats` "future outside lookahead" use the same air/release date vs `CALENDAR_LOOKAHEAD_DAYS` rules as `_compute_determination`. Policy-only `not_needed` rows (e.g. season 0 specials when `INCLUDE_SPECIALS` is false) no longer count as Future.
+- **REQUEST NFO backfill now runs in bulk NFO-only mode**
+  - Startup REQUEST backfill enqueues `nfo_refresh` jobs with direct player projection disabled so large libraries are not bottlenecked by per-item Plex/Jellyfin/Emby metadata writes during catch-up.
+- **Backfill completion now triggers one library refresh**
+  - Backfill jobs are tagged with a run id; when the last job in that run completes, the app triggers a single section refresh (`movies + episodes`) so players pick up updated NFO text in one pass.
+- **Backfill queue isolation**
+  - REQUEST backfill enqueues with pending-job merge disabled to avoid inheriting older mixed payloads and to keep backfill behavior deterministic.
+- **Persisted projected display status in DB**
+  - Added `placeholder.display_status_projected` so the user-facing status text is stored persistently (including REQUEST runtime bracket text like `[1h 43m · REQUEST]`) whenever status is written by orchestrator/materializer/import-grace paths.
+- **Plex force metadata refresh for REQUEST backfill completion**
+  - The one-time REQUEST NFO backfill completion refresh now calls Plex section refresh with `force=1` so existing library items are re-read for metadata changes from NFOs; normal status update paths continue to use direct projection behavior.
+- **Docker**: example compose sets `PUID`/`PGID` and bind mounts for appdata plus a placeholder/media root; startup entrypoint `chown`s `/config` and `/app`, then runs the app non-root via `setpriv`.
+
+### Documentation
+
+- **README**: Plex playback automation typically uses **Tautulli** (or similar) with Placeholdarr’s webhook URL.
+
+### Fixed
+
+- **`movie_added` webhook crash on first-time movie ingest (`int(None)`)**
+  - New `Movie` rows from `_upsert_movie` had no database primary key until a later `flush`, but `process_movie_add_event` called `_sync_linked_placeholder_presence(..., movie_id=int(movie_row.id), ...)` first — so brand-new titles (no prior DB row) raised `TypeError` and left `movie_imported` follow-ups without a catalog row.
+  - `_upsert_movie` and `_upsert_episode` now `flush()` immediately after inserting a new row (aligned with `_upsert_series` / `_upsert_season`) so `.id` is valid before any code reads it.
 
 ## [0.9.9] - 2026-04-30
 


### PR DESCRIPTION
Increment the version to 0.9.11 and provide documentation for new features and reliability fixes introduced since the last release. This includes enhancements to webhooks, backfill processes, and improved handling of metadata.