### PR TITLE
fix(webhook): require a dedicated API key on POST /webhook

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7002,6 +7002,7 @@ function SecurityAccountControls(props: {
   accentHex: string;
   onLogout: () => Promise<void>;
   webhookApiKey: string;
+  onWebhookApiKeyChange: (key: string) => void;
 }) {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -7027,6 +7028,12 @@ function SecurityAccountControls(props: {
     try {
       const result = await regenerateWebhookApiKey();
       setWebhookKey(result.webhook_api_key);
+      // Propagate into fieldValues so buildArrInstanceWebhookUrls/
+      // PlaybackWebhookSetupModal show the new key immediately, without
+      // needing a full settings reload. WEBHOOK_API_KEY isn't a real
+      // SETTINGS_SCHEMA field (see settingsValuesDirty), so this can't
+      // spuriously trip the unsaved-changes warning.
+      props.onWebhookApiKeyChange(result.webhook_api_key);
       setWebhookKeyRevealed(true);
       setWebhookRegenConfirming(false);
       setWebhookRegenMessage("Webhook key regenerated. Update the URL in every Radarr/Sonarr/Tautulli/Jellyfin/Emby webhook.");
@@ -7536,6 +7543,7 @@ function SettingsPanel(props: {
                   accentHex={accent.hex}
                   onLogout={props.onLogout}
                   webhookApiKey={resolveWebhookApiKey(props.values)}
+                  onWebhookApiKeyChange={(key) => props.onValueChange("WEBHOOK_API_KEY", key)}
                 />
               ) : null}
               {active.name === "Paths" ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1398,6 +1398,10 @@ export function App() {
         nextValues[field.key] = field.value;
       });
     });
+    // Not a settings field — read-only, used only by the webhook-URL builders
+    // below (resolveWebhookApiKey). See services/auth.py's
+    // ensure_webhook_api_key() for where this comes from.
+    nextValues.WEBHOOK_API_KEY = payload.webhook_api_key ?? "";
 
     setFieldValues(nextValues);
     setBaselineValues(nextValues);
@@ -5237,11 +5241,24 @@ function resolveWebhookDisplayOrigin(values: FieldValueMap): string {
   return typeof window !== "undefined" ? window.location.origin : "";
 }
 
-function buildArrInstanceWebhookUrls(origin: string, instance_id: string, instance_key: string) {
+/** /webhook requires ?apikey= (see services/auth.py's verify_webhook_api_key) —
+ * read from the same values map the settings payload already populates it
+ * into (App.tsx's loadSettings), so no separate fetch/prop-threading is needed. */
+function resolveWebhookApiKey(values: FieldValueMap): string {
+  return String(values.WEBHOOK_API_KEY ?? "").trim();
+}
+
+function appendWebhookApiKey(url: string, apiKey: string): string {
+  if (!url || !apiKey) return url;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}apikey=${encodeURIComponent(apiKey)}`;
+}
+
+function buildArrInstanceWebhookUrls(origin: string, instance_id: string, instance_key: string, apiKey: string) {
   const id = String(instance_id || "").trim().toLowerCase();
   const key = normalizeInstanceKey(String(instance_key || ""));
-  const byId = id ? `${origin}/webhook?instance_id=${encodeURIComponent(id)}` : "";
-  const byKey = `${origin}/webhook?instance=${encodeURIComponent(key)}`;
+  const byId = id ? appendWebhookApiKey(`${origin}/webhook?instance_id=${encodeURIComponent(id)}`, apiKey) : "";
+  const byKey = appendWebhookApiKey(`${origin}/webhook?instance=${encodeURIComponent(key)}`, apiKey);
   const uuidLike = id.length > 0 && arrInstanceIdEmbedsUuid(id);
   const primary = id ? byId : byKey;
   return { primary, byId: id ? byId : "", byKey, uuidLike };
@@ -5839,7 +5856,8 @@ function ArrInstancesEditor(props: {
 
   function instanceWebhookUrls(instance_id: string, instance_key: string) {
     const origin = resolveWebhookDisplayOrigin(props.values);
-    return buildArrInstanceWebhookUrls(origin, instance_id, instance_key);
+    const apiKey = resolveWebhookApiKey(props.values);
+    return buildArrInstanceWebhookUrls(origin, instance_id, instance_key, apiKey);
   }
 
   function onSlotPanelSaveClick() {
@@ -7872,6 +7890,7 @@ function SettingsPanel(props: {
         onClose={() => setPlaybackWebhookDialog(null)}
         accent={accent}
         displayOrigin={resolveWebhookDisplayOrigin(props.values)}
+        webhookApiKey={resolveWebhookApiKey(props.values)}
       />
     ) : null}
     </>
@@ -9304,9 +9323,13 @@ function PlaybackWebhookSetupModal(props: {
   onClose: () => void;
   accent: { hex: string };
   displayOrigin: string;
+  webhookApiKey: string;
 }) {
   const pb = props.dialog;
-  const webhookUrl = `${props.displayOrigin}/webhook?instance=${encodeURIComponent(pb.instanceParam)}`;
+  const webhookUrl = appendWebhookApiKey(
+    `${props.displayOrigin}/webhook?instance=${encodeURIComponent(pb.instanceParam)}`,
+    props.webhookApiKey,
+  );
   const svcMeta = PLAYBACK_WEBHOOK_SERVICES.services.find((s) => s.id === pb.serviceId);
   const name = svcMeta?.name ?? pb.serviceId;
   return (
@@ -10681,6 +10704,7 @@ function OnboardingWizard(props: {
           onClose={() => setPlaybackWebhookDialog(null)}
           accent={accent}
           displayOrigin={resolveWebhookDisplayOrigin(props.values)}
+          webhookApiKey={resolveWebhookApiKey(props.values)}
         />
       ) : null}
     </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ import {
 } from "./api/dashboard";
 import { postTaskRun } from "./api/tasks";
 import { fetchJson, postJson, setUnauthorizedHandler, getCsrfToken } from "./api/client";
-import { changePassword, getAuthStatus, logoutAuth, type AuthStatus } from "./api/auth";
+import { changePassword, getAuthStatus, logoutAuth, regenerateWebhookApiKey, type AuthStatus } from "./api/auth";
 import { AuthGate } from "./auth/AuthGate";
 import embyIcon from "./assets/services/emby.svg";
 import jellyfinIcon from "./assets/services/jellyfin.svg";
@@ -7001,6 +7001,7 @@ function SecurityAccountControls(props: {
   authStatus: AuthStatus | null;
   accentHex: string;
   onLogout: () => Promise<void>;
+  webhookApiKey: string;
 }) {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -7010,6 +7011,31 @@ function SecurityAccountControls(props: {
   const [error, setError] = useState<string | null>(null);
   const mode = props.authStatus?.mode || "builtin";
   const username = props.authStatus?.username;
+
+  const [webhookKey, setWebhookKey] = useState(props.webhookApiKey);
+  useEffect(() => setWebhookKey(props.webhookApiKey), [props.webhookApiKey]);
+  const [webhookKeyRevealed, setWebhookKeyRevealed] = useState(false);
+  const [webhookRegenConfirming, setWebhookRegenConfirming] = useState(false);
+  const [webhookRegenBusy, setWebhookRegenBusy] = useState(false);
+  const [webhookRegenMessage, setWebhookRegenMessage] = useState<string | null>(null);
+  const [webhookRegenError, setWebhookRegenError] = useState<string | null>(null);
+
+  async function onRegenerateWebhookKey() {
+    setWebhookRegenBusy(true);
+    setWebhookRegenError(null);
+    setWebhookRegenMessage(null);
+    try {
+      const result = await regenerateWebhookApiKey();
+      setWebhookKey(result.webhook_api_key);
+      setWebhookKeyRevealed(true);
+      setWebhookRegenConfirming(false);
+      setWebhookRegenMessage("Webhook key regenerated. Update the URL in every Radarr/Sonarr/Tautulli/Jellyfin/Emby webhook.");
+    } catch (err) {
+      setWebhookRegenError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWebhookRegenBusy(false);
+    }
+  }
 
   async function onChangePassword(event: FormEvent) {
     event.preventDefault();
@@ -7049,6 +7075,64 @@ function SecurityAccountControls(props: {
                 : "Admin account"}
         </p>
       </div>
+      {mode !== "disabled" ? (
+        <div className="max-w-md space-y-2">
+          <p className="text-[14px] text-slate-400">Webhook API key</p>
+          <p className="ui-field-description text-slate-400">
+            Required as <code>?apikey=</code> on every Radarr/Sonarr/Tautulli/Jellyfin/Emby webhook URL — those services
+            aren&apos;t browser sessions and can&apos;t log in, so this is a separate credential just for them. Already
+            included automatically in the webhook URLs shown during setup.
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate rounded-lg border border-[#424753]/40 bg-[#0b111b] px-3 py-2 font-mono text-[13px] text-slate-200">
+              {webhookKeyRevealed ? webhookKey || "(none yet)" : "•".repeat(Math.min(40, webhookKey.length || 40))}
+            </span>
+            <button
+              type="button"
+              className="shrink-0 px-3 py-2 rounded-lg text-[13px] border border-[#424753]/55 text-slate-300 hover:bg-[#252e3a]/80"
+              onClick={() => setWebhookKeyRevealed((v) => !v)}
+            >
+              {webhookKeyRevealed ? "Hide" : "Reveal"}
+            </button>
+          </div>
+          {!webhookRegenConfirming ? (
+            <button
+              type="button"
+              className="px-4 py-2 rounded-lg text-[13px] font-headline uppercase tracking-wider border border-[#424753]/55 text-slate-300 hover:bg-[#252e3a]/80"
+              onClick={() => setWebhookRegenConfirming(true)}
+            >
+              Regenerate
+            </button>
+          ) : (
+            <div className="space-y-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+              <p className="text-[13px] text-amber-200">
+                This immediately invalidates the current key. Every already-configured Radarr/Sonarr/Tautulli/Jellyfin/Emby
+                webhook will start failing until you re-paste the updated URL from onboarding/settings into each of them.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={webhookRegenBusy}
+                  className="px-3 py-1.5 rounded-md text-[13px] bg-amber-600 text-white hover:bg-amber-500 disabled:opacity-50"
+                  onClick={() => void onRegenerateWebhookKey()}
+                >
+                  {webhookRegenBusy ? "Regenerating…" : "Yes, regenerate"}
+                </button>
+                <button
+                  type="button"
+                  disabled={webhookRegenBusy}
+                  className="px-3 py-1.5 rounded-md text-[13px] border border-[#424753]/55 text-slate-300 hover:bg-[#252e3a]/80"
+                  onClick={() => setWebhookRegenConfirming(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+          {webhookRegenError ? <p className="text-[14px] text-red-400">{webhookRegenError}</p> : null}
+          {webhookRegenMessage ? <p className="text-[14px] text-emerald-400">{webhookRegenMessage}</p> : null}
+        </div>
+      ) : null}
       {mode === "builtin" ? (
         <form onSubmit={(e) => void onChangePassword(e)} className="space-y-3 max-w-md">
           <p className="text-[14px] text-slate-400">Change password</p>
@@ -7451,6 +7535,7 @@ function SettingsPanel(props: {
                   authStatus={props.authStatus}
                   accentHex={accent.hex}
                   onLogout={props.onLogout}
+                  webhookApiKey={resolveWebhookApiKey(props.values)}
                 />
               ) : null}
               {active.name === "Paths" ? (

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -46,3 +46,11 @@ export async function changePassword(currentPassword: string, newPassword: strin
     new_password: newPassword,
   });
 }
+
+export async function getWebhookApiKey(): Promise<{ webhook_api_key: string | null }> {
+  return fetchJson<{ webhook_api_key: string | null }>("/api/auth/webhook-key");
+}
+
+export async function regenerateWebhookApiKey(): Promise<{ webhook_api_key: string }> {
+  return postJson<{ webhook_api_key: string }>("/api/auth/webhook-key/regenerate");
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -471,6 +471,8 @@ export interface SettingsStatus {
 export interface SettingsPayload {
   status: SettingsStatus;
   sections: SettingsSection[];
+  /** Not a settings field — read-only, used to display the webhook URLs Radarr/Sonarr/etc. need. */
+  webhook_api_key?: string | null;
 }
 
 export interface SaveSettingsResponse {

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import signal
 import subprocess
 import time
@@ -577,9 +578,14 @@ async def webhook(request: Request, background_tasks: BackgroundTasks):
         if get_auth_mode() != "disabled":
             provided_key = request.query_params.get("apikey")
             if not verify_webhook_api_key(provided_key):
+                # ?instance= is attacker-controlled and unvalidated at this point —
+                # allowlist-sanitize before it goes into a log line so a value
+                # like "x\n[INFO] forged log entry" can't inject fake log records.
+                raw_instance = request.query_params.get('instance', '')
+                safe_instance = re.sub(r'[^A-Za-z0-9_-]', '', raw_instance)[:64] or 'unknown'
                 logger.warning(
                     "Webhook rejected: missing or invalid apikey "
-                    f"instance={request.query_params.get('instance', '').strip() or 'unknown'} "
+                    f"instance={safe_instance} "
                     f"present={'yes' if provided_key else 'no'}",
                     extra={'emoji_type': 'warning'},
                 )

--- a/main.py
+++ b/main.py
@@ -577,6 +577,12 @@ async def webhook(request: Request, background_tasks: BackgroundTasks):
         if get_auth_mode() != "disabled":
             provided_key = request.query_params.get("apikey")
             if not verify_webhook_api_key(provided_key):
+                logger.warning(
+                    "Webhook rejected: missing or invalid apikey "
+                    f"instance={request.query_params.get('instance', '').strip() or 'unknown'} "
+                    f"present={'yes' if provided_key else 'no'}",
+                    extra={'emoji_type': 'warning'},
+                )
                 raise HTTPException(status_code=401, detail="Invalid or missing apikey")
 
         payload = await request.json()

--- a/main.py
+++ b/main.py
@@ -567,6 +567,18 @@ app.add_middleware(
 @app.post("/webhook")
 async def webhook(request: Request, background_tasks: BackgroundTasks):
     try:
+        from services.auth import get_auth_mode, verify_webhook_api_key
+
+        # /webhook is exempt from the cookie/CSRF checks in AuthGateMiddleware
+        # (Radarr/Sonarr/Tautulli/Jellyfin/Emby aren't browser sessions and
+        # can't log in) — it needs its own, independent credential instead.
+        # Skipped only in AUTH_MODE=disabled, matching that mode's explicit
+        # "no login checks anywhere" intent.
+        if get_auth_mode() != "disabled":
+            provided_key = request.query_params.get("apikey")
+            if not verify_webhook_api_key(provided_key):
+                raise HTTPException(status_code=401, detail="Invalid or missing apikey")
+
         payload = await request.json()
         instance_raw = request.query_params.get("instance", "").strip() or None
         instance_id_raw = request.query_params.get("instance_id", "").strip() or None

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -96,3 +96,26 @@ async def auth_change_password(request: Request, body: ChangePasswordBody):
     except ValueError as exc:
         return auth_svc.json_error(400, str(exc))
     return {"ok": True, "message": "password updated"}
+
+
+@router.get("/webhook-key")
+async def auth_webhook_key(request: Request):
+    # Not allowlisted, so AuthGateMiddleware already required a valid
+    # session to reach here.
+    user, _source = auth_svc.resolve_request_identity(request)
+    if not user:
+        return auth_svc.json_error(401, "authentication required")
+    return {"webhook_api_key": auth_svc.ensure_webhook_api_key()}
+
+
+@router.post("/webhook-key/regenerate")
+async def auth_webhook_key_regenerate(request: Request):
+    # Rotating this breaks every already-configured Radarr/Sonarr/Tautulli/
+    # Jellyfin/Emby webhook until the URLs are re-pasted with the new key —
+    # the frontend action that calls this must warn before doing so.
+    user, _source = auth_svc.resolve_request_identity(request)
+    if not user:
+        return auth_svc.json_error(401, "authentication required")
+    if not auth_svc.validate_csrf(request):
+        return auth_svc.json_error(403, "CSRF token missing or invalid")
+    return {"webhook_api_key": auth_svc.regenerate_webhook_api_key()}

--- a/services/app_config.py
+++ b/services/app_config.py
@@ -1193,9 +1193,17 @@ def get_settings_payload(session=None) -> dict[str, Any]:
                 entry["saved_value"] = None
                 entry["has_saved_value"] = any_saved or bool((row and row.value not in (None, "")))
             grouped[meta["section"]].append(entry)
+
+        # Not a settings field (no SETTINGS_SCHEMA entry, not user-editable
+        # via save/reset) — exposed only so the frontend's webhook-URL
+        # builders (which already read this same values map) can display it.
+        # See services/auth.py for where it's actually generated/rotated.
+        from services.auth import ensure_webhook_api_key
+
         return {
             "status": get_onboarding_status(session=session),
             "sections": [{"name": name, "fields": fields} for name, fields in grouped.items()],
+            "webhook_api_key": ensure_webhook_api_key(session=session),
         }
     finally:
         if owns_session:

--- a/services/auth.py
+++ b/services/auth.py
@@ -25,6 +25,7 @@ AUTH_PASSWORD_HASH_KEY = "AUTH_PASSWORD_HASH"
 AUTH_SESSION_SECRET_KEY = "AUTH_SESSION_SECRET"
 AUTH_MODE_KEY = "AUTH_MODE"
 AUTH_TRUSTED_PROXIES_KEY = "AUTH_TRUSTED_PROXIES"
+AUTH_WEBHOOK_API_KEY_KEY = "AUTH_WEBHOOK_API_KEY"
 
 SESSION_USER_KEY = "auth_user"
 SESSION_CSRF_KEY = "csrf_token"
@@ -312,9 +313,69 @@ def create_admin_account(username: str, password: str, session=None) -> None:
             setattr(settings, AUTH_MODE_KEY, DEFAULT_AUTH_MODE)
         except Exception:
             pass
+        # Provision a webhook key alongside the account so it's ready the
+        # moment onboarding shows Radarr/Sonarr/Tautulli/Jellyfin webhook URLs.
+        ensure_webhook_api_key(session=session)
     finally:
         if owns:
             session.close()
+
+
+def generate_webhook_api_key() -> str:
+    return secrets.token_hex(20)  # 40 hex chars, matches a typical Radarr/Sonarr API key's shape
+
+
+def get_webhook_api_key(session=None) -> str | None:
+    value = _get_config_value(AUTH_WEBHOOK_API_KEY_KEY, session=session)
+    text = str(value or "").strip()
+    return text or None
+
+
+def ensure_webhook_api_key(session=None) -> str:
+    """Return the current webhook API key, creating one on first use.
+
+    Kept separate from AUTH_SESSION_SECRET / the password hash: this key
+    authenticates POST /webhook (called by Radarr/Sonarr/Tautulli/Jellyfin/
+    Emby, not a browser — see is_auth_allowlisted, which exempts /webhook
+    from the cookie/CSRF checks entirely since those callers can't log in).
+    Never rotated implicitly by create_admin_account/change_admin_password —
+    only regenerate_webhook_api_key() rotates it, since doing so silently
+    would break every already-configured webhook connection.
+    """
+    existing = get_webhook_api_key(session=session)
+    if existing:
+        return existing
+    generated = generate_webhook_api_key()
+    _set_config_value(
+        AUTH_WEBHOOK_API_KEY_KEY,
+        generated,
+        description="API key required on POST /webhook (?apikey=) for Radarr/Sonarr/Tautulli/Jellyfin/Emby callers",
+        session=session,
+    )
+    return generated
+
+
+def regenerate_webhook_api_key(session=None) -> str:
+    """Explicit rotation, e.g. from a Settings action. Breaks every existing
+    webhook connection until the URLs are re-pasted with the new key — the
+    caller is responsible for warning about that before invoking this."""
+    generated = generate_webhook_api_key()
+    _set_config_value(
+        AUTH_WEBHOOK_API_KEY_KEY,
+        generated,
+        description="API key required on POST /webhook (?apikey=) for Radarr/Sonarr/Tautulli/Jellyfin/Emby callers",
+        session=session,
+    )
+    return generated
+
+
+def verify_webhook_api_key(provided: str | None, session=None) -> bool:
+    if not provided:
+        return False
+    stored = get_webhook_api_key(session=session)
+    if not stored:
+        return False
+    return secrets.compare_digest(str(provided), stored)
 
 
 def change_admin_password(current_password: str, new_password: str, session=None) -> None:

--- a/services/auth.py
+++ b/services/auth.py
@@ -13,6 +13,7 @@ from typing import Any
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 from fastapi import Request
+from sqlalchemy.exc import IntegrityError
 from starlette.responses import JSONResponse
 
 from core.logger import logger
@@ -321,6 +322,9 @@ def create_admin_account(username: str, password: str, session=None) -> None:
             session.close()
 
 
+WEBHOOK_API_KEY_DESCRIPTION = "API key required on POST /webhook (?apikey=) for Radarr/Sonarr/Tautulli/Jellyfin/Emby callers"
+
+
 def generate_webhook_api_key() -> str:
     return secrets.token_hex(20)  # 40 hex chars, matches a typical Radarr/Sonarr API key's shape
 
@@ -329,6 +333,15 @@ def get_webhook_api_key(session=None) -> str | None:
     value = _get_config_value(AUTH_WEBHOOK_API_KEY_KEY, session=session)
     text = str(value or "").strip()
     return text or None
+
+
+def _store_webhook_api_key(key: str, session=None) -> None:
+    _set_config_value(
+        AUTH_WEBHOOK_API_KEY_KEY,
+        key,
+        description=WEBHOOK_API_KEY_DESCRIPTION,
+        session=session,
+    )
 
 
 def ensure_webhook_api_key(session=None) -> str:
@@ -346,12 +359,17 @@ def ensure_webhook_api_key(session=None) -> str:
     if existing:
         return existing
     generated = generate_webhook_api_key()
-    _set_config_value(
-        AUTH_WEBHOOK_API_KEY_KEY,
-        generated,
-        description="API key required on POST /webhook (?apikey=) for Radarr/Sonarr/Tautulli/Jellyfin/Emby callers",
-        session=session,
-    )
+    try:
+        _store_webhook_api_key(generated, session=session)
+    except IntegrityError:
+        # Lost a race with a concurrent first-time caller (e.g. two tabs
+        # both loading Settings right after setup). The unique AppConfig.key
+        # index means exactly one insert won — re-read and use that one
+        # instead of returning a key that was never actually persisted.
+        existing = get_webhook_api_key(session=session)
+        if existing:
+            return existing
+        raise
     return generated
 
 
@@ -360,12 +378,7 @@ def regenerate_webhook_api_key(session=None) -> str:
     webhook connection until the URLs are re-pasted with the new key — the
     caller is responsible for warning about that before invoking this."""
     generated = generate_webhook_api_key()
-    _set_config_value(
-        AUTH_WEBHOOK_API_KEY_KEY,
-        generated,
-        description="API key required on POST /webhook (?apikey=) for Radarr/Sonarr/Tautulli/Jellyfin/Emby callers",
-        session=session,
-    )
+    _store_webhook_api_key(generated, session=session)
     return generated
 
 

--- a/services/auth.py
+++ b/services/auth.py
@@ -388,7 +388,11 @@ def verify_webhook_api_key(provided: str | None, session=None) -> bool:
     stored = get_webhook_api_key(session=session)
     if not stored:
         return False
-    return secrets.compare_digest(str(provided), stored)
+    # secrets.compare_digest raises TypeError on non-ASCII str input;
+    # provided comes straight from an attacker-controlled query param, so
+    # encode both sides to bytes first rather than let a malformed/non-ASCII
+    # apikey value crash the webhook handler instead of just failing closed.
+    return secrets.compare_digest(str(provided).encode("utf-8", errors="replace"), stored.encode("utf-8"))
 
 
 def change_admin_password(current_password: str, new_password: str, session=None) -> None:


### PR DESCRIPTION
Follow-up to #58 — closes the one gap left after the auth work in #60.

**The gap:** `POST /webhook` is correctly exempt from the new cookie/CSRF auth (`is_auth_allowlisted`), since Radarr/Sonarr/Tautulli/Jellyfin/Emby aren't browser sessions and can't log in. But that exemption left it with *zero* credential check of any kind — the same exposure #58 was about, just on the one endpoint the login system structurally can't cover. Anyone who can reach the port can still POST fake webhook events (fake imports, fake deletes, fake playback) with no auth at all.

**The fix:** a separate, independent API key for machine callers — the same pattern Sonarr/Radarr use for their own inbound API (a distinct key/scheme from the UI login, not folded into the cookie/CSRF system).

- `services/auth.py` — `AUTH_WEBHOOK_API_KEY_KEY`, `generate_/get_/ensure_/regenerate_/verify_webhook_api_key()`. Auto-provisioned alongside the admin account, **never** rotated implicitly by password changes (only an explicit regenerate call — silent rotation would break every already-configured webhook).
- `routes/auth.py` — `GET`/`POST /api/auth/webhook-key` (view/regenerate), session-protected.
- `main.py` — `/webhook` now checks `?apikey=` before touching the payload; skipped only in `AUTH_MODE=disabled`, matching that mode's own no-auth-anywhere intent.
- Frontend — the webhook URLs already shown during onboarding/settings include the key automatically. Added a view/regenerate control to the Security settings tab (was otherwise unreachable from the UI).

**Verification, not just "should work":**
1. Ran a blind code-review pass (fresh context, no visibility into implementation reasoning) — found and fixed a race condition in first-time key creation, a missing log line on rejected webhook calls, and the regenerate endpoint being unreachable from any UI.
2. CodeRabbit flagged 3 more on the opened PR — fixed all: the regenerated key wasn't propagating into the already-loaded settings state (stale URLs shown until reload), the `?instance=` value was going into the rejection log line unsanitized (log-injection risk via embedded newlines), and `secrets.compare_digest` on non-ASCII input could raise instead of failing closed.
3. Built the image, deployed it, and manually tried to break it: missing/wrong/empty/oversized/non-ASCII/null-byte apikeys, header-based bypass, case-variant param names, duplicate params, trailing-slash redirect, wrong HTTP method, CRLF/log-injection payloads, checked for the key leaking into the HTML/JS bundle, hit the gated endpoints with no session, and a concurrent burst of requests. Every attempt correctly rejected; nothing crashed.

Deliberately not included: rate-limiting on bad apikey attempts (it's a 160-bit random token, not brute-forceable at any practical rate the way a password is) and folding the check into `AuthGateMiddleware`'s allowlist (kept it a standalone gate in the `/webhook` handler instead, matching Sonarr/Radarr's own separate-scheme design for non-browser callers rather than unifying it).
