### PR TITLE
Collections (Beta) enhancements - sources, sort, year filter, UX guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+### Added
+
+- **Collection sources**: StevenLu (default popular-movies JSON or a custom URL), AniList public user anime lists (GraphQL, throttled), and TMDB person / company / keyword / collection. Paste a TMDB page URL (or numeric id); no in-app search picker.
+
 ### Changed
 
 - **Collection title sort**: Arrange by Title (A–Z) ignores leading *a* / *an* / *the*, matching Library A–Z.
 - **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
+- **Collection editor sources**: New recipes start with no source (instead of TMDB Trending or My Catalog). **My Catalog** is first in the add-source menu.
 
 ## [0.9.16] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+### Changed
+
+- **Collection title sort**: Arrange by Title (A–Z) ignores leading *a* / *an* / *the*, matching Library A–Z.
+- **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
+
 ## [0.9.16] - 2026-08-14
 
 ### Action required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 ### Added
 
 - **Collection sources**: StevenLu (default popular-movies JSON or a custom URL), AniList public user anime lists (GraphQL, throttled), and TMDB person / company / keyword / collection. Paste a TMDB page URL (or numeric id); no in-app search picker.
+- **Collection year filter (TV)**: **Was airing during** matches shows whose first–last air years overlap the window (unknown last air = still running). Movies and the default **Premiere year** still use release / first-air year.
+- **Unsaved collection recipe**: Leaving the recipe editor (Back, Cancel, Library, or another dashboard page) shows an in-app confirm. Closing the browser tab still uses the browser’s leave prompt, which some embedded browsers (including Cursor’s) do not show.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 - **Collection title sort**: Arrange by Title (A–Z) ignores leading *a* / *an* / *the*, matching Library A–Z.
 - **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
-- **Collection editor sources**: New recipes start with no source (instead of TMDB Trending or My Catalog). **My Catalog** is first in the add-source menu.
+- **Collection preview**: Catalog sample shows up to 200 selected titles with file vs placeholder outlines. Multi-library recipes mark which Plex libraries each poster is in (filter chips dim the rest). Missing-from-ARR uses the same Arrange sort; **Select first N** matches the recipe max (capped at the add batch).
 
 ## [0.9.16] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Collection preview**: Catalog sample shows up to 200 selected titles with file vs placeholder outlines. Multi-library recipes mark which Plex libraries each poster is in (filter chips dim the rest). Missing-from-ARR uses the same Arrange sort; **Select first N** matches the recipe max (capped at the add batch).
 - **Missing-from-ARR add**: Lookups stay per title; Radarr/Sonarr adds go through `movie/import` / `series/import` (chunks of 100) with a **90s** timeout. Timeouts say the *arr may still add the title. Result titles include year.
 - **Plex path refresh**: Path-scoped library scans rewrite Placeholdarr folders onto Plex’s library locations (cached in memory from `/library/sections`, filled on connection test or first refresh). Docker mounts like `/placeholdarr/movies` no longer get skipped as unknown paths.
+- **TMDB keyword/company sort**: Pasted URLs honor `sort_by` (default `popularity.desc`, matching the TMDB keyword page). Query params were previously ignored, so Arrange by popularity only reordered whichever Discover pages came back unsorted.
+- **TMDB source cards**: URL-based TMDB pages are consolidated into one **TMDB Page** source card. Paste a list, person, company, keyword, or collection URL; company and keyword pages expose a **Sort from TMDB** control so the fetch order is explicit in the recipe instead of hidden inside the URL.
 
 ## [0.9.16] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
 - **Collection preview**: Catalog sample shows up to 200 selected titles with file vs placeholder outlines. Multi-library recipes mark which Plex libraries each poster is in (filter chips dim the rest). Missing-from-ARR uses the same Arrange sort; **Select first N** matches the recipe max (capped at the add batch).
 - **Missing-from-ARR add**: Lookups stay per title; Radarr/Sonarr adds go through `movie/import` / `series/import` (chunks of 100) with a **90s** timeout. Timeouts say the *arr may still add the title. Result titles include year.
+- **Plex path refresh**: Path-scoped library scans rewrite Placeholdarr folders onto Plex’s library locations (cached in memory from `/library/sections`, filled on connection test or first refresh). Docker mounts like `/placeholdarr/movies` no longer get skipped as unknown paths.
 
 ## [0.9.16] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-08-18
+
+### Summary
+
+Collections (Beta) gains new source types, a unified **TMDB Page** card, explicit **source-level sort**, a TV-specific **Was airing during** year filter, an **unsaved recipe** guard, improved **Plex path refresh** for Docker, and a better **preview** and **Missing-from-ARR** workflow.
+
 ### Added
 
 - **Collection sources**: StevenLu (default popular-movies JSON or a custom URL), AniList public user anime lists (GraphQL, throttled), and TMDB person / company / keyword / collection. Paste a TMDB page URL (or numeric id); no in-app search picker.
-- **Collection year filter (TV)**: **Was airing during** matches shows whose first–last air years overlap the window (unknown last air = still running). Movies and the default **Premiere year** still use release / first-air year.
-- **Unsaved collection recipe**: Leaving the recipe editor (Back, Cancel, Library, or another dashboard page) shows an in-app confirm. Closing the browser tab still uses the browser’s leave prompt, which some embedded browsers (including Cursor’s) do not show.
+- **TMDB Page source card**: One unified source block replaces the separate TMDB Person / Company / Keyword / Collection cards. Paste any TMDB page URL and the card detects the type. Company and keyword pages get a **Sort from TMDB** dropdown that controls which TMDB Discover order the fetch uses (popularity, rating, release date, title). Legacy recipes using the older separate types still work.
+- **Collection year filter (TV)**: New **Was airing during** mode matches shows whose first–last air years overlap the window (unknown last air = still running). Movies and the default **Premiere year** still use release / first-air year.
+- **Unsaved collection recipe prompt**: Leaving the recipe editor (Back, Cancel, Library, or another dashboard page) shows an in-app confirm modal. Closing the browser tab still uses the browser's native leave prompt (not available in all embedded browsers).
 
 ### Changed
 
@@ -19,9 +26,9 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
 - **Collection preview**: Catalog sample shows up to 200 selected titles with file vs placeholder outlines. Multi-library recipes mark which Plex libraries each poster is in (filter chips dim the rest). Missing-from-ARR uses the same Arrange sort; **Select first N** matches the recipe max (capped at the add batch).
 - **Missing-from-ARR add**: Lookups stay per title; Radarr/Sonarr adds go through `movie/import` / `series/import` (chunks of 100) with a **90s** timeout. Timeouts say the *arr may still add the title. Result titles include year.
-- **Plex path refresh**: Path-scoped library scans rewrite Placeholdarr folders onto Plex’s library locations (cached in memory from `/library/sections`, filled on connection test or first refresh). Docker mounts like `/placeholdarr/movies` no longer get skipped as unknown paths.
-- **TMDB keyword/company sort**: Pasted URLs honor `sort_by` (default `popularity.desc`, matching the TMDB keyword page). Query params were previously ignored, so Arrange by popularity only reordered whichever Discover pages came back unsorted.
-- **TMDB source cards**: URL-based TMDB pages are consolidated into one **TMDB Page** source card. Paste a list, person, company, keyword, or collection URL; company and keyword pages expose a **Sort from TMDB** control so the fetch order is explicit in the recipe instead of hidden inside the URL.
+- **Plex path refresh**: Path-scoped library scans rewrite Placeholdarr folders onto Plex's library locations (cached in memory from `/library/sections`, filled on connection test or first refresh). Docker mounts like `/placeholdarr/movies` no longer get skipped as unknown paths.
+- **TMDB keyword/company sort**: Source fetches now send `sort_by` to TMDB Discover (default `popularity.desc`). Previously this was ignored, so the pool of titles could miss popular items and Arrange by popularity only reordered whatever unsorted pages came back.
+- **TMDB source cards simplified**: The Add Source menu now shows **TMDB Page** instead of 4 separate link-type entries. Existing recipes are unaffected.
 
 ## [0.9.16] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Collection title sort**: Arrange by Title (A–Z) ignores leading *a* / *an* / *the*, matching Library A–Z.
 - **Plex collection order**: Synced collections use Plex custom sort and item order from the recipe (Plex previously kept default release-date order, which looked random vs preview).
 - **Collection preview**: Catalog sample shows up to 200 selected titles with file vs placeholder outlines. Multi-library recipes mark which Plex libraries each poster is in (filter chips dim the rest). Missing-from-ARR uses the same Arrange sort; **Select first N** matches the recipe max (capped at the add batch).
+- **Missing-from-ARR add**: Lookups stay per title; Radarr/Sonarr adds go through `movie/import` / `series/import` (chunks of 100) with a **90s** timeout. Timeouts say the *arr may still add the title. Result titles include year.
 
 ## [0.9.16] - 2026-08-14
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ import {
   readStoredLibrarySort,
 } from "./library/librarySortSettings";
 import { useLibraryShelves } from "./library/useLibraryShelves";
+import { ConfirmModal } from "./ConfirmModal";
 import { CollectionsPanel } from "./collections/CollectionsPanel";
 import { useActivityTasks } from "./activity/useActivityTasks";
 import { useActivityFeed } from "./activity/useActivityFeed";
@@ -961,6 +962,11 @@ export function App() {
     [fieldValues, baselineValues, settingsPayload],
   );
   const combinedSettingsDirty = hasUnsavedChanges || statusMessagesMeta.dirty;
+  const [collectionsDraftDirty, setCollectionsDraftDirty] = useState(false);
+  const [leaveConfirm, setLeaveConfirm] = useState<null | {
+    path: string;
+    kind: "settings" | "recipe";
+  }>(null);
   const hasUnsavedChangesRef = useRef(false);
   useEffect(() => {
     if (!combinedSettingsDirty) return;
@@ -1077,13 +1083,13 @@ export function App() {
 
   useEffect(() => {
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!combinedSettingsDirty) return;
+      if (!combinedSettingsDirty && !collectionsDraftDirty) return;
       event.preventDefault();
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
     return () => window.removeEventListener("beforeunload", onBeforeUnload);
-  }, [combinedSettingsDirty]);
+  }, [combinedSettingsDirty, collectionsDraftDirty]);
 
   /** Setup wizard — load on tab enter and tab focus only (no periodic 5s poll). */
   useEffect(() => {
@@ -1494,16 +1500,19 @@ export function App() {
     setSettingsFeedbackKind("success");
   }
 
-  function tryNavigate(path: string) {
+  function tryNavigate(path: string): boolean {
     const stayingWithinSettings = currentTab === "settings" && path.startsWith("/settings");
-    if (!combinedSettingsDirty || currentTab !== "settings" || stayingWithinSettings) {
-      navigate(path);
-      return;
+    if (combinedSettingsDirty && currentTab === "settings" && !stayingWithinSettings) {
+      setLeaveConfirm({ path, kind: "settings" });
+      return false;
     }
-    const shouldLeave = window.confirm("You have unsaved settings changes. Leave this section without saving?");
-    if (shouldLeave) {
-      navigate(path);
+    const stayingOnCollections = currentTab === "collections" && path.startsWith("/collections");
+    if (collectionsDraftDirty && currentTab === "collections" && !stayingOnCollections) {
+      setLeaveConfirm({ path, kind: "recipe" });
+      return false;
     }
+    navigate(path);
+    return true;
   }
 
   async function openWhatsNewCatalog() {
@@ -1539,7 +1548,7 @@ export function App() {
       sessionStorage.setItem("libraryScrollTop", String(currentScrollTop));
       sessionStorage.setItem("libraryScrollRestorePending", "1");
     }
-    navigate(`/library/${item.type}/${item.item_id}`);
+    if (!tryNavigate(`/library/${item.type}/${item.item_id}`)) return;
     setTitleSearchOpen(false);
   }
 
@@ -1753,6 +1762,7 @@ export function App() {
           libraryLoading={libraryLoading}
           onEnsureLibrary={ensureLibraryLoaded}
           onOpenPlexSettings={() => tryNavigate("/settings/media-integrations")}
+          onDraftDirty={setCollectionsDraftDirty}
         />
       );
     }
@@ -2580,6 +2590,28 @@ export function App() {
           />
           <Route path="*" element={null} />
         </Routes>
+
+        {leaveConfirm ? (
+          <ConfirmModal
+            title={leaveConfirm.kind === "recipe" ? "Leave without saving?" : "Unsaved settings"}
+            message={
+              leaveConfirm.kind === "recipe"
+                ? "You have an unsaved collection recipe. If you leave now, this draft will be lost."
+                : "You have unsaved settings changes. Leave this section without saving?"
+            }
+            confirmLabel="Leave"
+            cancelLabel="Stay"
+            accentHex={brandAccent.hex}
+            themeMode={themeMode}
+            onCancel={() => setLeaveConfirm(null)}
+            onConfirm={() => {
+              const path = leaveConfirm.path;
+              setLeaveConfirm(null);
+              if (leaveConfirm.kind === "recipe") setCollectionsDraftDirty(false);
+              navigate(path);
+            }}
+          />
+        ) : null}
 
         <TaskRunConfirmModals
           modal={taskRunModal}

--- a/frontend/src/ConfirmModal.tsx
+++ b/frontend/src/ConfirmModal.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+import type { ThemeMode } from "./brandTypes";
+
+export function ConfirmModal(props: {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  accentHex: string;
+  themeMode: ThemeMode;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const isLight = props.themeMode === "light";
+  const confirmLabel = props.confirmLabel ?? "Leave";
+  const cancelLabel = props.cancelLabel ?? "Stay";
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") props.onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [props.onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) props.onCancel();
+      }}
+    >
+      <div
+        className={`w-full max-w-md rounded-lg border shadow-lg shadow-black/15 overflow-hidden ${
+          isLight ? "border-slate-200 bg-white" : "border-[#424753]/40 bg-[#171c22]"
+        }`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+      >
+        <div className={`px-5 py-4 border-b ${isLight ? "border-slate-200" : "border-[#424753]/30"}`}>
+          <h3
+            id="confirm-modal-title"
+            className={`text-[18px] font-bold font-headline ${isLight ? "text-slate-900" : "text-white"}`}
+          >
+            {props.title}
+          </h3>
+          <p className={`mt-2 text-[15px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-300"}`}>
+            {props.message}
+          </p>
+        </div>
+        <div
+          className={`px-5 py-4 flex flex-wrap justify-end gap-3 border-t ${
+            isLight ? "border-slate-200" : "border-[#424753]/30"
+          }`}
+        >
+          <button
+            type="button"
+            onClick={props.onCancel}
+            className={`text-[14px] font-headline uppercase tracking-wider ${
+              isLight ? "text-slate-500 hover:text-slate-900" : "text-slate-400 hover:text-slate-200"
+            }`}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={props.onConfirm}
+            className="px-4 py-2 rounded-lg text-[14px] font-headline uppercase tracking-wider text-[#0a0e14]"
+            style={{ backgroundColor: props.accentHex }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/api/collections.ts
+++ b/frontend/src/api/collections.ts
@@ -15,6 +15,9 @@ import type {
   PlexSectionOption,
 } from "../types/api";
 
+/** Must match `ARR_ADD_BATCH_CAP` in `routes/collections.py`. */
+export const ARR_ADD_BATCH_CAP = 100;
+
 export interface RecipeWritePayload {
   name: string;
   enabled: boolean;

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -5,6 +5,7 @@ import {
   getCollectionBuilderMeta,
   getCollectionTmdbMeta,
   previewCollectionDefinition,
+  ARR_ADD_BATCH_CAP,
   type RecipeWritePayload,
 } from "../api/collections";
 import { ArrAddModal } from "./ArrAddModal";
@@ -2363,7 +2364,11 @@ export function CollectionEditor(props: {
                           <button
                             type="button"
                             className={`rounded-md border px-2.5 py-1 text-[11px] font-headline uppercase tracking-wider ${theme.chipInactive}`}
-                            onClick={() => setSelectedMissing(new Set(missingItems.map(missingKey)))}
+                            onClick={() =>
+                              setSelectedMissing(
+                                new Set(missingItems.slice(0, ARR_ADD_BATCH_CAP).map(missingKey)),
+                              )
+                            }
                           >
                             Select all
                           </button>
@@ -2376,10 +2381,13 @@ export function CollectionEditor(props: {
                           </button>
                           <span className={`text-[12px] ${theme.muted}`}>
                             {selectedMissing.size} selected
+                            {missingItems.length > ARR_ADD_BATCH_CAP
+                              ? ` (max ${ARR_ADD_BATCH_CAP} per add)`
+                              : ""}
                           </span>
                           <button
                             type="button"
-                            disabled={selectedMissing.size < 1}
+                            disabled={selectedMissing.size < 1 || selectedMissing.size > ARR_ADD_BATCH_CAP}
                             onClick={() => setArrModalOpen(true)}
                             className="ml-auto rounded-lg px-4 py-1.5 text-[13px] font-headline uppercase tracking-wider text-[#0a0e14] disabled:opacity-40"
                             style={{ backgroundColor: accentHex }}
@@ -2418,7 +2426,7 @@ export function CollectionEditor(props: {
                                   setSelectedMissing((prev) => {
                                     const next = new Set(prev);
                                     if (next.has(key)) next.delete(key);
-                                    else next.add(key);
+                                    else if (next.size < ARR_ADD_BATCH_CAP) next.add(key);
                                     return next;
                                   });
                                 }}
@@ -2503,7 +2511,9 @@ export function CollectionEditor(props: {
       {arrModalOpen ? (
         <ArrAddModal
           mediaType={sectionType}
-          items={missingItems.filter((item) => selectedMissing.has(missingKey(item)))}
+          items={missingItems
+            .filter((item) => selectedMissing.has(missingKey(item)))
+            .slice(0, ARR_ADD_BATCH_CAP)}
           defaultTag={name.trim() || "placeholdarr"}
           accentHex={accentHex}
           onClose={() => setArrModalOpen(false)}

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -69,6 +69,7 @@ const SOURCE_META: Record<
   tmdb_popular: { label: "TMDB Popular", icon: "local_fire_department", description: "All-time popular titles on TMDB", requires: "tmdb" },
   tmdb_upcoming: { label: "TMDB Upcoming / On Air", icon: "event_upcoming", description: "Upcoming movies or currently-airing shows", requires: "tmdb" },
   tmdb_discover: { label: "TMDB Discover", icon: "travel_explore", description: "Filter TMDB by genre, year, streaming service", requires: "tmdb" },
+  tmdb_url: { label: "TMDB Page", icon: "link", description: "Paste a TMDB list, person, company, keyword, or collection page URL", requires: "tmdb" },
   tmdb_list: { label: "TMDB List", icon: "format_list_bulleted", description: "A public TMDB list — paste the list URL or id", requires: "tmdb" },
   tmdb_person: { label: "TMDB Person", icon: "person", description: "Filmography for a person — paste their TMDB page URL", requires: "tmdb" },
   tmdb_company: { label: "TMDB Company", icon: "apartment", description: "Titles from a studio/company — paste the TMDB company URL", requires: "tmdb" },
@@ -79,6 +80,34 @@ const SOURCE_META: Record<
   stevenlu: { label: "StevenLu", icon: "star", description: "Popular movies JSON (Radarr's StevenLu list), or a compatible URL", requires: null },
   anilist: { label: "AniList", icon: "animation", description: "A public AniList user anime list — paste the profile/list URL", requires: null },
 };
+
+const VISIBLE_SOURCE_TYPES: CollectionSourceType[] = [
+  "catalog",
+  "tmdb_trending",
+  "tmdb_popular",
+  "tmdb_upcoming",
+  "tmdb_discover",
+  "tmdb_url",
+  "mdblist",
+  "trakt_list",
+  "stevenlu",
+  "anilist",
+];
+
+const TMDB_SOURCE_SORT_OPTIONS: { value: NonNullable<CollectionSourceBlock["sort_by"]>; label: string }[] = [
+  { value: "popularity.desc", label: "Popularity (highest first)" },
+  { value: "vote_average.desc", label: "Rating (highest first)" },
+  { value: "vote_count.desc", label: "Votes (most first)" },
+  { value: "primary_release_date.desc", label: "Release date (newest first)" },
+  { value: "primary_release_date.asc", label: "Release date (oldest first)" },
+  { value: "title.asc", label: "Title (A–Z)" },
+  { value: "title.desc", label: "Title (Z–A)" },
+];
+
+function guessTmdbUrlKind(value: string): "list" | "person" | "company" | "keyword" | "collection" | null {
+  const match = /themoviedb\.org\/(list|person|company|keyword|collection)\/\d+/i.exec(String(value || ""));
+  return (match?.[1]?.toLowerCase() as "list" | "person" | "company" | "keyword" | "collection" | undefined) ?? null;
+}
 
 const FILTER_META: Record<CollectionFilterField, { label: string; icon: string }> = {
   genre: { label: "Genre", icon: "theater_comedy" },
@@ -131,6 +160,8 @@ function defaultSourceBlock(type: CollectionSourceType): CollectionSourceBlock {
       return { type, window: "week", limit: 50 };
     case "tmdb_discover":
       return { type, genre_ids: [], provider_ids: [], watch_region: "US", limit: 100 };
+    case "tmdb_url":
+      return { type, tmdb_ref: "", sort_by: "popularity.desc", limit: 200 };
     case "tmdb_list":
       return { type, list_id: "", limit: 200 };
     case "tmdb_person":
@@ -1216,6 +1247,8 @@ export function CollectionEditor(props: {
     }
     const region = block.watch_region || "US";
     const regionMeta = metaCache[`${mediaType}:${region}`] ?? baseMeta;
+    const tmdbUrlKind = block.type === "tmdb_url" ? guessTmdbUrlKind(block.tmdb_ref ?? "") : null;
+    const tmdbUrlSupportsSourceSort = tmdbUrlKind === "company" || tmdbUrlKind === "keyword";
     return (
       <div className="flex flex-col gap-3">
         {block.type === "tmdb_trending" ? (
@@ -1245,6 +1278,25 @@ export function CollectionEditor(props: {
           </label>
         ) : null}
 
+        {block.type === "tmdb_url" ? (
+          <>
+            <label className={`flex items-center gap-2 ${theme.label}`}>
+              Page URL
+              <input
+                className={`${theme.field} flex-1`}
+                style={{ minWidth: 260 }}
+                value={block.tmdb_ref ?? ""}
+                placeholder="Paste a TMDB list, person, company, keyword, or collection page URL"
+                onChange={(e) => updateSource(index, { tmdb_ref: e.target.value })}
+              />
+            </label>
+            <p className="text-[12px] text-slate-500">
+              Supports TMDB list, person, company, keyword, and collection pages. Company and keyword pages can fetch
+              in TMDB’s page order.
+            </p>
+          </>
+        ) : null}
+
         {block.type === "tmdb_person" ||
         block.type === "tmdb_company" ||
         block.type === "tmdb_keyword" ||
@@ -1267,7 +1319,7 @@ export function CollectionEditor(props: {
                   : block.type === "tmdb_company"
                     ? "Paste the TMDB company URL, e.g. themoviedb.org/company/2-lucasfilm-ltd"
                     : block.type === "tmdb_keyword"
-                      ? "Paste the TMDB keyword URL, e.g. themoviedb.org/keyword/9715-superhero"
+                      ? "Paste the TMDB keyword URL. sort_by on the URL is used (default popularity)."
                       : "Paste the TMDB collection URL, e.g. themoviedb.org/collection/10-star-wars-collection"
               }
               onChange={(e) => updateSource(index, { tmdb_ref: e.target.value })}
@@ -1309,6 +1361,20 @@ export function CollectionEditor(props: {
 
         {block.type === "tmdb_discover" ? (
           <>
+            <label className={`flex items-center gap-2 ${theme.label}`}>
+              Sort from TMDB
+              <select
+                className={theme.selectField}
+                value={block.sort_by ?? "popularity.desc"}
+                onChange={(e) => updateSource(index, { sort_by: e.target.value })}
+              >
+                {TMDB_SOURCE_SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
             <div>
               <div className="text-[12px] font-headline uppercase tracking-widest text-slate-500 mb-1.5">Genres</div>
               <MultiChipPicker
@@ -1393,6 +1459,29 @@ export function CollectionEditor(props: {
               />
             </div>
           </>
+        ) : null}
+
+        {block.type === "tmdb_url" && tmdbUrlSupportsSourceSort ? (
+          <label className={`flex items-center gap-2 ${theme.label}`}>
+            Sort from TMDB
+            <select
+              className={theme.selectField}
+              value={block.sort_by ?? "popularity.desc"}
+              onChange={(e) => updateSource(index, { sort_by: e.target.value })}
+            >
+              {TMDB_SOURCE_SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {block.type === "tmdb_url" && tmdbUrlKind && !tmdbUrlSupportsSourceSort ? (
+          <p className="text-[12px] text-slate-500">
+            This TMDB {tmdbUrlKind} page uses its native order. Recipe Arrange still runs after the source is fetched.
+          </p>
         ) : null}
 
         <label className={`flex items-center gap-2 ${theme.label}`}>
@@ -1998,17 +2087,27 @@ export function CollectionEditor(props: {
             </p>
           ) : null}
           {definition.sources.map((block, index) => {
+            const legacyUrlKind = block.type === "tmdb_url" ? guessTmdbUrlKind(block.tmdb_ref ?? "") : null;
             const meta = SOURCE_META[block.type] ?? {
               label: block.type,
               icon: "help",
               description: "",
             };
+            const title = block.type === "tmdb_url" && legacyUrlKind ? `TMDB ${legacyUrlKind[0].toUpperCase()}${legacyUrlKind.slice(1)} Page` : meta.label;
+            const subtitle =
+              block.type === "tmdb_url" && legacyUrlKind
+                ? `${meta.description}. ${
+                    legacyUrlKind === "company" || legacyUrlKind === "keyword"
+                      ? "Source sort matches TMDB."
+                      : "Uses TMDB’s native page order."
+                  }`
+                : meta.description;
             return (
             <BlockCard
               key={`${block.type}-${index}`}
               icon={meta.icon}
-              title={meta.label}
-              subtitle={meta.description}
+              title={title}
+              subtitle={subtitle}
               accentHex={accentHex}
               onRemove={() => removeSource(index)}
             >
@@ -2018,7 +2117,7 @@ export function CollectionEditor(props: {
           })}
           <AddBlockMenu
             label="Add source"
-            options={(Object.keys(SOURCE_META) as CollectionSourceType[]).map((type) => {
+            options={VISIBLE_SOURCE_TYPES.map((type) => {
               const requires = SOURCE_META[type].requires;
               const movieOnly = type === "stevenlu" || type === "tmdb_collection";
               const disabled =

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -30,6 +30,7 @@ import type {
   CollectionPinnedItem,
   CollectionMissingFromArrItem,
   CollectionPreviewResponse,
+  CollectionPreviewSampleItem,
   CollectionRecipe,
   CollectionRatingProvider,
   CollectionSourceBlock,
@@ -795,6 +796,61 @@ function PinPicker(props: {
   );
 }
 
+function fileStateOutline(state: CollectionPreviewSampleItem["file_state"]): string {
+  if (state === "file") return "outline outline-2 outline-offset-[-2px] outline-emerald-400";
+  if (state === "placeholder") return "outline outline-2 outline-dashed outline-offset-[-2px] outline-cyan-400";
+  if (state === "mixed") return "outline outline-2 outline-dashed outline-offset-[-2px] outline-violet-400";
+  return "";
+}
+
+function CatalogSamplePoster(props: {
+  item: CollectionPreviewSampleItem;
+  libraries: PlexSectionOption[];
+  dimmed: boolean;
+  showLibraryTicks: boolean;
+}) {
+  const theme = useCollectionTheme();
+  const state = props.item.file_state ?? "none";
+  const chip =
+    state === "file" ? "File" : state === "placeholder" ? "PH" : state === "mixed" ? "Mix" : null;
+  const inSet = new Set(props.item.in_libraries ?? []);
+  return (
+    <div
+      title={`${props.item.title}${props.item.year ? ` (${props.item.year})` : ""}${
+        chip ? ` · ${chip === "PH" ? "Placeholder" : chip === "Mix" ? "File + placeholder" : "Real file"}` : ""
+      }`}
+      className={`relative aspect-[2/3] w-full overflow-hidden rounded-md ${theme.posterFallback} ${fileStateOutline(state)} ${
+        props.dimmed ? "opacity-35" : ""
+      }`}
+    >
+      {props.item.poster ? (
+        <img src={props.item.poster} alt={props.item.title} className="h-full w-full object-cover" loading="lazy" />
+      ) : (
+        <span className={`block h-full p-1 text-[9px] leading-tight ${theme.sampleFallback}`}>{props.item.title}</span>
+      )}
+      {chip ? (
+        <span className="absolute left-0.5 top-0.5 rounded bg-black/70 px-1 text-[8px] font-headline uppercase tracking-wider text-white">
+          {chip}
+        </span>
+      ) : null}
+      {props.showLibraryTicks ? (
+        <span className="absolute inset-x-0 bottom-0 flex flex-wrap gap-0.5 bg-black/55 px-0.5 py-0.5">
+          {props.libraries.map((lib) => (
+            <span
+              key={lib.id}
+              className={`rounded px-0.5 text-[8px] font-headline uppercase leading-none ${
+                inSet.has(lib.id) ? "text-white" : "text-white/35"
+              }`}
+            >
+              {lib.title.slice(0, 3)}
+            </span>
+          ))}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 export function CollectionEditor(props: {
   recipe: CollectionRecipe | null;
   sections: PlexSectionOption[];
@@ -999,6 +1055,7 @@ export function CollectionEditor(props: {
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [previewPane, setPreviewPane] = useState<"catalog" | "missing">("catalog");
+  const [sampleLibraryFilter, setSampleLibraryFilter] = useState<number | null>(null);
   const [selectedMissing, setSelectedMissing] = useState<Set<string>>(new Set());
   const [arrModalOpen, setArrModalOpen] = useState(false);
   const previewSeq = useRef(0);
@@ -1712,6 +1769,13 @@ export function CollectionEditor(props: {
   const missingPrefilter = preview?.missing_from_arr_prefilter_count ?? 0;
   const missingGaps = preview?.missing_from_arr_filter_gaps ?? [];
   const missingItems = preview?.missing_from_arr ?? [];
+  const selectFirstCount = Math.min(
+    definition.limit && definition.limit > 0 ? definition.limit : 50,
+    ARR_ADD_BATCH_CAP,
+    missingItems.length,
+  );
+  const targetLibraries = props.sections.filter((s) => sectionIds.includes(s.id));
+  const showLibraryTicks = targetLibraries.length > 1;
   const arrIncludeLabels = arrIncludeConstraintLabels(definition.filters);
   const showMissingPane = missingCount > 0 || missingPrefilter > 0 || missingGaps.length > 0;
   const missingKey = (item: CollectionMissingFromArrItem) =>
@@ -2449,6 +2513,19 @@ export function CollectionEditor(props: {
                           >
                             Select all
                           </button>
+                          {selectFirstCount > 0 ? (
+                            <button
+                              type="button"
+                              className={`rounded-md border px-2.5 py-1 text-[11px] font-headline uppercase tracking-wider ${theme.chipInactive}`}
+                              onClick={() =>
+                                setSelectedMissing(
+                                  new Set(missingItems.slice(0, selectFirstCount).map(missingKey)),
+                                )
+                              }
+                            >
+                              Select first {selectFirstCount}
+                            </button>
+                          ) : null}
                           <button
                             type="button"
                             className={`rounded-md border px-2.5 py-1 text-[11px] font-headline uppercase tracking-wider ${theme.chipInactive}`}
@@ -2551,28 +2628,71 @@ export function CollectionEditor(props: {
                         )}
                       </>
                     ) : preview?.sample?.length ? (
-                      <div className="grid grid-cols-4 gap-2 sm:grid-cols-5 xl:grid-cols-6">
-                        {preview.sample.map((item) =>
-                          item.poster ? (
-                            <img
-                              key={item.id}
-                              src={item.poster}
-                              alt={item.title}
-                              title={`${item.title}${item.year ? ` (${item.year})` : ""}`}
-                              className={`aspect-[2/3] w-full rounded-md object-cover ${theme.posterFallback}`}
-                              loading="lazy"
-                            />
-                          ) : (
-                            <div
-                              key={item.id}
-                              title={`${item.title}${item.year ? ` (${item.year})` : ""}`}
-                              className={`aspect-[2/3] w-full rounded-md p-1 text-[9px] leading-tight overflow-hidden ${theme.sampleFallback}`}
+                      <>
+                        <div className={`mb-2 flex flex-wrap items-center gap-2 ${theme.muted}`}>
+                          <span className="inline-flex items-center gap-1">
+                            <span className="inline-block h-2.5 w-2.5 rounded-sm outline outline-2 outline-emerald-400" />
+                            File
+                          </span>
+                          <span className="inline-flex items-center gap-1">
+                            <span className="inline-block h-2.5 w-2.5 rounded-sm outline outline-2 outline-dashed outline-cyan-400" />
+                            Placeholder
+                          </span>
+                          <span className="inline-flex items-center gap-1">
+                            <span className="inline-block h-2.5 w-2.5 rounded-sm outline outline-2 outline-dashed outline-violet-400" />
+                            Both
+                          </span>
+                        </div>
+                        {showLibraryTicks ? (
+                          <div className="mb-2 flex flex-wrap gap-1">
+                            <button
+                              type="button"
+                              onClick={() => setSampleLibraryFilter(null)}
+                              className={`rounded-md border px-2 py-1 text-[11px] font-headline uppercase tracking-wider ${
+                                sampleLibraryFilter == null ? "text-[#0a0e14]" : theme.chipInactive
+                              }`}
+                              style={
+                                sampleLibraryFilter == null
+                                  ? { backgroundColor: accentHex, borderColor: accentHex }
+                                  : undefined
+                              }
                             >
-                              {item.title}
-                            </div>
-                          ),
-                        )}
-                      </div>
+                              All libraries
+                            </button>
+                            {targetLibraries.map((lib) => (
+                              <button
+                                key={lib.id}
+                                type="button"
+                                onClick={() => setSampleLibraryFilter(lib.id)}
+                                className={`rounded-md border px-2 py-1 text-[11px] font-headline uppercase tracking-wider ${
+                                  sampleLibraryFilter === lib.id ? "text-[#0a0e14]" : theme.chipInactive
+                                }`}
+                                style={
+                                  sampleLibraryFilter === lib.id
+                                    ? { backgroundColor: accentHex, borderColor: accentHex }
+                                    : undefined
+                                }
+                              >
+                                {lib.title}
+                              </button>
+                            ))}
+                          </div>
+                        ) : null}
+                        <div className="grid grid-cols-4 gap-2 sm:grid-cols-5 xl:grid-cols-6">
+                          {preview.sample.map((item) => (
+                            <CatalogSamplePoster
+                              key={item.id}
+                              item={item}
+                              libraries={targetLibraries}
+                              showLibraryTicks={showLibraryTicks}
+                              dimmed={
+                                sampleLibraryFilter != null &&
+                                !(item.in_libraries ?? []).includes(sampleLibraryFilter)
+                              }
+                            />
+                          ))}
+                        </div>
+                      </>
                     ) : (
                       <p className={theme.muted}>No catalog sample for this recipe.</p>
                     )}

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -152,12 +152,24 @@ function defaultSourceBlock(type: CollectionSourceType): CollectionSourceBlock {
   }
 }
 
+function collectionEditorSnapshot(parts: {
+  name: string;
+  enabled: boolean;
+  sectionIds: number[];
+  collectionTitle: string;
+  runIntervalHours: number | null;
+  activeWindow: CollectionActiveWindow | null;
+  definition: CollectionDefinition;
+}): string {
+  return JSON.stringify(parts);
+}
+
 function defaultFilterBlock(field: CollectionFilterField, sectionType: "movie" | "show"): CollectionFilterBlock {
   switch (field) {
     case "genre":
       return { field, op: "includes_any", values: [] };
     case "year":
-      return { field, op: "gte", value: 2000 };
+      return { field, op: "gte", value: 2000, basis: "premiered" };
     case "certification":
       return { field, op: "in", values: [] };
     case "studio_network":
@@ -574,6 +586,11 @@ const RELEASE_BASIS_LABELS: Record<string, string> = {
   physical: "physical release",
 };
 
+const YEAR_BASIS_LABELS: Record<string, string> = {
+  premiered: "premiere year",
+  aired_during: "was airing during",
+};
+
 function explainRuleCheckLabel(check: CollectionExplainCheck): string {
   const base = filterMeta(String(check.field ?? "")).label;
   const op = FILTER_OP_LABELS[String(check.op ?? "")] ?? String(check.op ?? "");
@@ -584,7 +601,9 @@ function explainRuleCheckLabel(check: CollectionExplainCheck): string {
   const basis =
     check.field === "release_window" && check.basis
       ? `(by ${RELEASE_BASIS_LABELS[check.basis] ?? check.basis})`
-      : "";
+      : check.field === "year"
+        ? `(${YEAR_BASIS_LABELS[String(check.basis || "premiered")] ?? "premiere year"})`
+        : "";
   const provider =
     check.field === "rating"
       ? check.provider
@@ -867,6 +886,7 @@ export function CollectionEditor(props: {
   saveError: string | null;
   onSave: (payload: RecipeWritePayload) => void;
   onCancel: () => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const accentHex = props.accent.hex;
   const theme = getCollectionTheme(props.themeMode === "light");
@@ -886,6 +906,27 @@ export function CollectionEditor(props: {
       ? props.recipe.definition
       : { sources: [], filters: [], limit: 50, sort: "popularity" },
   );
+  const editorSnapshot = useMemo(
+    () =>
+      collectionEditorSnapshot({
+        name,
+        enabled,
+        sectionIds,
+        collectionTitle,
+        runIntervalHours,
+        activeWindow,
+        definition,
+      }),
+    [name, enabled, sectionIds, collectionTitle, runIntervalHours, activeWindow, definition],
+  );
+  const initialSnapshotRef = useRef(editorSnapshot);
+  const dirty = editorSnapshot !== initialSnapshotRef.current;
+  useEffect(() => {
+    props.onDirtyChange?.(dirty);
+  }, [dirty, props.onDirtyChange]);
+  useEffect(() => {
+    return () => props.onDirtyChange?.(false);
+  }, [props.onDirtyChange]);
 
   const sectionId = sectionIds[0] ?? null;
   const section = useMemo(
@@ -1430,6 +1471,23 @@ export function CollectionEditor(props: {
                 />
               </>
             ) : null}
+            {sectionType === "show" ? (
+              <label className={`flex items-center gap-2 ${theme.label}`}>
+                based on
+                <select
+                  className={theme.selectField}
+                  value={block.basis === "aired_during" ? "aired_during" : "premiered"}
+                  onChange={(e) =>
+                    update({ basis: e.target.value as CollectionFilterBlock["basis"] })
+                  }
+                >
+                  <option value="premiered">Premiere year</option>
+                  <option value="aired_during">Was airing during</option>
+                </select>
+              </label>
+            ) : (
+              <span className="text-[13px] text-slate-500">premiere year</span>
+            )}
           </div>
         );
       case "certification": {

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -63,14 +63,20 @@ const SOURCE_META: Record<
   CollectionSourceType,
   { label: string; icon: string; description: string; requires: "tmdb" | "trakt" | null }
 > = {
+  catalog: { label: "My Catalog", icon: "inventory_2", description: "Everything Placeholdarr tracks for this library type", requires: null },
   tmdb_trending: { label: "TMDB Trending", icon: "trending_up", description: "What's trending on TMDB right now", requires: "tmdb" },
   tmdb_popular: { label: "TMDB Popular", icon: "local_fire_department", description: "All-time popular titles on TMDB", requires: "tmdb" },
   tmdb_upcoming: { label: "TMDB Upcoming / On Air", icon: "event_upcoming", description: "Upcoming movies or currently-airing shows", requires: "tmdb" },
   tmdb_discover: { label: "TMDB Discover", icon: "travel_explore", description: "Filter TMDB by genre, year, streaming service", requires: "tmdb" },
-  tmdb_list: { label: "TMDB List", icon: "format_list_bulleted", description: "A public TMDB list by ID", requires: "tmdb" },
+  tmdb_list: { label: "TMDB List", icon: "format_list_bulleted", description: "A public TMDB list — paste the list URL or id", requires: "tmdb" },
+  tmdb_person: { label: "TMDB Person", icon: "person", description: "Filmography for a person — paste their TMDB page URL", requires: "tmdb" },
+  tmdb_company: { label: "TMDB Company", icon: "apartment", description: "Titles from a studio/company — paste the TMDB company URL", requires: "tmdb" },
+  tmdb_keyword: { label: "TMDB Keyword", icon: "sell", description: "Titles tagged with a TMDB keyword — paste the keyword URL", requires: "tmdb" },
+  tmdb_collection: { label: "TMDB Collection", icon: "collections_bookmark", description: "A TMDB movie collection (Star Wars, MCU) — paste the collection URL", requires: "tmdb" },
   mdblist: { label: "MDBList", icon: "playlist_add_check", description: "A public MDBList — paste the list URL", requires: null },
   trakt_list: { label: "Trakt List", icon: "playlist_play", description: "A public Trakt user list — paste the URL or user/slug", requires: "trakt" },
-  catalog: { label: "My Catalog", icon: "inventory_2", description: "Everything Placeholdarr tracks for this library type", requires: null },
+  stevenlu: { label: "StevenLu", icon: "star", description: "Popular movies JSON (Radarr's StevenLu list), or a compatible URL", requires: null },
+  anilist: { label: "AniList", icon: "animation", description: "A public AniList user anime list — paste the profile/list URL", requires: null },
 };
 
 const FILTER_META: Record<CollectionFilterField, { label: string; icon: string }> = {
@@ -126,8 +132,17 @@ function defaultSourceBlock(type: CollectionSourceType): CollectionSourceBlock {
       return { type, genre_ids: [], provider_ids: [], watch_region: "US", limit: 100 };
     case "tmdb_list":
       return { type, list_id: "", limit: 200 };
+    case "tmdb_person":
+      return { type, tmdb_ref: "", limit: 500 };
+    case "tmdb_company":
+    case "tmdb_keyword":
+    case "tmdb_collection":
+      return { type, tmdb_ref: "", limit: 200 };
     case "mdblist":
     case "trakt_list":
+    case "anilist":
+      return { type, list_ref: "", limit: 200 };
+    case "stevenlu":
       return { type, list_ref: "", limit: 200 };
     case "catalog":
       return { type };
@@ -813,7 +828,7 @@ export function CollectionEditor(props: {
   const [definition, setDefinition] = useState<CollectionDefinition>(
     props.recipe?.definition && Array.isArray(props.recipe.definition.sources)
       ? props.recipe.definition
-      : { sources: [defaultSourceBlock(props.tmdbConfigured ? "tmdb_trending" : "catalog")], filters: [], limit: 50, sort: "popularity" },
+      : { sources: [], filters: [], limit: 50, sort: "popularity" },
   );
 
   const sectionId = sectionIds[0] ?? null;
@@ -1121,18 +1136,48 @@ export function CollectionEditor(props: {
 
         {block.type === "tmdb_list" ? (
           <label className={`flex items-center gap-2 ${theme.label}`}>
-            List ID
+            List
             <input
-              className={theme.field}
-              style={{ width: 160 }}
+              className={`${theme.field} flex-1`}
+              style={{ minWidth: 260 }}
               value={block.list_id ?? ""}
-              placeholder="e.g. 8136"
+              placeholder="Paste a TMDB list URL or id, e.g. themoviedb.org/list/8136"
               onChange={(e) => updateSource(index, { list_id: e.target.value })}
             />
           </label>
         ) : null}
 
-        {block.type === "mdblist" || block.type === "trakt_list" ? (
+        {block.type === "tmdb_person" ||
+        block.type === "tmdb_company" ||
+        block.type === "tmdb_keyword" ||
+        block.type === "tmdb_collection" ? (
+          <label className={`flex items-center gap-2 ${theme.label}`}>
+            {block.type === "tmdb_person"
+              ? "Person"
+              : block.type === "tmdb_company"
+                ? "Company"
+                : block.type === "tmdb_keyword"
+                  ? "Keyword"
+                  : "Collection"}
+            <input
+              className={`${theme.field} flex-1`}
+              style={{ minWidth: 260 }}
+              value={block.tmdb_ref ?? ""}
+              placeholder={
+                block.type === "tmdb_person"
+                  ? "Paste the TMDB person URL, e.g. themoviedb.org/person/32982-jane-austen"
+                  : block.type === "tmdb_company"
+                    ? "Paste the TMDB company URL, e.g. themoviedb.org/company/2-lucasfilm-ltd"
+                    : block.type === "tmdb_keyword"
+                      ? "Paste the TMDB keyword URL, e.g. themoviedb.org/keyword/9715-superhero"
+                      : "Paste the TMDB collection URL, e.g. themoviedb.org/collection/10-star-wars-collection"
+              }
+              onChange={(e) => updateSource(index, { tmdb_ref: e.target.value })}
+            />
+          </label>
+        ) : null}
+
+        {block.type === "mdblist" || block.type === "trakt_list" || block.type === "anilist" ? (
           <label className={`flex items-center gap-2 ${theme.label}`}>
             List
             <input
@@ -1142,8 +1187,23 @@ export function CollectionEditor(props: {
               placeholder={
                 block.type === "mdblist"
                   ? "Paste a list URL or user/slug, e.g. linaspurinis/top-watched-movies-of-the-week"
-                  : "Paste a list URL or user/slug, e.g. garycrawfordgc/latest-releases"
+                  : block.type === "anilist"
+                    ? "Paste an AniList URL, e.g. anilist.co/user/NAME/animelist"
+                    : "Paste a list URL or user/slug, e.g. garycrawfordgc/latest-releases"
               }
+              onChange={(e) => updateSource(index, { list_ref: e.target.value })}
+            />
+          </label>
+        ) : null}
+
+        {block.type === "stevenlu" ? (
+          <label className={`flex items-center gap-2 ${theme.label}`}>
+            JSON URL
+            <input
+              className={`${theme.field} flex-1`}
+              style={{ minWidth: 260 }}
+              value={block.list_ref ?? ""}
+              placeholder="Leave blank for the default StevenLu popular-movies list"
               onChange={(e) => updateSource(index, { list_ref: e.target.value })}
             />
           </label>
@@ -1242,7 +1302,7 @@ export function CollectionEditor(props: {
           <NumberInput
             value={block.limit}
             min={1}
-            max={200}
+            max={block.type === "tmdb_person" ? 1000 : 500}
             placeholder="100"
             onChange={(v) => updateSource(index, { limit: v ?? undefined })}
           />
@@ -1810,24 +1870,39 @@ export function CollectionEditor(props: {
         {/* Sources */}
         <div className="flex flex-col gap-2.5">
           <div className={theme.sectionLabel}>Sources</div>
-          {definition.sources.map((block, index) => (
+          {definition.sources.length === 0 ? (
+            <p className="text-[13px] text-slate-500">
+              No source yet. Add one below — nothing is selected by default.
+            </p>
+          ) : null}
+          {definition.sources.map((block, index) => {
+            const meta = SOURCE_META[block.type] ?? {
+              label: block.type,
+              icon: "help",
+              description: "",
+            };
+            return (
             <BlockCard
               key={`${block.type}-${index}`}
-              icon={SOURCE_META[block.type].icon}
-              title={SOURCE_META[block.type].label}
-              subtitle={SOURCE_META[block.type].description}
+              icon={meta.icon}
+              title={meta.label}
+              subtitle={meta.description}
               accentHex={accentHex}
-              onRemove={definition.sources.length > 1 ? () => removeSource(index) : undefined}
+              onRemove={() => removeSource(index)}
             >
               {renderSourceConfig(block, index)}
             </BlockCard>
-          ))}
+            );
+          })}
           <AddBlockMenu
             label="Add source"
             options={(Object.keys(SOURCE_META) as CollectionSourceType[]).map((type) => {
               const requires = SOURCE_META[type].requires;
+              const movieOnly = type === "stevenlu" || type === "tmdb_collection";
               const disabled =
-                (requires === "tmdb" && !props.tmdbConfigured) || (requires === "trakt" && !props.traktConfigured);
+                (requires === "tmdb" && !props.tmdbConfigured) ||
+                (requires === "trakt" && !props.traktConfigured) ||
+                (movieOnly && sectionType !== "movie");
               return {
                 key: type,
                 label: SOURCE_META[type].label,
@@ -1835,7 +1910,9 @@ export function CollectionEditor(props: {
                 description:
                   requires === "trakt" && !props.traktConfigured
                     ? "Add a Trakt Client ID in Settings to enable"
-                    : SOURCE_META[type].description,
+                    : movieOnly && sectionType !== "movie"
+                      ? "Movie libraries only"
+                      : SOURCE_META[type].description,
                 disabled,
               };
             })}

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -2049,7 +2049,7 @@ export function CollectionEditor(props: {
                 <option value="release_date">Release date (newest)</option>
                 <option value="latest_aired">Newest content first{sectionType === "show" ? " (latest aired episode)" : ""}</option>
                 <option value="rating">Rating (highest first)</option>
-                <option value="title">Title (A–Z)</option>
+        <option value="title">Title (A–Z, ignoring a/an/the)</option>
               </select>
             </label>
             {definition.sort === "rating" ? (

--- a/frontend/src/collections/CollectionsPanel.tsx
+++ b/frontend/src/collections/CollectionsPanel.tsx
@@ -272,8 +272,8 @@ export function CollectionsPanel(props: {
       {plexBanner}
       {!tmdbConfigured ? (
         <div className="mb-4 rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-4 py-2.5 text-[14px] text-yellow-300">
-          No TMDB API key configured. TMDB sources (Trending, Popular, Discover…) are disabled — add a key under
-          Settings → Media Integrations to enable them. Catalog-based collections still work.
+          No TMDB API key configured. TMDB sources (Trending, Popular, Discover, person pages…) are disabled — add a
+          key under Settings → Media Integrations to enable them. Catalog, MDBList, StevenLu, and AniList still work.
         </div>
       ) : null}
       {actionError ? (
@@ -297,8 +297,8 @@ export function CollectionsPanel(props: {
             </span>
             <p className={`mt-3 text-[16px] ${isLight ? "text-slate-600" : "text-slate-400"}`}>No collections yet.</p>
             <p className={`mt-1 text-[14px] max-w-md mx-auto ${theme.muted}`}>
-              Build rule-based Plex collections from TMDB trending, streaming services, or your own catalog metadata —
-              they stay in sync automatically.
+              Build rule-based Plex collections from your catalog, TMDB, MDBList, Trakt, StevenLu, or AniList — they
+              stay in sync automatically.
             </p>
           </div>
         ) : (

--- a/frontend/src/collections/CollectionsPanel.tsx
+++ b/frontend/src/collections/CollectionsPanel.tsx
@@ -11,6 +11,7 @@ import {
   type RecipeWritePayload,
 } from "../api/collections";
 import type { CollectionRecipe, LibraryItem, PlexSectionOption } from "../types/api";
+import { ConfirmModal } from "../ConfirmModal";
 import { ToggleSwitch } from "../ToggleSwitch";
 import { CollectionEditor } from "./CollectionEditor";
 import { getCollectionTheme } from "./collectionTheme";
@@ -43,6 +44,8 @@ export function CollectionsPanel(props: {
   onEnsureLibrary: () => void;
   /** Navigate to Settings → Media Integrations (Plex). */
   onOpenPlexSettings?: () => void;
+  /** True while the recipe editor has unsaved edits (for sidebar leave prompts). */
+  onDraftDirty?: (dirty: boolean) => void;
 }) {
   const accentHex = props.accent.hex;
   const isLight = props.themeMode === "light";
@@ -59,12 +62,41 @@ export function CollectionsPanel(props: {
 
   // null = list view; "new" = creating; recipe = editing
   const [editing, setEditing] = useState<CollectionRecipe | "new" | null>(null);
+  const [editorDirty, setEditorDirty] = useState(false);
+  const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [runningIds, setRunningIds] = useState<Set<number>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
 
   const plexReady = sectionsLoaded && !sectionsError;
+
+  const handleEditorDirty = useCallback((dirty: boolean) => {
+    setEditorDirty(dirty);
+  }, []);
+
+  useEffect(() => {
+    props.onDraftDirty?.(editing !== null && editorDirty);
+  }, [editing, editorDirty, props.onDraftDirty]);
+
+  useEffect(() => {
+    return () => props.onDraftDirty?.(false);
+  }, [props.onDraftDirty]);
+
+  const discardEditor = () => {
+    setLeaveConfirmOpen(false);
+    setEditing(null);
+    setSaveError(null);
+    setEditorDirty(false);
+  };
+
+  const leaveEditor = () => {
+    if (editorDirty) {
+      setLeaveConfirmOpen(true);
+      return;
+    }
+    discardEditor();
+  };
 
   const refresh = useCallback(async () => {
     try {
@@ -195,13 +227,22 @@ export function CollectionsPanel(props: {
   if (editing !== null) {
     return (
       <div>
+        {leaveConfirmOpen ? (
+          <ConfirmModal
+            title="Leave without saving?"
+            message="You have an unsaved collection recipe. If you leave now, this draft will be lost."
+            confirmLabel="Leave"
+            cancelLabel="Stay"
+            accentHex={accentHex}
+            themeMode={props.themeMode}
+            onCancel={() => setLeaveConfirmOpen(false)}
+            onConfirm={discardEditor}
+          />
+        ) : null}
         <div className="flex items-center gap-3 mb-6">
           <button
             type="button"
-            onClick={() => {
-              setEditing(null);
-              setSaveError(null);
-            }}
+            onClick={leaveEditor}
             className={`material-symbols-outlined transition-colors ${theme.iconMuted} ${isLight ? "hover:text-slate-900" : "hover:text-white"}`}
             style={{ fontSize: 22 }}
             title="Back to collections"
@@ -226,10 +267,8 @@ export function CollectionsPanel(props: {
           saving={saving}
           saveError={saveError}
           onSave={(payload) => void handleSave(payload)}
-          onCancel={() => {
-            setEditing(null);
-            setSaveError(null);
-          }}
+          onCancel={leaveEditor}
+          onDirtyChange={handleEditorDirty}
         />
       </div>
     );

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -499,14 +499,20 @@ export interface IntegrationTestResponse {
 // ---------------------------------------------------------------------------
 
 export type CollectionSourceType =
+  | "catalog"
   | "tmdb_trending"
   | "tmdb_popular"
   | "tmdb_upcoming"
   | "tmdb_discover"
   | "tmdb_list"
+  | "tmdb_person"
+  | "tmdb_company"
+  | "tmdb_keyword"
+  | "tmdb_collection"
   | "mdblist"
   | "trakt_list"
-  | "catalog";
+  | "stevenlu"
+  | "anilist";
 
 export interface CollectionSourceBlock {
   type: CollectionSourceType;
@@ -519,9 +525,10 @@ export interface CollectionSourceBlock {
   provider_ids?: number[];
   watch_region?: string;
   min_vote_average?: number | null;
-  /** tmdb_list */
+  /** tmdb_list / tmdb_person / tmdb_company / tmdb_keyword / tmdb_collection — id or TMDB URL */
   list_id?: string;
-  /** mdblist / trakt_list — pasted list URL or user/slug */
+  tmdb_ref?: string;
+  /** mdblist / trakt_list / anilist / stevenlu — pasted URL or user/slug */
   list_ref?: string;
   /** per-source candidate cap */
   limit?: number;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -504,6 +504,7 @@ export type CollectionSourceType =
   | "tmdb_popular"
   | "tmdb_upcoming"
   | "tmdb_discover"
+  | "tmdb_url"
   | "tmdb_list"
   | "tmdb_person"
   | "tmdb_company"
@@ -525,6 +526,8 @@ export interface CollectionSourceBlock {
   provider_ids?: number[];
   watch_region?: string;
   min_vote_average?: number | null;
+  /** tmdb_discover / tmdb_url / legacy tmdb company|keyword URL pages */
+  sort_by?: string | null;
   /** tmdb_list / tmdb_person / tmdb_company / tmdb_keyword / tmdb_collection — id or TMDB URL */
   list_id?: string;
   tmdb_ref?: string;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -554,6 +554,9 @@ export type CollectionReleaseWindowBasis =
   | "digital"
   | "physical";
 
+/** Year filter: premiere/release year vs TV first–last air overlap. */
+export type CollectionYearBasis = "premiered" | "aired_during";
+
 /** Radarr nested rating providers for movie rating filters. TV uses Sonarr's flat score. */
 export type CollectionRatingProvider =
   | "imdb"
@@ -568,8 +571,8 @@ export interface CollectionFilterBlock {
   value?: string | number | boolean | null;
   value_to?: number | null;
   values?: string[];
-  /** release_window only: TV air-date mode or movie release type. */
-  basis?: CollectionReleaseWindowBasis | null;
+  /** release_window: TV air-date mode or movie release type. year: premiere vs was-airing-during. */
+  basis?: CollectionReleaseWindowBasis | CollectionYearBasis | null;
   /** rating only (movies): which Radarr ratings.* key to use. */
   provider?: CollectionRatingProvider | null;
   /** rating only: require at least this many votes on the chosen score. */
@@ -716,7 +719,7 @@ export interface CollectionExplainCheck {
   value?: string | number | boolean | null;
   value_to?: number | null;
   values?: string[] | null;
-  basis?: CollectionReleaseWindowBasis | null;
+  basis?: CollectionReleaseWindowBasis | CollectionYearBasis | null;
   provider?: CollectionRatingProvider | null;
   min_votes?: number | null;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -755,6 +755,10 @@ export interface CollectionPreviewSampleItem {
   tmdb_id: number | null;
   tvdb_id: number | null;
   poster: string | null;
+  has_file?: boolean;
+  has_placeholder?: boolean;
+  file_state?: "file" | "placeholder" | "mixed" | "none";
+  in_libraries?: number[];
 }
 
 export interface CollectionMissingFromArrItem {

--- a/routes/collections.py
+++ b/routes/collections.py
@@ -375,6 +375,7 @@ class ArrAddPayload(BaseModel):
     tag: str = "placeholdarr"
 
 
+# Keep in sync with `ARR_ADD_BATCH_CAP` in frontend/src/api/collections.ts
 ARR_ADD_BATCH_CAP = 100
 
 

--- a/routes/collections.py
+++ b/routes/collections.py
@@ -454,54 +454,20 @@ async def arr_add(body: ArrAddPayload):
                     )
                 continue
             tag_ids = [tag_id]
-
-        for item in body.items:
-            title = item.title or "Untitled"
-            try:
-                if body.media_type == "movie":
-                    lookup = arr_api.lookup_movie(url=url, api_key=api_key, tmdb_id=item.tmdb_id, imdb_id=item.imdb_id)
-                    if not lookup:
-                        results.append(
-                            {"title": title, "instance_key": key, "status": "error", "error": "Radarr lookup found nothing"}
-                        )
-                        continue
-                    status, error = arr_api.add_movie_to_radarr(
-                        url=url,
-                        api_key=api_key,
-                        lookup=lookup,
-                        quality_profile_id=opts.quality_profile_id,
-                        root_folder_path=opts.root_folder_path,
-                        monitored=body.monitored,
-                        search=body.search,
-                        tag_ids=tag_ids,
-                    )
-                else:
-                    lookup = arr_api.lookup_series(
-                        url=url,
-                        api_key=api_key,
-                        tvdb_id=item.tvdb_id,
-                        tmdb_id=item.tmdb_id,
-                        imdb_id=item.imdb_id,
-                    )
-                    if not lookup:
-                        results.append(
-                            {"title": title, "instance_key": key, "status": "error", "error": "Sonarr lookup found nothing"}
-                        )
-                        continue
-                    status, error = arr_api.add_series_to_sonarr(
-                        url=url,
-                        api_key=api_key,
-                        lookup=lookup,
-                        quality_profile_id=opts.quality_profile_id,
-                        root_folder_path=opts.root_folder_path,
-                        monitored=body.monitored,
-                        search=body.search,
-                        tag_ids=tag_ids,
-                    )
-            except Exception as exc:
-                results.append({"title": title, "instance_key": key, "status": "error", "error": str(exc)})
-                continue
-            results.append({"title": title, "instance_key": key, "status": status, "error": error})
+        results.extend(
+            arr_api.add_missing_titles(
+                media_type=body.media_type,
+                url=url,
+                api_key=api_key,
+                items=body.items,
+                quality_profile_id=opts.quality_profile_id,
+                root_folder_path=opts.root_folder_path,
+                monitored=body.monitored,
+                search=body.search,
+                tag_ids=tag_ids,
+                instance_key=key,
+            )
+        )
 
     ok = sum(1 for row in results if row.get("status") == "ok")
     skipped = sum(1 for row in results if row.get("status") == "skipped")

--- a/services/app_config.py
+++ b/services/app_config.py
@@ -1442,6 +1442,21 @@ def save_settings(
                 session.add(setup_row)
 
         session.commit()
+        plex_location_cache_keys = {
+            "ENABLE_PLEX",
+            "PLEX_URL",
+            "PLEX_TOKEN",
+            "PLEX_MOVIE_SECTION_ID",
+            "PLEX_TV_SECTION_ID",
+            "LIBRARY_ROOT",
+        }
+        if plex_location_cache_keys.intersection(saved_keys):
+            try:
+                from services.media_servers.plex import clear_plex_section_location_cache
+
+                clear_plex_section_location_cache()
+            except Exception:
+                pass
         if specials_before is not None and specials_after is not None and specials_before != specials_after:
             try:
                 from services.source_of_truth.lite_reconcile import mark_specials_backfill_pending

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -68,6 +68,7 @@ MOVIE_RATING_PROVIDERS = ("imdb", "tmdb", "trakt", "metacritic", "rottenTomatoes
 DEFAULT_SOURCE_LIMIT = 100
 MAX_COLLECTION_ITEMS = 500
 MISSING_FROM_ARR_CAP = 200
+PREVIEW_SAMPLE_SIZE = 200
 TMDB_POSTER_BASE = "https://image.tmdb.org/t/p/w185"
 
 
@@ -424,6 +425,8 @@ def _missing_from_arr_items(
     pins: Any = None,
     genre_map: Optional[dict[int, str]] = None,
     cap: int = MISSING_FROM_ARR_CAP,
+    sort: Optional[str] = None,
+    sort_provider: Optional[str] = None,
 ) -> tuple[list[dict[str, Any]], int, int, list[str]]:
     """Source candidates not in the catalog, after recipe filters that can run off-list.
 
@@ -443,6 +446,7 @@ def _missing_from_arr_items(
         raw.append(candidate)
     prefilter = len(raw)
     kept = [c for c in raw if tree is None or _candidate_node_passes(c, tree, section_type, genre_map or {})]
+    kept = _sort_candidates(kept, sort, sort_provider)
     items = [
         {
             "title": candidate.get("title") or "Untitled",
@@ -1312,6 +1316,55 @@ def _sort_rows(
     return rows
 
 
+def _candidate_rating_score(candidate: dict[str, Any], sort_provider: Optional[str]) -> float:
+    ratings = candidate.get("ratings") if isinstance(candidate.get("ratings"), dict) else {}
+    if sort_provider and ratings:
+        raw = ratings.get(sort_provider) or ratings.get(str(sort_provider).lower())
+        if isinstance(raw, dict):
+            raw = raw.get("value")
+        try:
+            if raw is not None:
+                return float(raw)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return float(candidate.get("vote_average"))
+    except (TypeError, ValueError):
+        return float("-inf")
+
+
+def _sort_candidates(
+    candidates: list[dict[str, Any]],
+    sort: Optional[str],
+    sort_provider: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Apply the recipe Arrange sort to missing-from-ARR candidates (stable)."""
+    if not sort:
+        return candidates
+    indexed = list(enumerate(candidates))
+    epoch = datetime(1900, 1, 1, tzinfo=timezone.utc)
+
+    def keyed(item: tuple[int, dict[str, Any]]) -> tuple:
+        index, candidate = item
+        if sort == "title":
+            return (_title_sort_key(candidate.get("title")), index)
+        if sort in ("release_date", "latest_aired"):
+            dt = _candidate_release_dt(candidate) or epoch
+            return (-dt.timestamp(), index)
+        if sort == "rating":
+            score = _candidate_rating_score(candidate, sort_provider)
+            return (-score, index)
+        # popularity / list rank (missing popularity keeps source order)
+        try:
+            pop = float(candidate.get("popularity") or 0)
+        except (TypeError, ValueError):
+            pop = 0.0
+        return (-pop, index)
+
+    indexed.sort(key=keyed)
+    return [candidate for _index, candidate in indexed]
+
+
 # ---------------------------------------------------------------------------
 # Pins (always include / always exclude)
 # ---------------------------------------------------------------------------
@@ -1424,7 +1477,44 @@ def _provider_key_groups(rows: list[Any], section_type: str) -> list[list[str]]:
     return groups
 
 
-def _row_summary(row: Any, section_type: str) -> dict[str, Any]:
+def _row_has_file_placeholder(row: Any, section_type: str) -> tuple[bool, bool]:
+    if section_type == "movie":
+        return bool(getattr(row, "has_file", False)), bool(getattr(row, "has_placeholder", False))
+    has_file = bool(getattr(row, "has_files", False) or int(getattr(row, "episode_files", 0) or 0))
+    has_placeholder = bool(
+        int(getattr(row, "episode_placeholders", 0) or 0) or getattr(row, "has_placeholder", False)
+    )
+    return has_file, has_placeholder
+
+
+def _catalog_file_state(rows: list[Any], section_type: str) -> dict[Any, tuple[bool, bool]]:
+    """OR file/placeholder flags across ARR instances for the same title."""
+    acc: dict[Any, tuple[bool, bool]] = {}
+    for row in rows:
+        ident = _row_identity(row, section_type)
+        if ident in (None, 0):
+            continue
+        has_file, has_placeholder = _row_has_file_placeholder(row, section_type)
+        prev = acc.get(ident, (False, False))
+        acc[ident] = (prev[0] or has_file, prev[1] or has_placeholder)
+    return acc
+
+
+def _row_summary(
+    row: Any,
+    section_type: str,
+    file_state: Optional[dict[Any, tuple[bool, bool]]] = None,
+) -> dict[str, Any]:
+    ident = _row_identity(row, section_type)
+    has_file, has_placeholder = (file_state or {}).get(ident, _row_has_file_placeholder(row, section_type))
+    if has_file and has_placeholder:
+        state = "mixed"
+    elif has_file:
+        state = "file"
+    elif has_placeholder:
+        state = "placeholder"
+    else:
+        state = "none"
     return {
         "id": row.id,
         "title": row.title,
@@ -1432,6 +1522,10 @@ def _row_summary(row: Any, section_type: str) -> dict[str, Any]:
         "tmdb_id": int(row.tmdbid if section_type == "movie" else (row.sonarr_tmdbid or 0)) or None,
         "tvdb_id": int(getattr(row, "tvdbid", 0) or 0) or None,
         "poster": row.remote_poster,
+        "has_file": has_file,
+        "has_placeholder": has_placeholder,
+        "file_state": state,
+        "in_libraries": [],
     }
 
 
@@ -1454,6 +1548,7 @@ def _evaluate(
 
     rows = _load_catalog_rows(section_type, id_sets)
     matched_count = len(_dedupe_rows(rows, section_type))
+    file_state = _catalog_file_state(rows, section_type)
     missing_items, missing_count, missing_prefilter, missing_gaps = _missing_from_arr_items(
         candidates,
         rows,
@@ -1461,6 +1556,8 @@ def _evaluate(
         filters=normalized["filters"],
         pins=normalized["pins"],
         genre_map=_tmdb_genre_map(media_type),
+        sort=normalized["sort"],
+        sort_provider=normalized.get("sort_provider"),
     )
 
     air_dates = (
@@ -1505,6 +1602,7 @@ def _evaluate(
         "missing_from_arr_count": missing_count,
         "missing_from_arr_prefilter_count": missing_prefilter,
         "missing_from_arr_filter_gaps": missing_gaps,
+        "file_state": file_state,
     }
 
     if resolve:
@@ -1560,15 +1658,18 @@ def preview_definition(
     section_id: int,
     section_type: str,
     *,
-    sample_size: int = 48,
+    sample_size: int = PREVIEW_SAMPLE_SIZE,
     extra_section_ids: Any = None,
 ) -> dict[str, Any]:
     """Evaluate a definition without writing to Plex. Returns staged counts + sample items."""
     section_ids = normalize_section_ids(section_id, extra_section_ids)
     primary = _evaluate(definition, section_ids[0], section_type, resolve=True)
-    sample = [_row_summary(row, section_type) for row in primary["rows"][:sample_size]]
+    sample_rows = primary["rows"][:sample_size]
+    file_state = primary.get("file_state") or {}
+    sample = [_row_summary(row, section_type, file_state) for row in sample_rows]
     libraries: list[dict[str, Any]] = []
     plex_errors: list[str] = []
+    key_groups = _provider_key_groups(sample_rows, section_type)
     for sid in section_ids:
         outcome = primary if sid == section_ids[0] else _evaluate(definition, sid, section_type, resolve=True)
         libraries.append(
@@ -1581,6 +1682,13 @@ def preview_definition(
         )
         if outcome["plex_error"]:
             plex_errors.append(str(outcome["plex_error"]))
+        try:
+            mask = plex_collections.membership_mask(sid, section_type, key_groups)
+        except plex_collections.PlexCollectionsError:
+            mask = [False] * len(sample)
+        for index, present in enumerate(mask):
+            if present and index < len(sample):
+                sample[index]["in_libraries"].append(sid)
     in_library_total = sum(int(lib["in_target_library"] or 0) for lib in libraries)
     unresolved_total = sum(int(lib["unresolved"] or 0) for lib in libraries)
     return {

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -63,6 +63,8 @@ RELEASE_WINDOW_BASES = (
     "physical",
 )
 MOVIE_RELEASE_BASES = ("theater", "digital", "physical")
+# Year filter: premiere (series/movie year) vs TV first–last air overlap.
+YEAR_BASES = ("premiered", "aired_during")
 # Radarr nested rating providers (Sonarr is a single flat value/votes).
 MOVIE_RATING_PROVIDERS = ("imdb", "tmdb", "trakt", "metacritic", "rottenTomatoes")
 DEFAULT_SOURCE_LIMIT = 100
@@ -88,6 +90,9 @@ def _validate_filter_rule(rule: Any) -> dict[str, Any]:
     if rule.get("field") == "release_window" and rule.get("basis") is not None:
         if rule["basis"] not in RELEASE_WINDOW_BASES:
             raise RecipeValidationError(f"unknown release_window basis: {rule['basis']!r}")
+    if rule.get("field") == "year" and rule.get("basis") is not None:
+        if rule["basis"] not in YEAR_BASES:
+            raise RecipeValidationError(f"unknown year basis: {rule['basis']!r}")
     if rule.get("field") == "rating":
         provider = rule.get("provider")
         if provider is not None and provider not in MOVIE_RATING_PROVIDERS:
@@ -523,6 +528,48 @@ def _candidate_language_names(candidate: dict[str, Any]) -> set[str]:
     return names
 
 
+def _year_window_bounds(rule: dict[str, Any]) -> tuple[int, int]:
+    op = str(rule.get("op") or "")
+    if op == "gte":
+        return int(rule.get("value") or 0), 9999
+    if op == "lte":
+        return 0, int(rule.get("value") or 9999)
+    if op == "between":
+        return int(rule.get("value") or 0), int(rule.get("value_to") or 9999)
+    value = int(rule.get("value") or 0)
+    return value, value
+
+
+def _year_span_matches(start: Optional[int], end: Optional[int], rule: dict[str, Any]) -> bool:
+    """True when [start, end] overlaps the rule window. ``end is None`` means still running."""
+    if not start:
+        return False
+    low, high = _year_window_bounds(rule)
+    last = int(end) if end else 9999
+    return int(start) <= high and last >= low
+
+
+def _year_from_date_value(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return int(raw.year)
+    if hasattr(raw, "year") and not isinstance(raw, str):
+        try:
+            return int(raw.year)
+        except (TypeError, ValueError):
+            pass
+    text = str(raw).strip()
+    if len(text) >= 4 and text[:4].isdigit():
+        year = int(text[:4])
+        return year if year > 0 else None
+    try:
+        year = int(text)
+    except (TypeError, ValueError):
+        return None
+    return year if year > 0 else None
+
+
 def _candidate_year(candidate: dict[str, Any]) -> Optional[int]:
     try:
         year = int(candidate.get("year") or 0)
@@ -530,10 +577,46 @@ def _candidate_year(candidate: dict[str, Any]) -> Optional[int]:
         year = 0
     if year:
         return year
-    date = str(candidate.get("date") or "")
-    if len(date) >= 4 and date[:4].isdigit():
-        return int(date[:4])
-    return None
+    return _year_from_date_value(candidate.get("date"))
+
+
+def _candidate_last_year(candidate: dict[str, Any]) -> Optional[int]:
+    try:
+        year = int(candidate.get("last_year") or 0)
+    except (TypeError, ValueError):
+        year = 0
+    if year:
+        return year
+    return _year_from_date_value(candidate.get("last_air_date") or candidate.get("last_aired"))
+
+
+def _row_premiere_year(row: Any) -> Optional[int]:
+    try:
+        year = int(row.year or 0)
+    except (TypeError, ValueError):
+        year = 0
+    return year or None
+
+
+def _row_year_span(
+    row: Any,
+    section_type: str,
+    rule: dict[str, Any],
+    air_dates: Optional[dict[int, dict[str, Optional[datetime]]]] = None,
+) -> tuple[Optional[int], Optional[int]]:
+    premiere = _row_premiere_year(row)
+    basis = str(rule.get("basis") or "premiered")
+    if section_type != "show" or basis != "aired_during":
+        return premiere, premiere
+    entry = (air_dates or {}).get(int(getattr(row, "id", 0) or 0)) or {}
+    start_dt = entry.get("aired_start")
+    end_dt = entry.get("aired_end")
+    start = int(start_dt.year) if start_dt is not None else premiere
+    if end_dt is not None:
+        return start, int(end_dt.year)
+    if start_dt is None:
+        return premiere, premiere
+    return start, None
 
 
 def _candidate_release_dt(candidate: dict[str, Any]) -> Optional[datetime]:
@@ -657,18 +740,11 @@ def _candidate_passes_filter(
     op = str(rule.get("op") or "")
 
     if field == "year":
-        year = _candidate_year(candidate)
-        if not year:
-            return False
-        if op == "gte":
-            return year >= int(rule.get("value") or 0)
-        if op == "lte":
-            return year <= int(rule.get("value") or 9999)
-        if op == "between":
-            low = int(rule.get("value") or 0)
-            high = int(rule.get("value_to") or 9999)
-            return low <= year <= high
-        return year == int(rule.get("value") or 0)
+        start = _candidate_year(candidate)
+        basis = str(rule.get("basis") or "premiered")
+        if section_type == "show" and basis == "aired_during":
+            return _year_span_matches(start, _candidate_last_year(candidate), rule)
+        return _year_span_matches(start, start, rule)
 
     if field == "genre":
         values = {str(v).strip().lower() for v in (rule.get("values") or []) if v}
@@ -1007,6 +1083,8 @@ def _definition_needs_air_dates(normalized: dict[str, Any], section_type: str) -
     for rule in _iter_filter_rules(normalized["filters"]):
         if rule.get("field") == "release_window" and rule.get("basis") in ("latest_episode", "latest_season"):
             return True
+        if rule.get("field") == "year" and str(rule.get("basis") or "") == "aired_during":
+            return True
     return False
 
 
@@ -1036,6 +1114,23 @@ def _load_air_date_lookup(series_row_ids: list[int]) -> dict[int, dict[str, Opti
         )
         for series_id, latest in latest_episode_rows:
             lookup.setdefault(int(series_id), {})["latest_episode"] = _coerce_utc_datetime(latest)
+
+        aired_span_rows = (
+            session.query(Season.series_id, func.min(Episode.air_date), func.max(Episode.air_date))
+            .join(Episode, Episode.season_id == Season.id)
+            .filter(
+                Season.series_id.in_(series_row_ids),
+                Season.is_deleted.is_(False),
+                Episode.is_deleted.is_(False),
+                Episode.air_date.isnot(None),
+            )
+            .group_by(Season.series_id)
+            .all()
+        )
+        for series_id, earliest, latest in aired_span_rows:
+            entry = lookup.setdefault(int(series_id), {})
+            entry["aired_start"] = _coerce_utc_datetime(earliest)
+            entry["aired_end"] = _coerce_utc_datetime(latest)
 
         # Season premieres: MIN(air_date) per season, then the newest premiere that has
         # already aired. Season 0 (specials) excluded so a one-off special doesn't count
@@ -1103,18 +1198,8 @@ def _passes_filter(
         return bool(genres & values)
 
     if field == "year":
-        year = int(row.year or 0)
-        if not year:
-            return False
-        if op == "gte":
-            return year >= int(rule.get("value") or 0)
-        if op == "lte":
-            return year <= int(rule.get("value") or 9999)
-        if op == "between":
-            low = int(rule.get("value") or 0)
-            high = int(rule.get("value_to") or 9999)
-            return low <= year <= high
-        return year == int(rule.get("value") or 0)
+        start, end = _row_year_span(row, section_type, rule, air_dates)
+        return _year_span_matches(start, end, rule)
 
     if field == "certification":
         values = {str(v).strip().upper() for v in (rule.get("values") or []) if v}

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -23,14 +23,20 @@ from services.postgres.db import session_scope
 from services.postgres.models import CollectionRecipe, Episode, Movie, Season, Series
 
 SOURCE_TYPES = (
+    "catalog",
     "tmdb_trending",
     "tmdb_popular",
     "tmdb_upcoming",
     "tmdb_discover",
     "tmdb_list",
+    "tmdb_person",
+    "tmdb_company",
+    "tmdb_keyword",
+    "tmdb_collection",
     "mdblist",
     "trakt_list",
-    "catalog",
+    "stevenlu",
+    "anilist",
 )
 FILTER_FIELDS = (
     "genre",
@@ -158,9 +164,13 @@ def validate_definition(definition: dict[str, Any]) -> dict[str, Any]:
         source_type = source.get("type")
         if source_type not in SOURCE_TYPES:
             raise RecipeValidationError(f"unknown source type: {source_type!r}")
-        if source_type == "tmdb_list" and not str(source.get("list_id") or "").strip():
-            raise RecipeValidationError("tmdb_list source requires a list_id")
-        if source_type in ("mdblist", "trakt_list") and not str(source.get("list_ref") or "").strip():
+        if source_type == "tmdb_list" and not str(source.get("list_id") or source.get("tmdb_ref") or "").strip():
+            raise RecipeValidationError("tmdb_list source requires a list id or TMDB list URL")
+        if source_type in ("tmdb_person", "tmdb_company", "tmdb_keyword", "tmdb_collection") and not str(
+            source.get("tmdb_ref") or ""
+        ).strip():
+            raise RecipeValidationError(f"{source_type} source requires a TMDB URL or numeric id")
+        if source_type in ("mdblist", "trakt_list", "anilist") and not str(source.get("list_ref") or "").strip():
             raise RecipeValidationError(f"{source_type} source requires a list URL or user/slug")
         normalized_sources.append(source)
 
@@ -241,11 +251,23 @@ def _fetch_source_items(source: dict[str, Any], media_type: str) -> list[dict[st
             limit=limit,
         )
     if source_type == "tmdb_list":
-        return tmdb_client.fetch_list(str(source.get("list_id")), media_type, limit)
+        return tmdb_client.fetch_list(str(source.get("list_id") or source.get("tmdb_ref") or ""), media_type, limit)
+    if source_type == "tmdb_person":
+        return tmdb_client.fetch_person_credits(str(source.get("tmdb_ref") or ""), media_type, limit)
+    if source_type == "tmdb_company":
+        return tmdb_client.fetch_company(str(source.get("tmdb_ref") or ""), media_type, limit)
+    if source_type == "tmdb_keyword":
+        return tmdb_client.fetch_keyword(str(source.get("tmdb_ref") or ""), media_type, limit)
+    if source_type == "tmdb_collection":
+        return tmdb_client.fetch_collection(str(source.get("tmdb_ref") or ""), media_type, limit)
     if source_type == "mdblist":
         return list_sources.fetch_mdblist(str(source.get("list_ref")), media_type, limit)
     if source_type == "trakt_list":
         return list_sources.fetch_trakt_list(str(source.get("list_ref")), media_type, limit)
+    if source_type == "stevenlu":
+        return list_sources.fetch_stevenlu(str(source.get("list_ref") or ""), media_type, limit)
+    if source_type == "anilist":
+        return list_sources.fetch_anilist(str(source.get("list_ref")), media_type, limit)
     return []
 
 

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -10,6 +10,7 @@ collection so the builder UI can show live staged counts.
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
@@ -1229,6 +1230,19 @@ def _apply_filters(
 # Sort / limit
 # ---------------------------------------------------------------------------
 
+_LEADING_NON_ALNUM = re.compile(r"^[^a-z0-9]+", re.IGNORECASE)
+_LEADING_ARTICLE = re.compile(r"^(the|an|a)\s+", re.IGNORECASE)
+
+
+def _title_sort_key(title: str | None) -> str:
+    """Same rules as frontend `titleSortKey`: drop leading punctuation and a/an/the."""
+    raw = str(title or "").strip().lower()
+    raw = _LEADING_NON_ALNUM.sub("", raw)
+    raw = _LEADING_ARTICLE.sub("", raw)
+    raw = _LEADING_NON_ALNUM.sub("", raw)
+    return raw
+
+
 def _sort_rows(
     rows: list[Any],
     sort: Optional[str],
@@ -1238,7 +1252,7 @@ def _sort_rows(
     sort_provider: Optional[str] = None,
 ) -> list[Any]:
     if sort == "title":
-        return sorted(rows, key=lambda r: str(r.title or "").lower())
+        return sorted(rows, key=lambda r: _title_sort_key(getattr(r, "title", None)))
     if sort == "release_date":
         epoch = datetime(1900, 1, 1, tzinfo=timezone.utc)
         return sorted(rows, key=lambda r: _row_release_date(r, section_type) or epoch, reverse=True)

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -28,6 +28,7 @@ SOURCE_TYPES = (
     "tmdb_popular",
     "tmdb_upcoming",
     "tmdb_discover",
+    "tmdb_url",
     "tmdb_list",
     "tmdb_person",
     "tmdb_company",
@@ -67,6 +68,18 @@ MOVIE_RELEASE_BASES = ("theater", "digital", "physical")
 YEAR_BASES = ("premiered", "aired_during")
 # Radarr nested rating providers (Sonarr is a single flat value/votes).
 MOVIE_RATING_PROVIDERS = ("imdb", "tmdb", "trakt", "metacritic", "rottenTomatoes")
+TMDB_SOURCE_SORTS = (
+    "popularity.desc",
+    "popularity.asc",
+    "vote_average.desc",
+    "vote_average.asc",
+    "vote_count.desc",
+    "vote_count.asc",
+    "primary_release_date.desc",
+    "primary_release_date.asc",
+    "title.asc",
+    "title.desc",
+)
 DEFAULT_SOURCE_LIMIT = 100
 MAX_COLLECTION_ITEMS = 500
 MISSING_FROM_ARR_CAP = 200
@@ -172,10 +185,15 @@ def validate_definition(definition: dict[str, Any]) -> dict[str, Any]:
             raise RecipeValidationError(f"unknown source type: {source_type!r}")
         if source_type == "tmdb_list" and not str(source.get("list_id") or source.get("tmdb_ref") or "").strip():
             raise RecipeValidationError("tmdb_list source requires a list id or TMDB list URL")
+        if source_type == "tmdb_url" and not str(source.get("tmdb_ref") or "").strip():
+            raise RecipeValidationError("tmdb_url source requires a TMDB page URL")
         if source_type in ("tmdb_person", "tmdb_company", "tmdb_keyword", "tmdb_collection") and not str(
             source.get("tmdb_ref") or ""
         ).strip():
             raise RecipeValidationError(f"{source_type} source requires a TMDB URL or numeric id")
+        sort_by = source.get("sort_by")
+        if sort_by is not None and str(sort_by).strip() and str(sort_by) not in TMDB_SOURCE_SORTS:
+            raise RecipeValidationError(f"unknown TMDB source sort: {sort_by!r}")
         if source_type in ("mdblist", "trakt_list", "anilist") and not str(source.get("list_ref") or "").strip():
             raise RecipeValidationError(f"{source_type} source requires a list URL or user/slug")
         normalized_sources.append(source)
@@ -239,6 +257,7 @@ def _fetch_source_items(source: dict[str, Any], media_type: str) -> list[dict[st
     """Fetch candidates for one external source block (cached by the underlying clients)."""
     source_type = source.get("type")
     limit = int(source.get("limit") or DEFAULT_SOURCE_LIMIT)
+    source_sort = tmdb_client.normalize_tmdb_sort_by(source.get("sort_by"), media_type)
     if source_type == "tmdb_trending":
         return tmdb_client.fetch_trending(media_type, str(source.get("window") or "week"), limit)
     if source_type == "tmdb_popular":
@@ -254,16 +273,31 @@ def _fetch_source_items(source: dict[str, Any], media_type: str) -> list[dict[st
             provider_ids=[int(p) for p in (source.get("provider_ids") or [])],
             watch_region=source.get("watch_region"),
             min_vote_average=source.get("min_vote_average"),
+            sort_by=source_sort,
             limit=limit,
         )
+    if source_type == "tmdb_url":
+        tmdb_ref = str(source.get("tmdb_ref") or "")
+        kind = tmdb_client.parse_tmdb_resource_kind(tmdb_ref)
+        if kind == "list":
+            return tmdb_client.fetch_list(tmdb_ref, media_type, limit)
+        if kind == "person":
+            return tmdb_client.fetch_person_credits(tmdb_ref, media_type, limit)
+        if kind == "company":
+            return tmdb_client.fetch_company(tmdb_ref, media_type, limit, source_sort)
+        if kind == "keyword":
+            return tmdb_client.fetch_keyword(tmdb_ref, media_type, limit, source_sort)
+        if kind == "collection":
+            return tmdb_client.fetch_collection(tmdb_ref, media_type, limit)
+        raise tmdb_client.TmdbError("TMDB URL source needs a TMDB list, person, company, keyword, or collection URL")
     if source_type == "tmdb_list":
         return tmdb_client.fetch_list(str(source.get("list_id") or source.get("tmdb_ref") or ""), media_type, limit)
     if source_type == "tmdb_person":
         return tmdb_client.fetch_person_credits(str(source.get("tmdb_ref") or ""), media_type, limit)
     if source_type == "tmdb_company":
-        return tmdb_client.fetch_company(str(source.get("tmdb_ref") or ""), media_type, limit)
+        return tmdb_client.fetch_company(str(source.get("tmdb_ref") or ""), media_type, limit, source_sort)
     if source_type == "tmdb_keyword":
-        return tmdb_client.fetch_keyword(str(source.get("tmdb_ref") or ""), media_type, limit)
+        return tmdb_client.fetch_keyword(str(source.get("tmdb_ref") or ""), media_type, limit, source_sort)
     if source_type == "tmdb_collection":
         return tmdb_client.fetch_collection(str(source.get("tmdb_ref") or ""), media_type, limit)
     if source_type == "mdblist":

--- a/services/integrations.py
+++ b/services/integrations.py
@@ -234,7 +234,15 @@ def _assert_media_server_matches_payload(data: dict[str, Any], expected: str) ->
 
 def test_plex_connection(url: str, token: str) -> dict[str, Any]:
     endpoint = _normalize_url(url)
-    ok, message = _test_get(f'{endpoint}/identity', headers={'X-Plex-Token': str(token or '').strip()})
+    token_value = str(token or '').strip()
+    ok, message = _test_get(f'{endpoint}/identity', headers={'X-Plex-Token': token_value})
+    if ok:
+        try:
+            from services.media_servers.plex import prime_plex_section_location_cache
+
+            prime_plex_section_location_cache(plex_url=endpoint, plex_token=token_value)
+        except Exception:
+            pass
     return {'ok': ok, 'message': message, 'service': 'plex'}
 
 

--- a/services/list_sources.py
+++ b/services/list_sources.py
@@ -2,7 +2,9 @@
 
 Public lists only — no account linking:
 - MDBList: public list JSON export, no API key required.
-- Trakt: public user lists, requires a free API Client ID (header auth, no OAuth).
+- Trakt: public user lists, requires a Client ID (header auth, no OAuth).
+- StevenLu: public popular-movies JSON (or a compatible custom URL).
+- AniList: public user anime lists via GraphQL (rate-limited).
 
 Items are normalized to the same candidate shape the engine expects, with
 multi-provider ids so catalog matching can fall back to IMDb/TVDB when a
@@ -308,6 +310,245 @@ def fetch_trakt_list(reference: str, media_type: str, limit: int = 200) -> list[
                 imdb_id=imdb_id,
                 tvdb_id=tvdb_id,
                 rank=raw.get("rank"),
+            )
+        )
+        if len(items) >= limit:
+            break
+
+    _cache_set(cache_key, items)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# StevenLu
+# ---------------------------------------------------------------------------
+
+STEVENLU_DEFAULT_URL = "https://s3.amazonaws.com/popular-movies/movies.json"
+
+
+def fetch_stevenlu(reference: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+    """Fetch StevenLu popular-movies JSON (IMDb ids). Movies only."""
+    if media_type != "movie":
+        raise ListSourceError("StevenLu lists are movie-only")
+    url = str(reference or "").strip() or STEVENLU_DEFAULT_URL
+    if not url.startswith("http://") and not url.startswith("https://"):
+        raise ListSourceError("StevenLu source needs an https JSON URL")
+    limit = max(1, min(int(limit or 200), 1000))
+    cache_key = f"stevenlu:{url}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+    resp = _get_with_retry(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "Placeholdarr"},
+        source_name="StevenLu",
+    )
+    if resp.status_code != 200:
+        raise ListSourceError(f"StevenLu URL returned HTTP {resp.status_code}")
+    try:
+        data = resp.json()
+    except ValueError as extra:
+        raise ListSourceError("StevenLu URL did not return JSON") from extra
+    if not isinstance(data, list):
+        raise ListSourceError("Unexpected StevenLu payload (expected a JSON array)")
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in data:
+        if not isinstance(raw, dict):
+            continue
+        imdb_id = raw.get("imdb_id") or raw.get("imdb") or raw.get("imdbid")
+        tmdb_id = raw.get("tmdb") or raw.get("tmdb_id") or raw.get("tmdbid")
+        title = str(raw.get("title") or raw.get("name") or "")
+        key = str(imdb_id or tmdb_id or title)
+        if not key or key in seen:
+            continue
+        if not (imdb_id or tmdb_id):
+            continue
+        seen.add(key)
+        year = None
+        try:
+            year = int(raw.get("year") or 0) or None
+        except (TypeError, ValueError):
+            year = None
+        items.append(
+            _normalize_candidate(
+                title=title,
+                year=year,
+                tmdb_id=int(tmdb_id) if tmdb_id else None,
+                imdb_id=str(imdb_id) if imdb_id else None,
+                tvdb_id=None,
+                rank=len(items) + 1,
+            )
+        )
+        if len(items) >= limit:
+            break
+    _cache_set(cache_key, items)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# AniList
+# ---------------------------------------------------------------------------
+
+ANILIST_GRAPHQL_URL = "https://graphql.anilist.co"
+_ANILIST_MIN_INTERVAL_SECONDS = 2.1
+_anilist_lock = threading.Lock()
+_anilist_last_at = 0.0
+
+_ANILIST_USER_RE = re.compile(
+    r"anilist\.co/user/([^/\s]+)(?:/(?:animelist|mangalist)(?:/([^/\s?#]+))?)?",
+    re.IGNORECASE,
+)
+
+_ANILIST_QUERY = """
+query ($userName: String, $type: MediaType) {
+  MediaListCollection(userName: $userName, type: $type) {
+    lists {
+      name
+      isCustomList
+      entries {
+        media {
+          id
+          idMal
+          format
+          type
+          title { english romaji native }
+          startDate { year }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def parse_anilist_reference(reference: str) -> tuple[str, Optional[str]]:
+    """Return (username, optional custom list name) from a URL or user/list."""
+    text = str(reference or "").strip()
+    if not text:
+        raise ListSourceError("AniList source requires a user list URL")
+    match = _ANILIST_USER_RE.search(text)
+    if match:
+        return match.group(1), match.group(2)
+    parts = [p for p in text.strip("/").split("/") if p]
+    if len(parts) == 1:
+        return parts[0], None
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    raise ListSourceError("Could not parse AniList reference; expected anilist.co/user/NAME/animelist")
+
+
+def _anilist_throttle() -> None:
+    global _anilist_last_at
+    with _anilist_lock:
+        wait = _ANILIST_MIN_INTERVAL_SECONDS - (time.monotonic() - _anilist_last_at)
+        if wait > 0:
+            time.sleep(wait)
+        _anilist_last_at = time.monotonic()
+
+
+def fetch_anilist(reference: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+    """Fetch a public AniList user anime list (one GraphQL call, cached)."""
+    user, list_name = parse_anilist_reference(reference)
+    limit = max(1, min(int(limit or 200), 1000))
+    cache_key = f"anilist:{user}:{list_name or '*'}:{media_type}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    wanted_movie = media_type == "movie"
+    payload = {
+        "query": _ANILIST_QUERY,
+        "variables": {"userName": user, "type": "ANIME"},
+    }
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "Placeholdarr",
+        "Content-Type": "application/json",
+    }
+    try:
+        _anilist_throttle()
+        resp = requests.post(ANILIST_GRAPHQL_URL, json=payload, headers=headers, timeout=LIST_HTTP_TIMEOUT_SECONDS)
+        if resp.status_code == 429:
+            try:
+                delay = min(max(float(resp.headers.get("Retry-After", 60)), 2.0), 90.0)
+            except (TypeError, ValueError):
+                delay = 60.0
+            time.sleep(delay)
+            _anilist_throttle()
+            resp = requests.post(ANILIST_GRAPHQL_URL, json=payload, headers=headers, timeout=LIST_HTTP_TIMEOUT_SECONDS)
+    except requests.RequestException as exc:
+        raise ListSourceError(f"AniList request failed: {exc}") from exc
+    if resp.status_code == 429:
+        raise ListSourceError("AniList rate limit exceeded — try again in a minute")
+    if resp.status_code != 200:
+        raise ListSourceError(f"AniList returned HTTP {resp.status_code}")
+    try:
+        body = resp.json()
+    except ValueError as extra:
+        raise ListSourceError("AniList returned invalid JSON") from extra
+    errors = body.get("errors") if isinstance(body, dict) else None
+    if errors:
+        message = errors[0].get("message") if errors and isinstance(errors[0], dict) else "AniList query failed"
+        raise ListSourceError(str(message))
+    collection = ((body.get("data") or {}).get("MediaListCollection") or {})
+    lists = collection.get("lists") or []
+    wanted_slug = (list_name or "").replace("-", " ").strip().lower()
+    entries: list[dict[str, Any]] = []
+    for lst in lists:
+        if not isinstance(lst, dict):
+            continue
+        name = str(lst.get("name") or "")
+        if wanted_slug and name.replace("-", " ").strip().lower() != wanted_slug:
+            continue
+        for entry in lst.get("entries") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("media"), dict):
+                entries.append(entry["media"])
+        if wanted_slug:
+            break
+    if wanted_slug and not entries:
+        raise ListSourceError(f"AniList list {list_name!r} was not found for user {user}")
+
+    movie_formats = {"MOVIE"}
+    tv_formats = {"TV", "TV_SHORT", "OVA", "ONA", "SPECIAL", "MUSIC"}
+    items: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    from services import tmdb_client
+
+    for media in entries:
+        anilist_id = media.get("id")
+        if not anilist_id or int(anilist_id) in seen:
+            continue
+        fmt = str(media.get("format") or "")
+        if wanted_movie and fmt not in movie_formats:
+            continue
+        if not wanted_movie and fmt not in tv_formats and fmt:
+            continue
+        titles = media.get("title") if isinstance(media.get("title"), dict) else {}
+        title = str(titles.get("english") or titles.get("romaji") or titles.get("native") or "")
+        year = None
+        start = media.get("startDate") if isinstance(media.get("startDate"), dict) else {}
+        try:
+            year = int(start.get("year") or 0) or None
+        except (TypeError, ValueError):
+            year = None
+        tmdb_id = None
+        if tmdb_client.tmdb_configured() and title:
+            try:
+                tmdb_id = tmdb_client.search_title(title, year, "movie" if wanted_movie else "tv")
+            except Exception:
+                tmdb_id = None
+        if not tmdb_id:
+            continue
+        seen.add(int(anilist_id))
+        items.append(
+            _normalize_candidate(
+                title=title,
+                year=year,
+                tmdb_id=tmdb_id,
+                imdb_id=None,
+                tvdb_id=None,
+                rank=len(items) + 1,
             )
         )
         if len(items) >= limit:

--- a/services/media_servers/plex.py
+++ b/services/media_servers/plex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import threading
 import xml.etree.ElementTree as ET
 from typing import Literal
 from urllib.parse import quote
@@ -18,6 +19,176 @@ def _plex_base_and_token() -> tuple[str | None, str | None]:
     if not plex_url or not plex_token:
         return None, None
     return str(plex_url).rstrip('/'), str(plex_token)
+
+
+_section_locations_lock = threading.Lock()
+_section_locations_by_id: dict[int, tuple[str, ...]] | None = None
+_section_locations_creds: tuple[str, str] | None = None
+
+
+def _section_locations_fingerprint(plex_url: str, plex_token: str) -> tuple[str, str]:
+    return (str(plex_url).rstrip("/"), str(plex_token or ""))
+
+
+def clear_plex_section_location_cache() -> None:
+    """Drop cached Plex library folder locations (settings change or tests)."""
+    global _section_locations_by_id, _section_locations_creds
+    with _section_locations_lock:
+        _section_locations_by_id = None
+        _section_locations_creds = None
+
+
+def _relpath_under_root(abs_folder: str, root: str) -> str | None:
+    """Return the relative path of abs_folder under root, or None if it is not inside."""
+    root_abs = os.path.abspath(str(root or "").strip())
+    folder_abs = os.path.abspath(abs_folder)
+    if not root_abs:
+        return None
+    try:
+        if os.path.commonpath([folder_abs, root_abs]) != root_abs:
+            return None
+    except ValueError:
+        return None
+    rel = os.path.relpath(folder_abs, root_abs)
+    if rel.startswith(".."):
+        return None
+    return rel
+
+
+def _join_plex_location(location: str, relative: str) -> str:
+    loc = str(location or "").replace("\\", "/").rstrip("/")
+    rel = str(relative or "").replace("\\", "/").lstrip("/")
+    if not rel or rel == ".":
+        return loc
+    return f"{loc}/{rel}"
+
+
+def rewrite_folder_to_plex_locations(
+    abs_folder: str,
+    *,
+    our_roots: list[str],
+    plex_locations: list[str] | tuple[str, ...],
+) -> list[str]:
+    """Map a Placeholdarr folder onto each Plex library location for that section.
+
+    `/placeholdarr/movies/Title` under our root `/placeholdarr/movies` becomes
+    `/mnt/user/data/placeholdarr/movies/Title` when that is Plex's location.
+    """
+    relative = None
+    for root in our_roots:
+        if not root:
+            continue
+        relative = _relpath_under_root(abs_folder, root)
+        if relative is not None:
+            break
+    if relative is None:
+        return []
+    rewritten: list[str] = []
+    seen: set[str] = set()
+    for location in plex_locations:
+        loc = str(location or "").strip()
+        if not loc:
+            continue
+        path = _join_plex_location(loc, relative)
+        if path in seen:
+            continue
+        seen.add(path)
+        rewritten.append(path)
+    return rewritten
+
+
+def _parse_section_locations_xml(payload_text: str) -> dict[int, tuple[str, ...]]:
+    root = ET.fromstring(payload_text)
+    parsed: dict[int, tuple[str, ...]] = {}
+    for directory in root.findall(".//Directory"):
+        raw_key = directory.attrib.get("key")
+        if raw_key is None:
+            continue
+        try:
+            section_id = int(str(raw_key).strip())
+        except (TypeError, ValueError):
+            continue
+        locations: list[str] = []
+        seen: set[str] = set()
+        for loc in directory.findall("Location"):
+            path = str(loc.attrib.get("path") or "").strip()
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            locations.append(path)
+        parsed[section_id] = tuple(locations)
+    return parsed
+
+
+def fetch_plex_section_locations(
+    *,
+    plex_url: str | None = None,
+    plex_token: str | None = None,
+) -> dict[int, tuple[str, ...]]:
+    """GET /library/sections and return section id -> folder locations."""
+    url = str(plex_url).rstrip("/") if plex_url else None
+    token = str(plex_token or "").strip() if plex_token is not None else None
+    if not url or not token:
+        base, stored = _plex_base_and_token()
+        url = url or base
+        token = token or stored
+    if not url or not token:
+        return {}
+    response = requests.get(
+        f"{url}/library/sections",
+        headers={"X-Plex-Token": token, "Accept": "application/xml"},
+        timeout=10,
+    )
+    response.raise_for_status()
+    return _parse_section_locations_xml(response.text)
+
+
+def prime_plex_section_location_cache(
+    *,
+    plex_url: str | None = None,
+    plex_token: str | None = None,
+) -> dict[int, tuple[str, ...]]:
+    """Fetch Plex library locations into the process cache. Empty dict on failure."""
+    global _section_locations_by_id, _section_locations_creds
+    url = str(plex_url).rstrip("/") if plex_url else None
+    token = str(plex_token or "").strip() if plex_token is not None else None
+    if not url or not token:
+        base, stored = _plex_base_and_token()
+        url = url or base
+        token = token or stored
+    if not url or not token:
+        return {}
+    try:
+        parsed = fetch_plex_section_locations(plex_url=url, plex_token=token)
+    except Exception as exc:
+        logger.warning(
+            f"Failed to load Plex library locations: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+        return {}
+    fingerprint = _section_locations_fingerprint(url, token)
+    with _section_locations_lock:
+        _section_locations_by_id = dict(parsed)
+        _section_locations_creds = fingerprint
+    logger.info(
+        f"Cached Plex library locations for {len(parsed)} section(s)",
+        extra={"emoji_type": "info"},
+    )
+    return parsed
+
+
+def _cached_section_locations(section_id: int) -> tuple[str, ...]:
+    """Return cached locations for a section, fetching once per process/credentials."""
+    global _section_locations_by_id, _section_locations_creds
+    plex_url, plex_token = _plex_base_and_token()
+    if not plex_url or not plex_token:
+        return ()
+    fingerprint = _section_locations_fingerprint(plex_url, plex_token)
+    with _section_locations_lock:
+        if _section_locations_by_id is not None and _section_locations_creds == fingerprint:
+            return _section_locations_by_id.get(int(section_id), ())
+    parsed = prime_plex_section_location_cache(plex_url=plex_url, plex_token=plex_token)
+    return parsed.get(int(section_id), ())
 
 
 def get_plex_section_scan_state(section_ids: set[int] | list[int]) -> dict[str, object]:
@@ -283,11 +454,45 @@ def refresh_plex_section_ids(
     return {"refreshed": refreshed, "failed": failed}
 
 
+def _library_roots_and_section(abs_folder: str) -> tuple[list[str], int | None]:
+    movie_roots = [
+        str(r).strip()
+        for r in (
+            getattr(settings, "MOVIE_LIBRARY_FOLDER", None),
+            getattr(settings, "MOVIE_LIBRARY_4K_FOLDER", None),
+        )
+        if r
+    ]
+    tv_roots = [
+        str(r).strip()
+        for r in (
+            getattr(settings, "TV_LIBRARY_FOLDER", None),
+            getattr(settings, "TV_LIBRARY_4K_FOLDER", None),
+        )
+        if r
+    ]
+    movie_section = getattr(settings, "PLEX_MOVIE_SECTION_ID", None)
+    tv_section = getattr(settings, "PLEX_TV_SECTION_ID", None)
+    for root in movie_roots:
+        if _relpath_under_root(abs_folder, root) is not None:
+            try:
+                return movie_roots, int(movie_section) if movie_section is not None else None
+            except (TypeError, ValueError):
+                return movie_roots, None
+    for root in tv_roots:
+        if _relpath_under_root(abs_folder, root) is not None:
+            try:
+                return tv_roots, int(tv_section) if tv_section is not None else None
+            except (TypeError, ValueError):
+                return tv_roots, None
+    return [], None
+
+
 def refresh_plex_paths(paths: set[str], *, update_type: str = "Created") -> dict[str, int]:
     """Request path-scoped Plex refresh for changed folders.
 
-    Path-scoped refresh avoids broad library sweeps by targeting only the
-    specific folders where placeholder files were created or deleted.
+    Paths are rewritten onto Plex's library locations so Docker/container
+    mounts (e.g. /placeholdarr/movies) match what Plex actually scans.
     """
     if not paths:
         return {"refreshed": 0, "failed": 0}
@@ -295,10 +500,7 @@ def refresh_plex_paths(paths: set[str], *, update_type: str = "Created") -> dict
     if not getattr(settings, "plex_enabled", False):
         return {"refreshed": 0, "failed": 0}
 
-    plex_url = getattr(settings, "PLEX_URL", None)
-    plex_token = getattr(settings, "PLEX_TOKEN", None)
-    movie_section_id = getattr(settings, "PLEX_MOVIE_SECTION_ID", None)
-    tv_section_id = getattr(settings, "PLEX_TV_SECTION_ID", None)
+    plex_url, plex_token = _plex_base_and_token()
     if not plex_url or not plex_token:
         return {"refreshed": 0, "failed": 0}
 
@@ -311,53 +513,44 @@ def refresh_plex_paths(paths: set[str], *, update_type: str = "Created") -> dict
         normalized_folders.append(os.path.dirname(abs_path) if os.path.isfile(abs_path) else abs_path)
 
     for folder in dict.fromkeys(normalized_folders):
-        try:
-            abs_folder = os.path.abspath(folder)
+        abs_folder = os.path.abspath(folder)
+        our_roots, section_id = _library_roots_and_section(abs_folder)
+        if section_id is None:
+            logger.debug(
+                f"Skipping Plex refresh for out-of-scope folder: {abs_folder}",
+                extra={"emoji_type": "debug"},
+            )
+            continue
 
-            section_id = None
-            movie_roots = [
-                getattr(settings, "MOVIE_LIBRARY_FOLDER", None),
-                getattr(settings, "MOVIE_LIBRARY_4K_FOLDER", None),
-            ]
-            tv_roots = [
-                getattr(settings, "TV_LIBRARY_FOLDER", None),
-                getattr(settings, "TV_LIBRARY_4K_FOLDER", None),
-            ]
-
-            for root in [r for r in movie_roots if r]:
-                try:
-                    if os.path.commonpath([abs_folder, os.path.abspath(root)]) == os.path.abspath(root):
-                        section_id = movie_section_id
-                        break
-                except Exception:
-                    continue
-
-            if section_id is None:
-                for root in [r for r in tv_roots if r]:
-                    try:
-                        if os.path.commonpath([abs_folder, os.path.abspath(root)]) == os.path.abspath(root):
-                            section_id = tv_section_id
-                            break
-                    except Exception:
-                        continue
-
-            if section_id is None:
-                logger.debug(
-                    f"Skipping Plex refresh for out-of-scope folder: {abs_folder}",
-                    extra={"emoji_type": "debug"},
-                )
-                continue
-
-            url = f"{str(plex_url).rstrip('/')}/library/sections/{section_id}/refresh?path={quote(abs_folder)}"
-            response = requests.get(url, headers={"X-Plex-Token": plex_token}, timeout=15)
-            response.raise_for_status()
-            refreshed += 1
-        except Exception as e:
-            failed += 1
+        plex_locations = _cached_section_locations(section_id)
+        refresh_paths = rewrite_folder_to_plex_locations(
+            abs_folder, our_roots=our_roots, plex_locations=plex_locations
+        )
+        if not refresh_paths:
             logger.warning(
-                f"Path-scoped Plex refresh failed for folder={folder}: {e}",
+                f"Plex library locations unavailable for section {section_id}; "
+                f"sending Placeholdarr path as-is folder={abs_folder}",
                 extra={"emoji_type": "warning"},
             )
+            refresh_paths = [abs_folder]
+        elif any(path != abs_folder for path in refresh_paths):
+            logger.info(
+                f"Plex path refresh rewritten local={abs_folder} plex={refresh_paths} section={section_id}",
+                extra={"emoji_type": "refresh"},
+            )
+
+        for refresh_path in refresh_paths:
+            try:
+                url = f"{plex_url}/library/sections/{section_id}/refresh?path={quote(refresh_path)}"
+                response = requests.get(url, headers={"X-Plex-Token": plex_token}, timeout=15)
+                response.raise_for_status()
+                refreshed += 1
+            except Exception as e:
+                failed += 1
+                logger.warning(
+                    f"Path-scoped Plex refresh failed for folder={refresh_path}: {e}",
+                    extra={"emoji_type": "warning"},
+                )
 
     return {"refreshed": refreshed, "failed": failed}
 

--- a/services/media_servers/plex_collections.py
+++ b/services/media_servers/plex_collections.py
@@ -130,6 +130,22 @@ def resolve_items_in_section(
     return resolved, missing
 
 
+def membership_mask(
+    section_id: int,
+    section_type: str,
+    provider_key_groups: list[list[str]],
+) -> list[bool]:
+    """True for each provider-key group that exists in the Plex section."""
+    plex = get_plex_server()
+    if not plex:
+        raise PlexCollectionsError("Plex is not configured or unreachable")
+    index = _get_section_index(plex, section_id, section_type)
+    present: list[bool] = []
+    for group in provider_key_groups:
+        present.append(any(index.get(key) is not None for key in group))
+    return present
+
+
 def _find_collection(section, collection_title: str):
     needle = collection_title.strip().lower()
     for collection in section.collections():

--- a/services/media_servers/plex_collections.py
+++ b/services/media_servers/plex_collections.py
@@ -130,13 +130,60 @@ def resolve_items_in_section(
     return resolved, missing
 
 
+def _find_collection(section, collection_title: str):
+    needle = collection_title.strip().lower()
+    for collection in section.collections():
+        if str(getattr(collection, "title", "")).strip().lower() == needle:
+            return collection
+    return None
+
+
+def _apply_custom_item_order(collection, items: list[Any]) -> None:
+    """Force Plex custom sort so membership order matches Placeholdarr arrange order."""
+    if not items or collection is None or getattr(collection, "smart", False):
+        return
+    try:
+        if int(getattr(collection, "collectionSort", 0) or 0) != 2:
+            collection.sortUpdate(sort="custom")
+            collection.reload()
+    except Exception as exc:
+        logger.warning(
+            f"Collections: could not set custom sort on {getattr(collection, 'title', '')!r}: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+        return
+    try:
+        current = collection.items()
+        current_keys = [str(getattr(item, "ratingKey", "")) for item in current]
+    except Exception:
+        current_keys = []
+    desired_keys = [str(getattr(item, "ratingKey", "")) for item in items]
+    if current_keys == desired_keys:
+        return
+    after = None
+    for item in items:
+        try:
+            collection.moveItem(item, after=after)
+        except Exception as exc:
+            logger.warning(
+                f"Collections: could not move {getattr(item, 'title', item)!r} "
+                f"in {getattr(collection, 'title', '')!r}: {exc}",
+                extra={"emoji_type": "warning"},
+            )
+        after = item
+
+
 def sync_collection(
     section_id: int,
     section_type: str,
     collection_title: str,
     items: list[Any],
 ) -> dict[str, Any]:
-    """Create or update a Plex collection so its membership exactly matches `items`.
+    """Create or update a Plex collection so its membership and item order match `items`.
+
+    Plex defaults collections to release-date sort, which ignores recipe order.
+    After membership is synced, the collection is switched to custom order and
+    items are moved to match `items` (Placeholdarr arrange order).
 
     Returns counts: {"added": n, "removed": n, "total": n, "created": bool}.
     """
@@ -147,10 +194,7 @@ def sync_collection(
 
     existing = None
     try:
-        for collection in section.collections():
-            if str(getattr(collection, "title", "")).strip().lower() == collection_title.strip().lower():
-                existing = collection
-                break
+        existing = _find_collection(section, collection_title)
     except Exception as exc:
         raise PlexCollectionsError(f"Failed to list collections for section {section_id}: {exc}") from exc
 
@@ -160,11 +204,12 @@ def sync_collection(
         if not items:
             return {"added": 0, "removed": 0, "total": 0, "created": False}
         try:
-            section.createCollection(collection_title, items=items)
+            created = section.createCollection(collection_title, items=items)
         except Exception as exc:
             raise PlexCollectionsError(
                 f"Failed to create collection {collection_title!r} in section {section_id}: {exc}"
             ) from exc
+        _apply_custom_item_order(created, items)
         logger.info(
             f"Collections: created Plex collection {collection_title!r} "
             f"(section={section_id}, items={len(items)})",
@@ -188,6 +233,9 @@ def sync_collection(
             existing.addItems(to_add)
         if to_remove:
             existing.removeItems(to_remove)
+        if to_add or to_remove:
+            existing.reload()
+        _apply_custom_item_order(existing, items)
     except Exception as exc:
         raise PlexCollectionsError(
             f"Failed to update collection {collection_title!r} membership: {exc}"

--- a/services/source_of_truth/arr_api.py
+++ b/services/source_of_truth/arr_api.py
@@ -1,11 +1,11 @@
 import threading
 import time
 from datetime import date
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
-from requests import RequestException
+from requests import RequestException, Timeout
 from requests.exceptions import HTTPError
 
 from core.config import settings
@@ -18,6 +18,13 @@ _cache = {}
 _DEFAULT_TTL_SECONDS = 120
 # Bulk *arr reads (e.g. GET /api/v3/movie) can exceed 30s on large libraries over user-share I/O.
 ARR_HTTP_TIMEOUT_SECONDS = 120
+# Collections missing-from-ARR add: lookup stays snappy; import can sit while Radarr
+# writes many titles (Kometa/arrapi default is 90s).
+ARR_LOOKUP_TIMEOUT_SECONDS = 30
+ARR_ADD_TIMEOUT_SECONDS = 90
+ARR_IMPORT_CHUNK_SIZE = 100
+
+_last_write_error: dict[str, str | bool | int | None] = {}
 
 
 def _cache_get(key: str, ttl_seconds: int = _DEFAULT_TTL_SECONDS):
@@ -113,30 +120,44 @@ def _request_json(
             f'ARR write failed method={method.upper()} url={safe_url} status={status_code} reason={reason}',
             extra={'emoji_type': 'error'},
         )
+        _last_write_error.clear()
+        _last_write_error.update(
+            {
+                "timed_out": False,
+                "status_code": int(status_code) if status_code else None,
+                "message": f"HTTP {status_code} {reason or ''}".strip(),
+            }
+        )
+        return None
+    except Timeout as e:
+        logger.error(
+            f'ARR write failed method={method.upper()} url={safe_url} error_type={type(e).__name__}',
+            extra={'emoji_type': 'error'},
+        )
+        _last_write_error.clear()
+        _last_write_error.update(
+            {
+                "timed_out": True,
+                "status_code": None,
+                "message": f"did not respond within {timeout}s; it may still add the title(s)",
+            }
+        )
         return None
     except RequestException as e:
         logger.error(
             f'ARR write failed method={method.upper()} url={safe_url} error_type={type(e).__name__}',
             extra={'emoji_type': 'error'},
         )
+        _last_write_error.clear()
+        _last_write_error.update({"timed_out": False, "status_code": None, "message": str(e) or type(e).__name__})
         return None
     except Exception as e:
         logger.error(
             f'ARR write failed method={method.upper()} url={safe_url} error_type={type(e).__name__}',
             extra={'emoji_type': 'error'},
         )
-        return None
-    except RequestException as e:
-        logger.error(
-            f'ARR request failed url={safe_url} error_type={type(e).__name__}',
-            extra={'emoji_type': 'error'},
-        )
-        return None
-    except Exception as e:
-        logger.error(
-            f'ARR request failed url={safe_url} error_type={type(e).__name__}',
-            extra={'emoji_type': 'error'},
-        )
+        _last_write_error.clear()
+        _last_write_error.update({"timed_out": False, "status_code": None, "message": str(e) or type(e).__name__})
         return None
 
 
@@ -585,7 +606,7 @@ def lookup_movie(*, url: str, api_key: str, tmdb_id: Optional[int] = None, imdb_
     if not term:
         return None
     endpoint = _build_endpoint(url, "movie/lookup")
-    result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=30)
+    result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=ARR_LOOKUP_TIMEOUT_SECONDS)
     if isinstance(result, list) and result:
         return result[0] if isinstance(result[0], dict) else None
     return result if isinstance(result, dict) else None
@@ -610,7 +631,7 @@ def lookup_series(
         terms.append(f"imdb:{imdb_id}")
     for term in terms:
         endpoint = _build_endpoint(url, "series/lookup")
-        result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=30)
+        result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=ARR_LOOKUP_TIMEOUT_SECONDS)
         if isinstance(result, list) and result and isinstance(result[0], dict):
             return result[0]
         if isinstance(result, dict):
@@ -648,6 +669,205 @@ def _existing_arr_id(lookup: dict) -> bool:
         return False
 
 
+def _arr_write_failure_message(arr_name: str) -> str:
+    extra = _last_write_error.get("message")
+    if extra:
+        return f"{arr_name} {extra}"
+    return f"{arr_name} rejected the add (already present or invalid payload)"
+
+
+def _movie_add_payload(
+    lookup: dict,
+    *,
+    quality_profile_id: int,
+    root_folder_path: str,
+    monitored: bool,
+    search: bool,
+    tag_ids: Optional[List[int]] = None,
+) -> dict:
+    payload = dict(lookup)
+    payload.pop("id", None)
+    payload["qualityProfileId"] = int(quality_profile_id)
+    payload["rootFolderPath"] = str(root_folder_path).rstrip("/")
+    payload["monitored"] = bool(monitored)
+    payload["minimumAvailability"] = payload.get("minimumAvailability") or "released"
+    payload["addOptions"] = {"searchForMovie": bool(search)}
+    if tag_ids:
+        payload["tags"] = [int(t) for t in tag_ids]
+    return payload
+
+
+def _series_add_payload(
+    lookup: dict,
+    *,
+    quality_profile_id: int,
+    root_folder_path: str,
+    monitored: bool,
+    search: bool,
+    tag_ids: Optional[List[int]] = None,
+) -> dict:
+    payload = dict(lookup)
+    payload.pop("id", None)
+    payload["qualityProfileId"] = int(quality_profile_id)
+    payload["rootFolderPath"] = str(root_folder_path).rstrip("/")
+    payload["monitored"] = bool(monitored)
+    payload["addOptions"] = {"searchForMissingEpisodes": bool(search), "monitor": "all" if monitored else "none"}
+    if tag_ids:
+        payload["tags"] = [int(t) for t in tag_ids]
+    seasons = payload.get("seasons")
+    if isinstance(seasons, list) and monitored:
+        for season in seasons:
+            if isinstance(season, dict) and int(season.get("seasonNumber") or 0) != 0:
+                season["monitored"] = True
+    return payload
+
+
+def _lookup_identity_key(lookup: dict, *, movie: bool) -> Optional[str]:
+    if movie:
+        tmdb = lookup.get("tmdbId") or lookup.get("tmdb_id")
+        if tmdb:
+            return f"tmdb:{int(tmdb)}"
+        imdb = lookup.get("imdbId") or lookup.get("imdb_id")
+        if imdb:
+            return f"imdb:{imdb}"
+        return None
+    tvdb = lookup.get("tvdbId") or lookup.get("tvdb_id")
+    if tvdb:
+        return f"tvdb:{int(tvdb)}"
+    tmdb = lookup.get("tmdbId") or lookup.get("tmdb_id")
+    if tmdb:
+        return f"tmdb:{int(tmdb)}"
+    imdb = lookup.get("imdbId") or lookup.get("imdb_id")
+    if imdb:
+        return f"imdb:{imdb}"
+    return None
+
+
+def _imported_identity_keys(imported: Any, *, movie: bool) -> set[str]:
+    keys: set[str] = set()
+    rows = imported if isinstance(imported, list) else [imported] if isinstance(imported, dict) else []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = _lookup_identity_key(row, movie=movie)
+        if key:
+            keys.add(key)
+    return keys
+
+
+def add_movies_to_radarr(
+    *,
+    url: str,
+    api_key: str,
+    lookups: list[dict],
+    quality_profile_id: int,
+    root_folder_path: str,
+    monitored: bool,
+    search: bool,
+    tag_ids: Optional[List[int]] = None,
+) -> list[tuple[dict, str, Optional[str]]]:
+    """Bulk-add looked-up movies via POST /movie/import.
+
+    Returns one (lookup, status, error) per input lookup, in the same order.
+    """
+    results: list[Optional[tuple[dict, str, Optional[str]]]] = [None] * len(lookups)
+    pending: list[tuple[int, dict, dict]] = []
+    for index, lookup in enumerate(lookups):
+        if _existing_arr_id(lookup):
+            results[index] = (lookup, "skipped", "Already in this Radarr instance")
+            continue
+        payload = _movie_add_payload(
+            lookup,
+            quality_profile_id=quality_profile_id,
+            root_folder_path=root_folder_path,
+            monitored=monitored,
+            search=search,
+            tag_ids=tag_ids,
+        )
+        pending.append((index, lookup, payload))
+        results[index] = (lookup, "ok", None)
+
+    endpoint = _build_endpoint(url, "movie/import")
+    for chunk_start in range(0, len(pending), ARR_IMPORT_CHUNK_SIZE):
+        chunk = pending[chunk_start : chunk_start + ARR_IMPORT_CHUNK_SIZE]
+        payloads = [item[2] for item in chunk]
+        imported = _request_json(
+            "POST",
+            endpoint,
+            payload=payloads,
+            api_key=api_key,
+            timeout=ARR_ADD_TIMEOUT_SECONDS,
+        )
+        if imported is None:
+            message = _arr_write_failure_message("Radarr")
+            for _index, lookup, _payload in chunk:
+                results[_index] = (lookup, "error", message)
+            continue
+        accepted = _imported_identity_keys(imported, movie=True)
+        if not accepted:
+            continue
+        for index, lookup, _payload in chunk:
+            key = _lookup_identity_key(lookup, movie=True)
+            if key and key not in accepted:
+                results[index] = (lookup, "error", "Radarr did not confirm this title in the import response")
+    return [row if row is not None else (lookups[i], "error", "Radarr import did not return a result") for i, row in enumerate(results)]
+
+
+def add_series_to_sonarr_bulk(
+    *,
+    url: str,
+    api_key: str,
+    lookups: list[dict],
+    quality_profile_id: int,
+    root_folder_path: str,
+    monitored: bool,
+    search: bool,
+    tag_ids: Optional[List[int]] = None,
+) -> list[tuple[dict, str, Optional[str]]]:
+    """Bulk-add looked-up series via POST /series/import."""
+    results: list[Optional[tuple[dict, str, Optional[str]]]] = [None] * len(lookups)
+    pending: list[tuple[int, dict, dict]] = []
+    for index, lookup in enumerate(lookups):
+        if _existing_arr_id(lookup):
+            results[index] = (lookup, "skipped", "Already in this Sonarr instance")
+            continue
+        payload = _series_add_payload(
+            lookup,
+            quality_profile_id=quality_profile_id,
+            root_folder_path=root_folder_path,
+            monitored=monitored,
+            search=search,
+            tag_ids=tag_ids,
+        )
+        pending.append((index, lookup, payload))
+        results[index] = (lookup, "ok", None)
+
+    endpoint = _build_endpoint(url, "series/import")
+    for chunk_start in range(0, len(pending), ARR_IMPORT_CHUNK_SIZE):
+        chunk = pending[chunk_start : chunk_start + ARR_IMPORT_CHUNK_SIZE]
+        payloads = [item[2] for item in chunk]
+        imported = _request_json(
+            "POST",
+            endpoint,
+            payload=payloads,
+            api_key=api_key,
+            timeout=ARR_ADD_TIMEOUT_SECONDS,
+        )
+        if imported is None:
+            message = _arr_write_failure_message("Sonarr")
+            for _index, lookup, _payload in chunk:
+                results[_index] = (lookup, "error", message)
+            continue
+        accepted = _imported_identity_keys(imported, movie=False)
+        if not accepted:
+            continue
+        for index, lookup, _payload in chunk:
+            key = _lookup_identity_key(lookup, movie=False)
+            if key and key not in accepted:
+                results[index] = (lookup, "error", "Sonarr did not confirm this title in the import response")
+    return [row if row is not None else (lookups[i], "error", "Sonarr import did not return a result") for i, row in enumerate(results)]
+
+
 def add_movie_to_radarr(
     *,
     url: str,
@@ -660,21 +880,17 @@ def add_movie_to_radarr(
     tag_ids: Optional[List[int]] = None,
 ) -> tuple[str, Optional[str]]:
     """Returns (status, error) where status is ok|skipped|error."""
-    if _existing_arr_id(lookup):
-        return "skipped", "Already in this Radarr instance"
-    payload = dict(lookup)
-    payload["qualityProfileId"] = int(quality_profile_id)
-    payload["rootFolderPath"] = str(root_folder_path).rstrip("/")
-    payload["monitored"] = bool(monitored)
-    payload["minimumAvailability"] = payload.get("minimumAvailability") or "released"
-    payload["addOptions"] = {"searchForMovie": bool(search)}
-    if tag_ids:
-        payload["tags"] = [int(t) for t in tag_ids]
-    endpoint = _build_endpoint(url, "movie")
-    result = _request_json("POST", endpoint, payload=payload, api_key=api_key, timeout=30)
-    if result is None:
-        return "error", "Radarr rejected the add (already present or invalid payload)"
-    return "ok", None
+    row = add_movies_to_radarr(
+        url=url,
+        api_key=api_key,
+        lookups=[lookup],
+        quality_profile_id=quality_profile_id,
+        root_folder_path=root_folder_path,
+        monitored=monitored,
+        search=search,
+        tag_ids=tag_ids,
+    )[0]
+    return row[1], row[2]
 
 
 def add_series_to_sonarr(
@@ -688,23 +904,92 @@ def add_series_to_sonarr(
     search: bool,
     tag_ids: Optional[List[int]] = None,
 ) -> tuple[str, Optional[str]]:
-    if _existing_arr_id(lookup):
-        return "skipped", "Already in this Sonarr instance"
-    payload = dict(lookup)
-    payload["qualityProfileId"] = int(quality_profile_id)
-    payload["rootFolderPath"] = str(root_folder_path).rstrip("/")
-    payload["monitored"] = bool(monitored)
-    payload["addOptions"] = {"searchForMissingEpisodes": bool(search), "monitor": "all" if monitored else "none"}
-    if tag_ids:
-        payload["tags"] = [int(t) for t in tag_ids]
-    seasons = payload.get("seasons")
-    if isinstance(seasons, list) and monitored:
-        for season in seasons:
-            if isinstance(season, dict) and int(season.get("seasonNumber") or 0) != 0:
-                season["monitored"] = True
-    endpoint = _build_endpoint(url, "series")
-    result = _request_json("POST", endpoint, payload=payload, api_key=api_key, timeout=30)
-    if result is None:
-        return "error", "Sonarr rejected the add (already present or invalid payload)"
-    return "ok", None
+    row = add_series_to_sonarr_bulk(
+        url=url,
+        api_key=api_key,
+        lookups=[lookup],
+        quality_profile_id=quality_profile_id,
+        root_folder_path=root_folder_path,
+        monitored=monitored,
+        search=search,
+        tag_ids=tag_ids,
+    )[0]
+    return row[1], row[2]
+
+
+def add_missing_titles(
+    *,
+    media_type: str,
+    url: str,
+    api_key: str,
+    items: list[Any],
+    quality_profile_id: int,
+    root_folder_path: str,
+    monitored: bool,
+    search: bool,
+    tag_ids: Optional[List[int]] = None,
+    instance_key: str = "",
+) -> list[dict[str, Any]]:
+    """Lookup each title, then bulk-import into Radarr or Sonarr."""
+
+    def result_title(item: Any, lookup: Optional[dict] = None) -> str:
+        title = str((lookup or {}).get("title") or getattr(item, "title", None) or "Untitled")
+        year = getattr(item, "year", None)
+        if lookup:
+            raw_year = lookup.get("year")
+            try:
+                year = int(raw_year) if raw_year else year
+            except (TypeError, ValueError):
+                pass
+        return f"{title} ({year})" if year else title
+
+    def row(title: str, status: str, error: Optional[str] = None) -> dict[str, Any]:
+        return {"title": title, "instance_key": instance_key, "status": status, "error": error}
+
+    results: list[dict[str, Any]] = []
+    pending_items: list[Any] = []
+    pending_lookups: list[dict] = []
+    movie = media_type == "movie"
+    for item in items:
+        try:
+            if movie:
+                lookup = lookup_movie(
+                    url=url,
+                    api_key=api_key,
+                    tmdb_id=getattr(item, "tmdb_id", None),
+                    imdb_id=getattr(item, "imdb_id", None),
+                )
+                missing = "Radarr lookup found nothing"
+            else:
+                lookup = lookup_series(
+                    url=url,
+                    api_key=api_key,
+                    tvdb_id=getattr(item, "tvdb_id", None),
+                    tmdb_id=getattr(item, "tmdb_id", None),
+                    imdb_id=getattr(item, "imdb_id", None),
+                )
+                missing = "Sonarr lookup found nothing"
+            if not lookup:
+                results.append(row(result_title(item), "error", missing))
+                continue
+            pending_items.append(item)
+            pending_lookups.append(lookup)
+        except Exception as extra:
+            results.append(row(result_title(item), "error", str(extra)))
+    if not pending_lookups:
+        return results
+    adder = add_movies_to_radarr if movie else add_series_to_sonarr_bulk
+    added = adder(
+        url=url,
+        api_key=api_key,
+        lookups=pending_lookups,
+        quality_profile_id=quality_profile_id,
+        root_folder_path=root_folder_path,
+        monitored=monitored,
+        search=search,
+        tag_ids=tag_ids,
+    )
+    for item, lookup, (_lookup, status, error) in zip(pending_items, pending_lookups, added):
+        results.append(row(result_title(item, lookup), status, error))
+    return results
 

--- a/services/tmdb_client.py
+++ b/services/tmdb_client.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 from typing import Any, Optional
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -62,6 +63,53 @@ _TMDB_RESOURCE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Discover sorts the TMDB website exposes on keyword/company movie+TV tabs.
+_TMDB_DISCOVER_SORTS = frozenset(
+    {
+        "popularity.asc",
+        "popularity.desc",
+        "vote_average.asc",
+        "vote_average.desc",
+        "vote_count.asc",
+        "vote_count.desc",
+        "primary_release_date.asc",
+        "primary_release_date.desc",
+        "release_date.asc",
+        "release_date.desc",
+        "first_air_date.asc",
+        "first_air_date.desc",
+        "original_title.asc",
+        "original_title.desc",
+        "title.asc",
+        "title.desc",
+        "revenue.asc",
+        "revenue.desc",
+    }
+)
+DEFAULT_DISCOVER_SORT = "popularity.desc"
+
+
+def parse_tmdb_resource_kind(value: str) -> Optional[str]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    match = _TMDB_RESOURCE_RE.search(text)
+    if match:
+        return match.group(1).lower()
+    return None
+
+
+def parse_tmdb_sort_by(value: str, media_type: str = "movie") -> str:
+    """Read ``sort_by`` from a TMDB URL. Bare ids and unknown values use popularity.desc."""
+    text = str(value or "").strip()
+    raw = None
+    if "sort_by=" in text.lower() or "?" in text:
+        try:
+            raw = (parse_qs(urlparse(text).query).get("sort_by") or [None])[0]
+        except (TypeError, ValueError):
+            raw = None
+    return normalize_tmdb_sort_by(raw, media_type)
+
 
 def parse_tmdb_resource_id(value: str, expected: str) -> str:
     """Accept a TMDB URL or bare numeric id for person/company/keyword/collection/list."""
@@ -78,6 +126,26 @@ def parse_tmdb_resource_id(value: str, expected: str) -> str:
     if digits:
         return digits.group(1)
     raise TmdbError(f"Could not parse a TMDB {expected} id from {text!r}")
+
+
+def normalize_tmdb_sort_by(sort_by: Optional[str], media_type: str = "movie") -> str:
+    raw = str(sort_by or "").strip()
+    if raw in _TMDB_DISCOVER_SORTS:
+        value = raw
+    else:
+        value = DEFAULT_DISCOVER_SORT
+    if media_type != "movie" and value in {
+        "primary_release_date.asc",
+        "primary_release_date.desc",
+        "release_date.asc",
+        "release_date.desc",
+    }:
+        direction = "desc" if value.endswith(".desc") else "asc"
+        return f"first_air_date.{direction}"
+    if media_type == "movie" and value in {"first_air_date.asc", "first_air_date.desc"}:
+        direction = "desc" if value.endswith(".desc") else "asc"
+        return f"primary_release_date.{direction}"
+    return value
 
 
 def tmdb_configured() -> bool:
@@ -338,16 +406,38 @@ def fetch_person_credits(person_ref: str, media_type: str, limit: int = 500) -> 
     return items
 
 
-def fetch_company(company_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+def fetch_company(
+    company_ref: str,
+    media_type: str,
+    limit: int = 200,
+    sort_by: Optional[str] = None,
+) -> list[dict[str, Any]]:
     company_id = parse_tmdb_resource_id(company_ref, "company")
     kind = "movie" if media_type == "movie" else "tv"
-    return _fetch_paged(f"/discover/{kind}", {"with_companies": company_id}, media_type, limit)
+    sort_by = normalize_tmdb_sort_by(sort_by or parse_tmdb_sort_by(company_ref, media_type), media_type)
+    return _fetch_paged(
+        f"/discover/{kind}",
+        {"with_companies": company_id, "sort_by": sort_by},
+        media_type,
+        limit,
+    )
 
 
-def fetch_keyword(keyword_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+def fetch_keyword(
+    keyword_ref: str,
+    media_type: str,
+    limit: int = 200,
+    sort_by: Optional[str] = None,
+) -> list[dict[str, Any]]:
     keyword_id = parse_tmdb_resource_id(keyword_ref, "keyword")
     kind = "movie" if media_type == "movie" else "tv"
-    return _fetch_paged(f"/discover/{kind}", {"with_keywords": keyword_id}, media_type, limit)
+    sort_by = normalize_tmdb_sort_by(sort_by or parse_tmdb_sort_by(keyword_ref, media_type), media_type)
+    return _fetch_paged(
+        f"/discover/{kind}",
+        {"with_keywords": keyword_id, "sort_by": sort_by},
+        media_type,
+        limit,
+    )
 
 
 def fetch_collection(collection_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:

--- a/services/tmdb_client.py
+++ b/services/tmdb_client.py
@@ -167,11 +167,22 @@ def _normalize_item(raw: dict[str, Any], media_type: str) -> dict[str, Any] | No
     year = None
     if date and len(date) >= 4 and date[:4].isdigit():
         year = int(date[:4])
+    last_air_date = raw.get("last_air_date") or None
+    last_year = None
+    if last_air_date and len(str(last_air_date)) >= 4 and str(last_air_date)[:4].isdigit():
+        last_year = int(str(last_air_date)[:4])
+    elif raw.get("last_year"):
+        try:
+            last_year = int(raw.get("last_year") or 0) or None
+        except (TypeError, ValueError):
+            last_year = None
     return {
         "tmdb_id": int(tmdb_id),
         "title": title,
         "year": year,
         "date": date or None,
+        "last_air_date": last_air_date,
+        "last_year": last_year,
         "popularity": raw.get("popularity"),
         "vote_average": raw.get("vote_average"),
         "vote_count": raw.get("vote_count"),

--- a/services/tmdb_client.py
+++ b/services/tmdb_client.py
@@ -1,12 +1,14 @@
 """Thin TMDB API client for the Collections rule builder.
 
-Supports the source blocks (trending / popular / upcoming / discover / list) plus
-metadata helpers used by the builder UI (genres, watch providers, regions).
+Supports trending / popular / upcoming / discover / list plus person credits,
+company, keyword, and collection pages (paste a themoviedb.org URL or numeric
+id). Also metadata helpers for the builder UI (genres, watch providers, regions).
 Responses are cached in-process with a TTL so scheduled runs and UI previews do
 not hammer TMDB rate limits.
 """
 from __future__ import annotations
 
+import re
 import threading
 import time
 from typing import Any, Optional
@@ -20,7 +22,7 @@ TMDB_BASE_URL = "https://api.themoviedb.org/3"
 TMDB_HTTP_TIMEOUT_SECONDS = 20
 
 # Discover/list pagination guardrail: TMDB pages hold 20 items.
-MAX_PAGES_PER_SOURCE = 10
+MAX_PAGES_PER_SOURCE = 25
 
 _CACHE_TTL_SECONDS = 12 * 3600
 _META_CACHE_TTL_SECONDS = 24 * 3600
@@ -53,6 +55,29 @@ def _retry_after_seconds(resp: Any, default: float = 2.0, cap: float = 10.0) -> 
 
 class TmdbError(Exception):
     """Raised when TMDB is unconfigured or a request fails."""
+
+
+_TMDB_RESOURCE_RE = re.compile(
+    r"themoviedb\.org/(person|company|keyword|collection|list)/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def parse_tmdb_resource_id(value: str, expected: str) -> str:
+    """Accept a TMDB URL or bare numeric id for person/company/keyword/collection/list."""
+    text = str(value or "").strip()
+    if not text:
+        raise TmdbError(f"TMDB {expected} source needs a URL or numeric id")
+    match = _TMDB_RESOURCE_RE.search(text)
+    if match:
+        kind = match.group(1).lower()
+        if kind != expected:
+            raise TmdbError(f"That TMDB URL is a {kind} page, not a {expected} page")
+        return match.group(2)
+    digits = re.match(r"^(\d+)\b", text)
+    if digits:
+        return digits.group(1)
+    raise TmdbError(f"Could not parse a TMDB {expected} id from {text!r}")
 
 
 def tmdb_configured() -> bool:
@@ -243,6 +268,7 @@ def fetch_discover(
 
 def fetch_list(list_id: int | str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
     """Fetch a public TMDB v3 list, filtered to the requested media type."""
+    list_id = parse_tmdb_resource_id(str(list_id), "list")
     limit = max(1, min(int(limit or 200), 500))
     cache_key = _cache_key(f"/list/{list_id}", {"_limit": limit, "_mt": media_type})
     cached = _cache_get(cache_key, _CACHE_TTL_SECONDS)
@@ -272,6 +298,94 @@ def fetch_list(list_id: int | str, media_type: str, limit: int = 200) -> list[di
 
     _cache_set(cache_key, items)
     return items
+
+
+def fetch_person_credits(person_ref: str, media_type: str, limit: int = 500) -> list[dict[str, Any]]:
+    """All unique movie or TV credits for a person (cast and crew)."""
+    person_id = parse_tmdb_resource_id(person_ref, "person")
+    kind = "movie" if media_type == "movie" else "tv"
+    limit = max(1, min(int(limit or 500), 1000))
+    cache_key = _cache_key(f"/person/{person_id}/{kind}_credits", {"_limit": limit})
+    cached = _cache_get(cache_key, _CACHE_TTL_SECONDS)
+    if cached is not None:
+        return cached
+    data = _request(f"/person/{person_id}/{kind}_credits")
+    rows: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for bucket in ("cast", "crew"):
+        for raw in data.get(bucket) or []:
+            if not isinstance(raw, dict):
+                continue
+            normalized = _normalize_item(raw, media_type)
+            if not normalized or normalized["tmdb_id"] in seen:
+                continue
+            seen.add(normalized["tmdb_id"])
+            rows.append(normalized)
+    rows.sort(key=lambda item: float(item.get("popularity") or 0), reverse=True)
+    items = rows[:limit]
+    _cache_set(cache_key, items)
+    return items
+
+
+def fetch_company(company_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+    company_id = parse_tmdb_resource_id(company_ref, "company")
+    kind = "movie" if media_type == "movie" else "tv"
+    return _fetch_paged(f"/discover/{kind}", {"with_companies": company_id}, media_type, limit)
+
+
+def fetch_keyword(keyword_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+    keyword_id = parse_tmdb_resource_id(keyword_ref, "keyword")
+    kind = "movie" if media_type == "movie" else "tv"
+    return _fetch_paged(f"/discover/{kind}", {"with_keywords": keyword_id}, media_type, limit)
+
+
+def fetch_collection(collection_ref: str, media_type: str, limit: int = 200) -> list[dict[str, Any]]:
+    """TMDB movie collection (e.g. Star Wars). TV recipes get an empty set."""
+    if media_type != "movie":
+        return []
+    collection_id = parse_tmdb_resource_id(collection_ref, "collection")
+    limit = max(1, min(int(limit or 200), 500))
+    cache_key = _cache_key(f"/collection/{collection_id}", {"_limit": limit})
+    cached = _cache_get(cache_key, _CACHE_TTL_SECONDS)
+    if cached is not None:
+        return cached
+    data = _request(f"/collection/{collection_id}")
+    items: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for raw in data.get("parts") or []:
+        normalized = _normalize_item(raw, "movie")
+        if not normalized or normalized["tmdb_id"] in seen:
+            continue
+        seen.add(normalized["tmdb_id"])
+        items.append(normalized)
+        if len(items) >= limit:
+            break
+    _cache_set(cache_key, items)
+    return items
+
+
+def search_title(title: str, year: Optional[int], media_type: str) -> Optional[int]:
+    """Best-effort first TMDB search hit for AniList (and similar) title matching."""
+    query = str(title or "").strip()
+    if not query:
+        return None
+    kind = "movie" if media_type == "movie" else "tv"
+    params: dict[str, Any] = {"query": query}
+    if year:
+        params["year" if kind == "movie" else "first_air_date_year"] = int(year)
+    cache_key = _cache_key(f"/search/{kind}", params)
+    cached = _cache_get(cache_key, _CACHE_TTL_SECONDS)
+    if cached is not None:
+        return cached
+    data = _request(f"/search/{kind}", params)
+    tmdb_id = None
+    for raw in data.get("results") or []:
+        normalized = _normalize_item(raw, media_type)
+        if normalized:
+            tmdb_id = int(normalized["tmdb_id"])
+            break
+    _cache_set(cache_key, tmdb_id)
+    return tmdb_id
 
 
 # ---------------------------------------------------------------------------

--- a/services/whats_new.py
+++ b/services/whats_new.py
@@ -35,11 +35,11 @@ NOTICES: tuple[WhatsNewNotice, ...] = (
             "Action is required. Placeholdarr now requires an API key on every webhook URL "
             "so Radarr, Sonarr, Tautulli, Jellyfin, and Emby can still call /webhook after "
             "dashboard login. Existing notification URLs without ?apikey= will be rejected "
-            "until you copy the updated URL from Settings (ARR Integrations or each media "
-            "card's webhook button) and paste it into that service."
+            "until you copy the updated URL from Settings → Security → Webhook URLs and paste "
+            "it into each of those services."
         ),
-        cta_label="Open ARR Integrations",
-        cta_path="/settings/arr-integrations",
+        cta_label="Open Security",
+        cta_path="/settings/security",
     ),
     WhatsNewNotice(
         id="collections-beta",


### PR DESCRIPTION
### Summary
- Add StevenLu, AniList, and TMDB person/company/keyword/collection as new collection sources
- Unify TMDB URL-based sources into a single "TMDB Page" card with explicit sort control
- Add "Was airing during" TV year filter mode (first–last air year overlap)
- Add unsaved recipe confirmation modal to prevent accidental draft loss
- Fix Plex path-scoped refreshes for Docker-mounted library locations
- Improve collection preview (200 titles, file/placeholder state, library chips) and Missing-from-ARR bulk add (chunked imports, 90s timeout)
- Sync Plex collection custom sort order from recipe; title sort ignores leading articles
### Commits
- 16d19bf Unify TMDB "link type" sources behind a single TMDB Page card and make TMDB fetch ordering explicit.
- 7403203 feat(collections): add confirmation modal for unsaved changes and enhance year filter options
- 21b2210 feat(plex): implement path-scoped library scans to match Plex locations and enhance refresh logic
- 1f852c5 feat(collections): implement bulk addition of missing titles to Radarr and Sonarr with improved timeout handling
- ce1bdda feat(collections): enhance collection preview with file state indicators and library filtering options
- 8f2455c feat(collections): add support for new collection sources including TMDB person, company, keyword, and collection
- 76f026b feat(collections): enhance title sorting and sync Plex collection order with custom sort
- c214de8 fix(whats-new): send webhook recopy CTA to Settings → Security
- 1658173 feat(collections): synchronize ARR_ADD_BATCH_CAP constant between frontend and backend