### PR TITLE
feat: implement collection title conflict checking and adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,20 @@ Collections (Beta) expands with unified **TMDB/Trakt** source cards plus **Tautu
 
 ### Action required
 
-**Existing Collections users:** After upgrading, the next sync may create a new Placeholdarr-owned Plex collection beside an older unmarked duplicate (ownership no longer matches by title alone). Keep the collection whose summary ends with **Managed by Placeholdarr.** and delete the other. A What's new notice covers this.
+**Reconnect existing Collections:** Placeholdarr now tracks Plex collection ownership internally, rather than matching by name. Open each affected recipe and **save** it: you will be prompted to **adopt** the matching collection or rename the recipe. Until you do, scheduled runs for that recipe will fail and leave the Plex collection unchanged. Prefer adopt for collections Placeholdarr already created. If you built the collection in Plex or another tool, rename instead so Placeholdarr does not claim it. Adopting syncs the collection to the recipe, so non-matching items will be removed.
 
 ### Added
 
 - **Collection sources**: Unified **TMDB** and **Trakt** source cards with cascading subtypes; Tautulli most popular / most watched (optional `TAUTULLI_URL` + `TAUTULLI_API_KEY`); Radarr/Sonarr tag mirrors (`arr_tag`). Trakt Settings copy notes that creating a Trakt API Client ID currently requires **Trakt VIP**.
 - **Collection Sets**: One config fans out to many Plex collections by **genre**, **decade**, **content rating** (age certification — not critic scores), **\*arr tag**, or **release timing** (Upcoming / released this week|month|year|decade, with a shared release-date basis like recipe filters). Include/exclude value selection, title patterns, live preview, and cleanup of stale child collections this set previously managed.
-- **Collection ownership**: Recipes used to match Plex collections by title only, so a sync could take over (and empty) a hand-made collection with the same name. Synced collections are now marked with a visible summary footer **Managed by Placeholdarr.** (plus internal labels) and tracked by ratingKey, so Placeholdarr only edits collections it owns. Existing summary text is kept; the footer is appended. After upgrade, a recipe may create a new owned copy beside an older unmarked one — keep the footer copy and delete the other.
+- **Collection ownership**: Synced collections are tracked behind the scenes (labels, summary footer **Managed by Placeholdarr.**, and ratingKeys). Placeholdarr only edits collections it owns. If a same-named collection already exists in a selected library, save asks you to **rename** or **adopt**. Prefer adopt for collections Placeholdarr already created; rename if the shelf was built in Plex or another tool. Adopting syncs membership to the recipe, so non-matching items may be removed.
 - **Collection source Validate**: URL/list source cards (TMDB Page, MDBList, Trakt list, AniList, StevenLu, legacy TMDB link types) gain a **Validate** button that resolves the pasted link and shows the title/kind or an error before you run preview. If the collection title is still blank, a successful validate can fill it in.
 - **Collection export/import**: Export selected recipes (or Collection Sets) to a portable JSON file, or import a bundle into this install. Runtime fields (ids, last-run stats, Plex ratingKeys) are stripped on export; import rebinds to your Plex libraries and creates new recipes.
+
+### Fixed
+
+- **Tautulli collection source**: Home-stats rows that only expose modern `plex://` (or episode-level agent) guids no longer yield an empty candidate list. Placeholdarr resolves TMDB/IMDb/TVDB ids via Tautulli `get_metadata` and strips a trailing `(Placeholder)` from titles.
+- **Collection same-title twins**: Sync no longer creates a second Plex collection with the same name in a library (which produced 0-item counts and linked deletes). Conflicts require rename or explicit adopt.
 
 ## [0.9.17] - 2026-08-18
 

--- a/frontend/src/api/collections.ts
+++ b/frontend/src/api/collections.ts
@@ -70,6 +70,26 @@ export function previewCollectionDefinition(payload: {
   return postJson("/api/collections/preview", payload);
 }
 
+export interface CollectionTitleConflict {
+  title: string;
+  section_id: number;
+  section_title: string;
+  rating_key?: string | null;
+  item_count: number;
+  reason: "unlabeled" | "other_recipe" | "ours" | string;
+}
+
+export function checkCollectionTitleConflicts(payload: {
+  plex_section_id: number;
+  plex_section_ids?: number[];
+  plex_section_type: "movie" | "show";
+  collection_title: string;
+  definition: CollectionDefinition;
+  recipe_id?: number | null;
+}): Promise<{ conflicts: CollectionTitleConflict[]; titles_checked: string[] }> {
+  return postJson("/api/collections/title-conflicts", payload);
+}
+
 export function getCollectionPlexSections(): Promise<{ sections: PlexSectionOption[] }> {
   return fetchJson("/api/collections/plex-sections");
 }

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { ThemeMode } from "../brandTypes";
 import {
+  checkCollectionTitleConflicts,
   explainCollectionItem,
   getCollectionBuilderMeta,
   getCollectionTmdbMeta,
@@ -8,6 +9,7 @@ import {
   validateCollectionSource,
   ARR_ADD_BATCH_CAP,
   type CollectionSourceValidation,
+  type CollectionTitleConflict,
   type RecipeWritePayload,
 } from "../api/collections";
 import { ArrAddModal } from "./ArrAddModal";
@@ -1003,7 +1005,8 @@ export function CollectionEditor(props: {
   onDirtyChange?: (dirty: boolean) => void;
 }) {
   const accentHex = props.accent.hex;
-  const theme = getCollectionTheme(props.themeMode === "light");
+  const isLight = props.themeMode === "light";
+  const theme = getCollectionTheme(isLight);
 
   const [name, setName] = useState(props.recipe?.name ?? "");
   const [enabled, setEnabled] = useState(props.recipe?.enabled ?? true);
@@ -1020,6 +1023,13 @@ export function CollectionEditor(props: {
       ? props.recipe.definition
       : { sources: [], filters: [], limit: 50, sort: "popularity" },
   );
+  const [nameCheck, setNameCheck] = useState<
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "ok" }
+    | { status: "conflict"; conflicts: CollectionTitleConflict[] }
+    | { status: "error"; message: string }
+  >({ status: "idle" });
   const editorSnapshot = useMemo(
     () =>
       collectionEditorSnapshot({
@@ -1042,6 +1052,10 @@ export function CollectionEditor(props: {
     return () => props.onDirtyChange?.(false);
   }, [props.onDirtyChange]);
 
+  useEffect(() => {
+    setNameCheck({ status: "idle" });
+  }, [collectionTitle, sectionIds]);
+
   const sectionId = sectionIds[0] ?? null;
   const section = useMemo(
     () => props.sections.find((s) => s.id === sectionId) ?? null,
@@ -1049,6 +1063,32 @@ export function CollectionEditor(props: {
   );
   const sectionType: "movie" | "show" = section?.type ?? props.recipe?.plex_section_type ?? "movie";
   const mediaType: "movie" | "tv" = sectionType === "movie" ? "movie" : "tv";
+
+  const runCheckName = async () => {
+    if (!collectionTitle.trim() || !sectionId || sectionIds.length === 0) return;
+    setNameCheck({ status: "loading" });
+    try {
+      const result = await checkCollectionTitleConflicts({
+        plex_section_id: sectionId,
+        plex_section_ids: sectionIds,
+        plex_section_type: sectionType,
+        collection_title: collectionTitle.trim(),
+        definition,
+        recipe_id: props.recipe?.id ?? null,
+      });
+      const blocking = (result.conflicts || []).filter((c) => c.reason !== "ours");
+      if (blocking.length === 0) {
+        setNameCheck({ status: "ok" });
+        return;
+      }
+      setNameCheck({ status: "conflict", conflicts: blocking });
+    } catch (err) {
+      setNameCheck({
+        status: "error",
+        message: err instanceof Error ? err.message : "Could not check that name",
+      });
+    }
+  };
 
   // TMDB metadata (genres / providers / regions) cached per media type + region.
   const [metaCache, setMetaCache] = useState<Record<string, CollectionTmdbMeta>>({});
@@ -2418,16 +2458,92 @@ export function CollectionEditor(props: {
                 })}
               </div>
             </div>
-            <label className={`flex items-center gap-2 ${theme.label}`}>
-              Collection title
-              <input
-                className={theme.field}
-                style={{ width: 220 }}
-                value={collectionTitle}
-                placeholder="e.g. Trending Now"
-                onChange={(e) => setCollectionTitle(e.target.value)}
-              />
-            </label>
+            <div className="flex flex-col gap-1.5 min-w-0">
+              <label className={`flex flex-wrap items-center gap-2 ${theme.label}`}>
+                Collection title
+                <input
+                  className={theme.field}
+                  style={{ width: 220 }}
+                  value={collectionTitle}
+                  placeholder="e.g. Trending Now"
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setCollectionTitle(next);
+                    if (definition.adopt_existing) {
+                      setDefinition((prev) => {
+                        if (!prev.adopt_existing) return prev;
+                        const { adopt_existing: _drop, ...rest } = prev;
+                        return rest;
+                      });
+                    }
+                  }}
+                />
+                <button
+                  type="button"
+                  className={theme.cancelButton}
+                  disabled={!collectionTitle.trim() || sectionIds.length === 0 || nameCheck.status === "loading"}
+                  onClick={() => void runCheckName()}
+                >
+                  {nameCheck.status === "loading" ? "Checking…" : "Check name"}
+                </button>
+              </label>
+              {definition.adopt_existing ? (
+                <p className="text-[13px] text-amber-300/90 max-w-xl">
+                  Will adopt the existing Plex collection(s) with this name. That reconnects a previous Placeholdarr
+                  collection, or takes over a non-Placeholdarr one. Items that do not match this recipe will be removed
+                  on sync.
+                </p>
+              ) : null}
+              {nameCheck.status === "ok" ? (
+                <p className="text-[13px] text-emerald-400">Name is available in the selected libraries.</p>
+              ) : null}
+              {nameCheck.status === "error" ? (
+                <p className="text-[13px] text-red-400">{nameCheck.message}</p>
+              ) : null}
+              {nameCheck.status === "conflict" ? (
+                <div className={`text-[13px] space-y-2 max-w-xl ${theme.muted}`}>
+                  {nameCheck.conflicts.some((c) => c.reason === "other_recipe") ? (
+                    <p className={isLight ? "text-amber-800" : "text-amber-200"}>
+                      Another Placeholdarr recipe already uses this name in a selected library. Change this title, or
+                      rename the other recipe&apos;s collection first.
+                    </p>
+                  ) : (
+                    <p className={isLight ? "text-amber-800" : "text-amber-200"}>
+                      This name is already used in a selected library. Rename, or adopt when you save to reconnect a
+                      previous Placeholdarr collection (or take over a non-Placeholdarr one). Items that do not match
+                      this recipe will be removed on sync.
+                    </p>
+                  )}
+                  <ul className="space-y-1">
+                    {nameCheck.conflicts.map((c) => (
+                      <li key={`${c.section_id}:${c.title}:${c.rating_key || ""}`}>
+                        <span className={isLight ? "text-slate-800 font-semibold" : "text-slate-200 font-semibold"}>
+                          {c.title}
+                        </span>
+                        {" · "}
+                        {c.section_title}
+                        {c.reason === "other_recipe"
+                          ? " (owned by another Placeholdarr recipe)"
+                          : ` (${c.item_count} item${c.item_count === 1 ? "" : "s"})`}
+                      </li>
+                    ))}
+                  </ul>
+                  {nameCheck.conflicts.every((c) => c.reason !== "other_recipe") ? (
+                    <button
+                      type="button"
+                      className="px-3 py-1.5 rounded-md text-[12px] font-headline uppercase tracking-wider text-white"
+                      style={{ backgroundColor: accentHex }}
+                      onClick={() => {
+                        setDefinition((prev) => ({ ...prev, adopt_existing: true }));
+                        setNameCheck({ status: "idle" });
+                      }}
+                    >
+                      Adopt when saving
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
             <label className={`flex items-center gap-2 ${theme.label}`}>
               Recipe name
               <input

--- a/frontend/src/collections/CollectionSetEditor.tsx
+++ b/frontend/src/collections/CollectionSetEditor.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ThemeMode } from "../brandTypes";
 import {
+  checkCollectionTitleConflicts,
   getCollectionBuilderMeta,
   previewCollectionDefinition,
+  type CollectionTitleConflict,
   type RecipeWritePayload,
 } from "../api/collections";
 import type {
@@ -102,7 +104,7 @@ function defaultSetConfig(category: SetCategory = "genre"): CollectionSetConfig 
   };
 }
 
-function setDefinition(config: CollectionSetConfig): CollectionDefinition {
+function setDefinition(config: CollectionSetConfig, adoptExisting = false): CollectionDefinition {
   return {
     mode: "collection_set",
     collection_set: config,
@@ -111,6 +113,7 @@ function setDefinition(config: CollectionSetConfig): CollectionDefinition {
     limit: config.limit ?? null,
     sort: config.sort ?? "title",
     pins: { include: [], exclude: [] },
+    ...(adoptExisting ? { adopt_existing: true } : {}),
   };
 }
 
@@ -140,7 +143,8 @@ export function CollectionSetEditor(props: {
   onDirtyChange?: (dirty: boolean) => void;
 }) {
   const accentHex = props.accent.hex;
-  const theme = getCollectionTheme(props.themeMode === "light");
+  const isLight = props.themeMode === "light";
+  const theme = getCollectionTheme(isLight);
   const existing = props.recipe?.definition?.collection_set;
 
   const [name, setName] = useState(props.recipe?.name ?? "");
@@ -154,6 +158,14 @@ export function CollectionSetEditor(props: {
   const [activeWindow, setActiveWindow] = useState<CollectionActiveWindow | null>(
     props.recipe?.active_window ?? null,
   );
+  const [adoptExisting, setAdoptExisting] = useState(Boolean(props.recipe?.definition?.adopt_existing));
+  const [nameCheck, setNameCheck] = useState<
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "ok" }
+    | { status: "conflict"; conflicts: CollectionTitleConflict[] }
+    | { status: "error"; message: string }
+  >({ status: "idle" });
   const [setConfig, setSetConfig] = useState<CollectionSetConfig>(() => {
     const cat = setCategoryOf(existing);
     if (!cat) return defaultSetConfig("genre");
@@ -169,6 +181,7 @@ export function CollectionSetEditor(props: {
         sectionIds,
         runIntervalHours,
         activeWindow,
+        adoptExisting,
         setConfig: {
           category: setConfig.category,
           selection_mode: setConfig.selection_mode,
@@ -181,7 +194,7 @@ export function CollectionSetEditor(props: {
           release_basis: setConfig.release_basis,
         },
       }),
-    [name, enabled, sectionIds, runIntervalHours, activeWindow, setConfig],
+    [name, enabled, sectionIds, runIntervalHours, activeWindow, adoptExisting, setConfig],
   );
   const initialRef = useRef(snapshot);
   const dirty = snapshot !== initialRef.current;
@@ -192,6 +205,10 @@ export function CollectionSetEditor(props: {
     return () => props.onDirtyChange?.(false);
   }, [props.onDirtyChange]);
 
+  useEffect(() => {
+    setNameCheck({ status: "idle" });
+  }, [sectionIds, setConfig.title_pattern, setConfig.category, setConfig.selection_mode, setConfig.values]);
+
   const sectionId = sectionIds[0] ?? null;
   const section = useMemo(
     () => props.sections.find((s) => s.id === sectionId) ?? null,
@@ -199,6 +216,43 @@ export function CollectionSetEditor(props: {
   );
   const hasLibrary = sectionIds.length > 0;
   const sectionType: "movie" | "show" = section?.type ?? props.recipe?.plex_section_type ?? "movie";
+
+  const runCheckNames = async () => {
+    if (!sectionId || sectionIds.length === 0) return;
+    const pattern = setConfig.title_pattern.trim() || defaultSetConfig(setConfig.category).title_pattern;
+    if (!pattern.includes("{value}")) return;
+    setNameCheck({ status: "loading" });
+    try {
+      const { dimension: _omit, ...rest } = setConfig;
+      const config: CollectionSetConfig = {
+        ...rest,
+        category: setConfig.category,
+        title_pattern: pattern,
+        values: setConfig.selection_mode === "all" ? [] : setConfig.values,
+        instance_key: setConfig.category === "tag" ? setConfig.instance_key : null,
+        release_basis: setConfig.category === "release_timing" ? setConfig.release_basis : null,
+      };
+      const result = await checkCollectionTitleConflicts({
+        plex_section_id: sectionId,
+        plex_section_ids: sectionIds,
+        plex_section_type: sectionType,
+        collection_title: pattern,
+        definition: setDefinition(config, adoptExisting),
+        recipe_id: props.recipe?.id ?? null,
+      });
+      const blocking = (result.conflicts || []).filter((c) => c.reason !== "ours");
+      if (blocking.length === 0) {
+        setNameCheck({ status: "ok" });
+        return;
+      }
+      setNameCheck({ status: "conflict", conflicts: blocking });
+    } catch (err) {
+      setNameCheck({
+        status: "error",
+        message: err instanceof Error ? err.message : "Could not check those names",
+      });
+    }
+  };
 
   const [builderMeta, setBuilderMeta] = useState<CollectionBuilderMeta | null>(null);
   useEffect(() => {
@@ -367,7 +421,7 @@ export function CollectionSetEditor(props: {
       plex_section_ids: sectionIds,
       plex_section_type: sectionType,
       collection_title: pattern,
-      definition: setDefinition(config),
+      definition: setDefinition(config, adoptExisting),
       run_interval_hours: runIntervalHours,
       active_window: activeWindow,
     });
@@ -624,15 +678,88 @@ export function CollectionSetEditor(props: {
             </label>
           ) : null}
 
-          <label className={`flex items-center gap-2 ${theme.label}`}>
-            Title pattern
-            <input
-              className={`${theme.field} flex-1`}
-              style={{ minWidth: 220 }}
-              value={setConfig.title_pattern}
-              onChange={(e) => setSetConfig((prev) => ({ ...prev, title_pattern: e.target.value }))}
-            />
-          </label>
+          <div className="flex flex-col gap-1.5">
+            <label className={`flex flex-wrap items-center gap-2 ${theme.label}`}>
+              Title pattern
+              <input
+                className={`${theme.field} flex-1`}
+                style={{ minWidth: 220 }}
+                value={setConfig.title_pattern}
+                onChange={(e) => {
+                  setSetConfig((prev) => ({ ...prev, title_pattern: e.target.value }));
+                  if (adoptExisting) setAdoptExisting(false);
+                }}
+              />
+              <button
+                type="button"
+                className={theme.cancelButton}
+                disabled={
+                  sectionIds.length === 0 ||
+                  !setConfig.title_pattern.includes("{value}") ||
+                  nameCheck.status === "loading"
+                }
+                onClick={() => void runCheckNames()}
+              >
+                {nameCheck.status === "loading" ? "Checking…" : "Check names"}
+              </button>
+            </label>
+            {adoptExisting ? (
+              <p className="text-[13px] text-amber-300/90 max-w-xl">
+                Will adopt existing Plex collections when names match. That reconnects previous Placeholdarr
+                collections, or takes over non-Placeholdarr ones. Items that do not match this set will be removed on
+                sync.
+              </p>
+            ) : null}
+            {nameCheck.status === "ok" ? (
+              <p className="text-[13px] text-emerald-400">Those names are available in the selected libraries.</p>
+            ) : null}
+            {nameCheck.status === "error" ? (
+              <p className="text-[13px] text-red-400">{nameCheck.message}</p>
+            ) : null}
+            {nameCheck.status === "conflict" ? (
+              <div className={`text-[13px] space-y-2 max-w-xl ${theme.muted}`}>
+                {nameCheck.conflicts.some((c) => c.reason === "other_recipe") ? (
+                  <p className={isLight ? "text-amber-800" : "text-amber-200"}>
+                    One or more generated names are already used by another Placeholdarr recipe. Change the pattern or
+                    values, or rename the other recipe&apos;s collection first.
+                  </p>
+                ) : (
+                  <p className={isLight ? "text-amber-800" : "text-amber-200"}>
+                    One or more generated names are already used. Change the pattern or values, or adopt when you save
+                    to reconnect previous Placeholdarr collections (or take over non-Placeholdarr ones). Items that do
+                    not match are removed on sync.
+                  </p>
+                )}
+                <ul className="space-y-1 max-h-36 overflow-y-auto">
+                  {nameCheck.conflicts.map((c) => (
+                    <li key={`${c.section_id}:${c.title}:${c.rating_key || ""}`}>
+                      <span className={isLight ? "text-slate-800 font-semibold" : "text-slate-200 font-semibold"}>
+                        {c.title}
+                      </span>
+                      {" · "}
+                      {c.section_title}
+                      {c.reason === "other_recipe"
+                        ? " (owned by another Placeholdarr recipe)"
+                        : ` (${c.item_count} item${c.item_count === 1 ? "" : "s"})`}
+                    </li>
+                  ))}
+                </ul>
+                {nameCheck.conflicts.every((c) => c.reason !== "other_recipe") ? (
+                  <button
+                    type="button"
+                    className="px-3 py-1.5 rounded-md text-[12px] font-headline uppercase tracking-wider text-white"
+                    style={{ backgroundColor: accentHex }}
+                    onClick={() => {
+                      setAdoptExisting(true);
+                      setNameCheck({ status: "idle" });
+                    }}
+                  >
+                    Adopt when saving
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
           <p className={`text-[12px] ${theme.muted}`}>
             Use <code className="font-mono">{"{value}"}</code> for the value label. Optional:{" "}
             <code className="font-mono">{"{category}"}</code>.

--- a/frontend/src/collections/CollectionsPanel.tsx
+++ b/frontend/src/collections/CollectionsPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ThemeMode } from "../brandTypes";
 import {
+  checkCollectionTitleConflicts,
   createCollectionRecipe,
   deleteCollectionRecipe,
   exportCollectionRecipes,
@@ -10,6 +11,7 @@ import {
   runCollectionRecipe,
   toggleCollectionRecipe,
   updateCollectionRecipe,
+  type CollectionTitleConflict,
   type RecipeWritePayload,
 } from "../api/collections";
 import type { CollectionRecipe, LibraryItem, PlexSectionOption } from "../types/api";
@@ -70,6 +72,10 @@ export function CollectionsPanel(props: {
   const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [titleConflict, setTitleConflict] = useState<{
+    payload: RecipeWritePayload;
+    conflicts: CollectionTitleConflict[];
+  } | null>(null);
   const [runningIds, setRunningIds] = useState<Set<number>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
@@ -166,17 +172,56 @@ export function CollectionsPanel(props: {
     return () => window.clearInterval(timer);
   }, [runningIds, refresh, recipes]);
 
+  const persistRecipe = async (payload: RecipeWritePayload) => {
+    if (editing && editing !== "new" && editing !== "new-set") {
+      await updateCollectionRecipe(editing.id, payload);
+    } else {
+      await createCollectionRecipe(payload);
+    }
+    setEditing(null);
+    setTitleConflict(null);
+    await refresh();
+  };
+
   const handleSave = async (payload: RecipeWritePayload) => {
     setSaving(true);
     setSaveError(null);
     try {
-      if (editing && editing !== "new") {
-        await updateCollectionRecipe(editing.id, payload);
-      } else {
-        await createCollectionRecipe(payload);
+      if (payload.definition.adopt_existing) {
+        await persistRecipe(payload);
+        return;
       }
-      setEditing(null);
-      await refresh();
+      const recipeId = editing && editing !== "new" && editing !== "new-set" ? editing.id : null;
+      const result = await checkCollectionTitleConflicts({
+        plex_section_id: payload.plex_section_id,
+        plex_section_ids: payload.plex_section_ids,
+        plex_section_type: payload.plex_section_type,
+        collection_title: payload.collection_title,
+        definition: payload.definition,
+        recipe_id: recipeId,
+      });
+      const blocking = (result.conflicts || []).filter((c) => c.reason !== "ours");
+      if (blocking.length > 0) {
+        setTitleConflict({ payload, conflicts: blocking });
+        return;
+      }
+      await persistRecipe(payload);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save collection");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdoptConflict = async () => {
+    if (!titleConflict) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await persistRecipe({
+        ...titleConflict.payload,
+        definition: { ...titleConflict.payload.definition, adopt_existing: true },
+      });
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save collection");
     } finally {
@@ -337,6 +382,75 @@ export function CollectionsPanel(props: {
             onCancel={() => setLeaveConfirmOpen(false)}
             onConfirm={discardEditor}
           />
+        ) : null}
+        {titleConflict ? (
+          <div className="fixed inset-0 z-[85] flex items-center justify-center bg-[#0f1419]/85 backdrop-blur-sm p-6">
+            <div
+              className={`w-full max-w-lg rounded-2xl border p-6 shadow-2xl space-y-4 ${
+                isLight ? "border-slate-200 bg-white" : "border-[#424753]/40 bg-[#171c22]"
+              }`}
+            >
+              <h3 className={`text-[20px] font-headline font-bold ${isLight ? "text-slate-900" : "text-white"}`}>
+                {titleConflict.conflicts.some((c) => c.reason === "other_recipe")
+                  ? "Name used by another recipe"
+                  : "Collection name already in use"}
+              </h3>
+              {titleConflict.conflicts.some((c) => c.reason === "other_recipe") ? (
+                <p className={`text-[15px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-300"}`}>
+                  Another Placeholdarr recipe already uses this name in a selected library. Change this title, or rename
+                  the other recipe&apos;s collection first.
+                </p>
+              ) : (
+                <>
+                  <p className={`text-[15px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-300"}`}>
+                    A collection with this name already exists in a selected library. Rename this recipe, or adopt to
+                    reconnect it with Placeholdarr&apos;s ownership tracking (or take it over if it was not managed
+                    before).
+                  </p>
+                  <p className={`text-[14px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-400"}`}>
+                    Adopting reconnects a previous Placeholdarr collection, or takes over a non-Placeholdarr collection
+                    with this name. Items that do not match this recipe&apos;s sources and filters will be removed on
+                    sync.
+                  </p>
+                </>
+              )}
+              <ul className={`text-[13px] space-y-1.5 max-h-40 overflow-y-auto ${isLight ? "text-slate-700" : "text-slate-300"}`}>
+                {titleConflict.conflicts.map((c) => (
+                  <li key={`${c.section_id}:${c.title}:${c.rating_key || ""}`}>
+                    <span className="font-semibold">{c.title}</span>
+                    {" · "}
+                    {c.section_title}
+                    {c.reason === "other_recipe"
+                      ? " (owned by another Placeholdarr recipe)"
+                      : ` (${c.item_count} item${c.item_count === 1 ? "" : "s"} in Plex)`}
+                  </li>
+                ))}
+              </ul>
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  className={`px-4 py-2 rounded-lg text-[13px] font-headline uppercase tracking-wider ${
+                    isLight ? "text-slate-700 hover:bg-slate-100" : "text-slate-300 hover:bg-white/5"
+                  }`}
+                  onClick={() => setTitleConflict(null)}
+                  disabled={saving}
+                >
+                  {titleConflict.conflicts.some((c) => c.reason === "other_recipe") ? "OK" : "Rename"}
+                </button>
+                {titleConflict.conflicts.every((c) => c.reason !== "other_recipe") ? (
+                  <button
+                    type="button"
+                    className="px-4 py-2 rounded-lg text-[13px] font-headline uppercase tracking-wider text-white disabled:opacity-60"
+                    style={{ backgroundColor: accentHex }}
+                    onClick={() => void handleAdoptConflict()}
+                    disabled={saving}
+                  >
+                    {saving ? "Saving…" : "Adopt and save"}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </div>
         ) : null}
         <div className="flex items-center gap-3 mb-6">
           <button

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -653,6 +653,11 @@ export interface CollectionDefinition {
   /** When sort is rating (movies): which Radarr ratings.* key to order by. */
   sort_provider?: CollectionRatingProvider | null;
   pins?: CollectionPins;
+  /**
+   * When true, sync may claim an existing unlabeled Plex collection with the same
+   * title (per library) instead of refusing. Membership then follows the recipe.
+   */
+  adopt_existing?: boolean;
 }
 
 export interface CollectionRunSummary {

--- a/routes/collections.py
+++ b/routes/collections.py
@@ -22,6 +22,7 @@ from services.collections.engine import (
     preview_definition,
     recipe_section_ids,
     run_recipe,
+    titles_for_conflict_check,
     validate_active_window,
     validate_definition,
     window_is_active,
@@ -476,6 +477,48 @@ async def builder_meta(media_type: str = Query("movie", pattern="^(movie|show)$"
         "arr_tags": arr_tags,
         "tautulli_configured": list_sources.tautulli_configured(),
     }
+
+
+class TitleConflictsPayload(BaseModel):
+    plex_section_id: int = Field(..., ge=1)
+    plex_section_ids: list[int] | None = None
+    plex_section_type: str = Field(..., pattern="^(movie|show)$")
+    collection_title: str = ""
+    definition: dict[str, Any] = Field(default_factory=dict)
+    recipe_id: int | None = None
+
+
+@router.post("/api/collections/title-conflicts")
+async def title_conflicts(body: TitleConflictsPayload):
+    """Detect same-title Plex collections in any selected library (would create a twin)."""
+    try:
+        section_ids = normalize_section_ids(body.plex_section_id, body.plex_section_ids)
+        titles = titles_for_conflict_check(
+            collection_title=body.collection_title,
+            definition=body.definition or {},
+            section_type=body.plex_section_type,
+        )
+    except RecipeValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    known_keys = None
+    if body.recipe_id is not None:
+        with session_scope() as session:
+            row = session.query(CollectionRecipe).filter(CollectionRecipe.id == body.recipe_id).first()
+            if row is not None and isinstance(row.plex_collection_keys, dict):
+                known_keys = dict(row.plex_collection_keys)
+
+    try:
+        conflicts = plex_collections.find_title_conflicts(
+            section_ids,
+            body.plex_section_type,
+            titles,
+            recipe_id=body.recipe_id,
+            known_keys=known_keys,
+        )
+    except plex_collections.PlexCollectionsError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return {"conflicts": conflicts, "titles_checked": titles}
 
 
 @router.post("/api/collections/preview")

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -206,6 +206,7 @@ def validate_definition(definition: dict[str, Any]) -> dict[str, Any]:
             "sort": sort,
             "sort_provider": None,
             "pins": {"include": [], "exclude": []},
+            "adopt_existing": bool(definition.get("adopt_existing")),
         }
 
     sources = definition.get("sources") or []
@@ -314,12 +315,24 @@ def validate_definition(definition: dict[str, Any]) -> dict[str, Any]:
         "sort": sort,
         "sort_provider": sort_provider,
         "pins": normalized_pins,
+        "adopt_existing": bool(definition.get("adopt_existing")),
     }
 
 
-# ---------------------------------------------------------------------------
-# Source blocks
-# ---------------------------------------------------------------------------
+def titles_for_conflict_check(
+    *,
+    collection_title: str,
+    definition: dict[str, Any],
+    section_type: str,
+) -> list[str]:
+    """Titles that would be created/synced for conflict detection."""
+    if sets_mod.is_collection_set_definition(definition):
+        normalized = validate_definition(definition)
+        set_cfg = normalized["collection_set"]
+        children = sets_mod.expand_collection_set(set_cfg, section_type)
+        return [str(child.get("title") or "").strip() for child in children if child.get("title")]
+    title = str(collection_title or "").strip()
+    return [title] if title else []
 
 def _media_type_for_section(section_type: str) -> str:
     return "movie" if section_type == "movie" else "tv"
@@ -2427,6 +2440,7 @@ def run_collection_set_recipe(
             if outcome["plex_error"]:
                 raise plex_collections.PlexCollectionsError(outcome["plex_error"])
             known_key = plex_collections.lookup_stored_key(keys_map, sid, title)
+            adopt = bool(normalized.get("adopt_existing"))
             sync_stats = plex_collections.sync_collection(
                 sid,
                 section_type,
@@ -2435,6 +2449,7 @@ def run_collection_set_recipe(
                 recipe_id=recipe_id,
                 set_value=value_label,
                 known_rating_key=known_key,
+                adopt_unlabeled=adopt,
             )
             keys_map = plex_collections.set_stored_key(
                 keys_map, sid, title, sync_stats.get("rating_key")
@@ -2584,6 +2599,7 @@ def run_recipe(recipe_id: int) -> dict[str, Any]:
                 if outcome["plex_error"]:
                     raise plex_collections.PlexCollectionsError(outcome["plex_error"])
                 known_key = plex_collections.lookup_stored_key(keys_map, sid, collection_title)
+                adopt = bool(definition.get("adopt_existing"))
                 sync_stats = plex_collections.sync_collection(
                     sid,
                     section_type,
@@ -2591,6 +2607,7 @@ def run_recipe(recipe_id: int) -> dict[str, Any]:
                     outcome["resolved_items"] or [],
                     recipe_id=recipe_id,
                     known_rating_key=known_key,
+                    adopt_unlabeled=adopt,
                 )
                 keys_map = plex_collections.set_stored_key(
                     keys_map, sid, collection_title, sync_stats.get("rating_key")
@@ -2801,6 +2818,7 @@ def _clear_recipe_collection(recipe_id: int) -> dict[str, Any]:
                         [],
                         recipe_id=recipe_id,
                         known_rating_key=known_key,
+                        adopt_unlabeled=bool(definition.get("adopt_existing")),
                     )
                     keys_map = plex_collections.set_stored_key(
                         keys_map, sid, title, sync_stats.get("rating_key")
@@ -2827,6 +2845,7 @@ def _clear_recipe_collection(recipe_id: int) -> dict[str, Any]:
                     [],
                     recipe_id=recipe_id,
                     known_rating_key=known_key,
+                    adopt_unlabeled=bool(definition.get("adopt_existing")),
                 )
                 keys_map = plex_collections.set_stored_key(
                     keys_map, sid, collection_title, sync_stats.get("rating_key")

--- a/services/media_servers/plex_collections.py
+++ b/services/media_servers/plex_collections.py
@@ -6,17 +6,19 @@ membership. Targeting is per-section so recipes can point at any Plex
 library (including dedicated placeholder libraries), not just the
 configured movie/TV sections.
 
-Ownership: Placeholdarr only mutates collections that carry a
-``placeholdarr`` label and/or a visible summary starting with
-``Managed by Placeholdarr.`` as a summary footer (and stores their ratingKeys). Unlabeled
-same-title collections are left alone; sync creates a new owned one.
+Ownership: Placeholdarr only mutates collections it owns (``placeholdarr``
+label and/or ``Managed by Placeholdarr.`` summary footer), tracked by
+ratingKey. Same-title collections in one library share a Plex identity, so
+we never create a second copy: rename, or explicitly adopt the existing
+shelf (adoption syncs membership to the recipe and may remove non-matching
+items).
 """
 from __future__ import annotations
 
 import re
 import threading
 import time
-from typing import Any
+from typing import Any, Optional
 
 from core.logger import logger
 from services.media_servers.plex_lookup import (
@@ -29,6 +31,14 @@ from services.media_servers.plex_lookup import (
 
 class PlexCollectionsError(Exception):
     """Raised when Plex is unavailable or a collection operation fails."""
+
+
+class CollectionTitleConflict(PlexCollectionsError):
+    """Same-title collection exists in a target library and was not adopted."""
+
+    def __init__(self, message: str, *, conflicts: list[dict[str, Any]] | None = None):
+        super().__init__(message)
+        self.conflicts = list(conflicts or [])
 
 
 OWNERSHIP_LABEL = "placeholdarr"
@@ -199,6 +209,113 @@ def is_owned_collection(collection) -> bool:
     return has_ownership_label(collection) or has_ownership_summary(collection)
 
 
+def is_owned_by_recipe(collection, recipe_id: int) -> bool:
+    """True when this collection carries the recipe-specific ownership label."""
+    needle = f"placeholdarr-recipe-{int(recipe_id)}"
+    return needle in collection_label_names(collection)
+
+
+def _collection_item_count(collection) -> int:
+    try:
+        count = getattr(collection, "childCount", None)
+        if count is not None:
+            return int(count)
+    except (TypeError, ValueError):
+        pass
+    try:
+        return len(collection.items())
+    except Exception:
+        return 0
+
+
+def find_collections_by_title(section, collection_title: str) -> list[Any]:
+    needle = collection_title.strip().lower()
+    if not needle:
+        return []
+    matches: list[Any] = []
+    for collection in section.collections():
+        if str(getattr(collection, "title", "")).strip().lower() == needle:
+            matches.append(collection)
+    return matches
+
+
+def describe_title_conflict(
+    collection,
+    *,
+    section_id: int,
+    section_title: str,
+    collection_title: str,
+    recipe_id: int | None,
+) -> dict[str, Any]:
+    owned = is_owned_collection(collection)
+    owned_by_this = bool(recipe_id is not None and is_owned_by_recipe(collection, int(recipe_id)))
+    reason = "ours" if owned_by_this else ("other_recipe" if owned else "unlabeled")
+    return {
+        "title": collection_title.strip(),
+        "section_id": int(section_id),
+        "section_title": section_title,
+        "rating_key": str(getattr(collection, "ratingKey", "") or "") or None,
+        "item_count": _collection_item_count(collection),
+        "reason": reason,
+    }
+
+
+def find_title_conflicts(
+    section_ids: list[int],
+    section_type: str,
+    titles: list[str],
+    *,
+    recipe_id: int | None = None,
+    known_keys: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Return same-title clashes in any selected library that would create a twin.
+
+    Skips collections already owned by this recipe (label or stored ratingKey).
+    """
+    plex = get_plex_server()
+    if not plex:
+        raise PlexCollectionsError("Plex is not configured or unreachable")
+    unique_titles = []
+    seen_titles: set[str] = set()
+    for raw in titles:
+        title = str(raw or "").strip()
+        key = title.lower()
+        if not title or key in seen_titles:
+            continue
+        seen_titles.add(key)
+        unique_titles.append(title)
+    if not unique_titles or not section_ids:
+        return []
+
+    conflicts: list[dict[str, Any]] = []
+    for section_id in section_ids:
+        section = _get_section(plex, int(section_id))
+        section_title = str(getattr(section, "title", "") or section_id)
+        # Only movie/show sections of the recipe type are valid targets.
+        sec_type = str(getattr(section, "type", "") or "")
+        if section_type == "movie" and sec_type != "movie":
+            continue
+        if section_type == "show" and sec_type != "show":
+            continue
+        for title in unique_titles:
+            known = lookup_stored_key(known_keys, int(section_id), title) if known_keys else None
+            if known:
+                # Already bound to a ratingKey for this recipe — not a create conflict.
+                continue
+            for collection in find_collections_by_title(section, title):
+                row = describe_title_conflict(
+                    collection,
+                    section_id=int(section_id),
+                    section_title=section_title,
+                    collection_title=title,
+                    recipe_id=recipe_id,
+                )
+                if row["reason"] == "ours":
+                    continue
+                conflicts.append(row)
+    return conflicts
+
+
 def desired_ownership_summary(existing_summary: str | None = None) -> str:
     """Ensure the visible Plex summary ends with our ownership footer."""
     current = str(existing_summary or "").strip()
@@ -306,6 +423,14 @@ def _fetch_collection_by_rating_key(plex, rating_key: str):
     return item
 
 
+def _find_unlabeled_by_title(section, collection_title: str):
+    """First same-title collection that is not Placeholdarr-owned."""
+    for collection in find_collections_by_title(section, collection_title):
+        if not is_owned_collection(collection):
+            return collection
+    return None
+
+
 def _find_owned_collection_by_title(section, collection_title: str):
     """Title match only when the collection already has our ownership marker."""
     needle = collection_title.strip().lower()
@@ -381,16 +506,19 @@ def sync_collection(
     recipe_id: int,
     set_value: str | None = None,
     known_rating_key: str | None = None,
+    adopt_unlabeled: bool = False,
 ) -> dict[str, Any]:
     """Create or update a Placeholdarr-owned Plex collection.
 
-    Never mutates an unlabeled same-title collection. Returns counts plus
-    ``rating_key`` for persistence on the recipe.
+    Never creates a same-title twin in a library. Unlabeled same-title shelves
+    are adopted only when ``adopt_unlabeled`` is true (membership then follows
+    the recipe and non-matching items are removed).
     """
     plex = get_plex_server()
     if not plex:
         raise PlexCollectionsError("Plex is not configured or unreachable")
     section = _get_section(plex, section_id)
+    section_title = str(getattr(section, "title", "") or section_id)
 
     existing = resolve_owned_collection(
         plex,
@@ -398,6 +526,42 @@ def sync_collection(
         collection_title=collection_title,
         known_rating_key=known_rating_key,
     )
+    adopted = False
+
+    if existing is None:
+        unlabeled = _find_unlabeled_by_title(section, collection_title)
+        if unlabeled is not None:
+            if not adopt_unlabeled:
+                conflict = describe_title_conflict(
+                    unlabeled,
+                    section_id=int(section_id),
+                    section_title=section_title,
+                    collection_title=collection_title,
+                    recipe_id=recipe_id,
+                )
+                raise CollectionTitleConflict(
+                    f"Plex already has a collection named {collection_title!r} in "
+                    f"{section_title!r}. Rename this recipe or adopt the existing collection.",
+                    conflicts=[conflict],
+                )
+            existing = unlabeled
+            adopted = True
+        else:
+            # Another Placeholdarr recipe may already own this title.
+            for other in find_collections_by_title(section, collection_title):
+                if is_owned_collection(other) and not is_owned_by_recipe(other, recipe_id):
+                    conflict = describe_title_conflict(
+                        other,
+                        section_id=int(section_id),
+                        section_title=section_title,
+                        collection_title=collection_title,
+                        recipe_id=recipe_id,
+                    )
+                    raise CollectionTitleConflict(
+                        f"Collection {collection_title!r} in {section_title!r} is already "
+                        f"managed by another Placeholdarr recipe. Rename this recipe.",
+                        conflicts=[conflict],
+                    )
 
     target_keys = {str(getattr(item, "ratingKey", "")) for item in items}
 
@@ -408,6 +572,7 @@ def sync_collection(
                 "removed": 0,
                 "total": 0,
                 "created": False,
+                "adopted": False,
                 "rating_key": None,
                 "skipped_unlabeled": False,
             }
@@ -430,6 +595,7 @@ def sync_collection(
             "removed": 0,
             "total": len(items),
             "created": True,
+            "adopted": False,
             "rating_key": rating_key,
             "skipped_unlabeled": False,
         }
@@ -462,7 +628,7 @@ def sync_collection(
 
     rating_key = str(getattr(existing, "ratingKey", "") or "") or None
     logger.info(
-        f"Collections: synced Plex collection {collection_title!r} "
+        f"Collections: {'adopted' if adopted else 'synced'} Plex collection {collection_title!r} "
         f"(section={section_id}, added={len(to_add)}, removed={len(to_remove)}, "
         f"total={len(target_keys)}, recipe={recipe_id})",
         extra={"emoji_type": "info"},
@@ -472,6 +638,7 @@ def sync_collection(
         "removed": len(to_remove),
         "total": len(target_keys),
         "created": False,
+        "adopted": adopted,
         "rating_key": rating_key,
         "skipped_unlabeled": False,
     }

--- a/services/whats_new.py
+++ b/services/whats_new.py
@@ -56,15 +56,17 @@ NOTICES: tuple[WhatsNewNotice, ...] = (
         cta_path="/collections",
     ),
     WhatsNewNotice(
-        id="collections-ownership",
+        id="collections-title-adopt",
         since_version="0.9.18",
-        title="Action required: clean up collection duplicates",
+        title="Action required: reconnect Collections",
         body=(
-            "Placeholdarr Collections no longer take over same-named hand-made Plex collections. "
-            "On sync, Placeholdarr marks the collections it owns by appending "
-            "\"Managed by Placeholdarr.\" to the collection summary (the description shown in Plex). "
-            "If you already had Placeholdarr collections before this upgrade, the next sync may "
-            "create a second copy. Keep the one whose summary shows that text, and delete the other."
+            "Action is required. Placeholdarr now tracks Plex collection ownership internally, "
+            "rather than matching by name. Open each affected recipe and save it: you will be prompted "
+            "to adopt the matching collection or rename the recipe. Until you do, scheduled runs for "
+            "that recipe will fail and leave the Plex collection unchanged.\n\n"
+            "Prefer adopt for collections Placeholdarr already created. If you built the collection "
+            "in Plex or another tool, rename instead so Placeholdarr doesn't claim it. Adopting syncs "
+            "the collection to the Placeholdarr recipe, so non-matching items will be removed."
         ),
         cta_label="Open Collections",
         cta_path="/collections",
@@ -140,6 +142,18 @@ def _notice_payload(notice: WhatsNewNotice) -> dict[str, Any]:
     }
 
 
+def _notices_newest_update_first(notices: tuple[WhatsNewNotice, ...] | list[WhatsNewNotice]) -> list[WhatsNewNotice]:
+    """Newest since_version first; within one version, keep NOTICES declaration order."""
+    # Negate semver parts so we can sort ascending on index within a version.
+    return sorted(
+        notices,
+        key=lambda notice: (
+            tuple(-part for part in parse_semver(notice.since_version)),
+            NOTICES.index(notice),
+        ),
+    )
+
+
 def pending_notices(*, setup_complete: bool, session=None) -> dict[str, Any]:
     """Return notices for this install and stamp last_seen for first-run setup."""
     last_seen = get_last_seen_app_version(session=session)
@@ -155,29 +169,26 @@ def pending_notices(*, setup_complete: bool, session=None) -> dict[str, Any]:
         }
 
     effective_last = last_seen if last_seen else "0.0.0"
-    notices = [
-        _notice_payload(notice)
+    matched = [
+        notice
         for notice in NOTICES
         if version_less(effective_last, notice.since_version) and notice.id not in dismissed
     ]
     return {
         "app_version": APP_VERSION,
         "last_seen_app_version": last_seen,
-        "notices": notices,
+        "notices": [_notice_payload(notice) for notice in _notices_newest_update_first(matched)],
     }
 
 
 def catalog_notices(session=None) -> dict[str, Any]:
-    """Full What's new list for the sidebar version chip (newest first)."""
-    ordered = sorted(
-        NOTICES,
-        key=lambda notice: (parse_semver(notice.since_version), NOTICES.index(notice)),
-        reverse=True,
-    )
+    """Full What's new list for the sidebar version chip (newest update first)."""
     return {
         "app_version": APP_VERSION,
         "last_seen_app_version": get_last_seen_app_version(session=session),
-        "notices": [_notice_payload(notice) for notice in ordered],
+        "notices": [
+            _notice_payload(notice) for notice in _notices_newest_update_first(NOTICES)
+        ],
     }
 
 


### PR DESCRIPTION
- Added a new API endpoint to check for title conflicts in Plex collections.
- Introduced a new interface for handling collection title conflicts.
- Updated the CollectionEditor and CollectionSetEditor components to check for title conflicts when saving collections.
- Implemented UI feedback for users when a title conflict occurs, including options to adopt existing collections.
- Enhanced the backend logic to support adopting unlabeled collections and managing conflicts with existing recipes.
- Updated the documentation to reflect changes in collection ownership and conflict resolution.