### PR TITLE
release: 0.9.19 — reliable Add to Radarr/Sonarr and seasonal Run

### DIFF
--- a/.cursor/rules/changelog-one-feature-per-line.mdc
+++ b/.cursor/rules/changelog-one-feature-per-line.mdc
@@ -1,0 +1,24 @@
+---
+description: Keep changelog, PR, and release notes as one feature per bullet
+globs: CHANGELOG.md
+alwaysApply: true
+---
+
+# One feature per changelog line
+
+Never blend unrelated Collections (or other) features into one paragraph or one bullet. This applies to `CHANGELOG.md`, PR bodies, release notes, and commit messages.
+
+- **Summary** is a bullet list (or short paragraphs), one theme per line. Do not append a new feature onto an existing summary sentence.
+- **Added / Changed / Fixed** bullets: one **Bold lead-in** and one concern. If a sentence needs “and also…”, split it.
+- Do not nest tags, webhook ingest, seasonal windows, lookup fixes, or sidebar styling under Add to Radarr/Sonarr (or any other catch-all).
+- When folding Unreleased into a version, copy bullets as-is. Do not concatenate them.
+
+```markdown
+❌ BAD
+Collections Add to Radarr no longer hangs. Tags are chips. Seasonal Run now follows keep/empty/delete. Sidebar styling.
+
+✅ GOOD
+- **Add to Radarr/Sonarr**: Chunks of 20, then library poll after a silent import.
+- **Add tags**: Chips; a failed tag no longer aborts the add.
+- **Manual Run now (seasonal)**: Out-of-window runs follow keep / empty / delete.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+## [0.9.19] - 2026-08-26
+
+### Summary
+
+Collections **Add to Radarr/Sonarr** no longer hangs on a silent *arr import: chunks of 20, a short wait, then **library poll** until titles appear, with live per-title progress in the modal. Already-in-*arr and reconciled titles still enqueue placeholder ingest. Tags are chips; a failed tag no longer aborts the add. Webhook persist is serialized so import-list floods cannot exhaust the DB pool. MDBList public JSON `id` is treated as TMDB id, and lookups fall back through TMDB/TVDB/IMDb then title search. Missing-list copy says **catalog**. Sidebar selected-tab and hover styling.
+
+### Added
+
+- **Add modal progress**: After submit, the form is replaced by a per-title list that flips **Adding…** to a green **Added** (or an error) as each title is found.
+
+### Changed
+
+- **Add to Radarr/Sonarr**: Import chunks of 20. *arr often never returns `movie/import` / `series/import`, so Placeholdarr waits briefly then **polls the library** until titles appear. Already-in-*arr and reconciled titles still enqueue placeholder ingest.
+- **Add tags**: Tags are chips (Enter to add, spaces become dashes); a failed tag no longer aborts the add. API accepts `tags: string[]` (legacy `tag` still works).
+- **Webhook ingest**: Persist is serialized (`WEBHOOK_INGEST_CONCURRENCY`, default 1) so import-list `MovieAdded` floods cannot exhaust the DB pool.
+- **Collections missing list**: Preview and recipe list describe titles **missing from catalog**, not “not in Radarr/Sonarr” (the check is catalog membership).
+- **Sidebar**: New selected-tab and hover styling.
+
+### Fixed
+
+- **MDBList ids**: Public JSON `id` is treated as TMDB id.
+- **ARR lookup**: Radarr/Sonarr lookup tries TMDB/TVDB/IMDb then a title search (so a bad or missing id does not fail a title Radarr can find by name).
+
 ## [0.9.18] - 2026-08-24
 
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,31 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ### Summary
 
-Collections **Add to Radarr/Sonarr** no longer hangs on a silent *arr import: chunks of 20, a short wait, then **library poll** until titles appear, with live per-title progress in the modal. Already-in-*arr and reconciled titles still enqueue placeholder ingest. Tags are chips; a failed tag no longer aborts the add. Webhook persist is serialized so import-list floods cannot exhaust the DB pool. MDBList public JSON `id` is treated as TMDB id, and lookups fall back through TMDB/TVDB/IMDb then title search. Missing-list copy says **catalog**. Sidebar selected-tab and hover styling.
+- **Add to Radarr/Sonarr**: Chunks of 20, then **library poll** after a silent *arr import.
+- **Add modal progress**: Live per-title status in the add modal.
+- **Add tags**: Chips (Enter to add, spaces become dashes); a failed tag no longer aborts the add.
+- **Webhook ingest**: Persist is serialized so import-list floods cannot exhaust the DB pool.
+- **Seasonal Run now**: Out-of-window runs follow keep / empty / delete instead of filling the collection.
+- **Seasonal delete**: Dormant recipes can delete Placeholdarr-owned Plex collections (Sets delete managed children).
+- **Missing from catalog**: Preview and recipe list copy (the check is catalog membership).
+- **Sidebar**: Selected-tab and hover styling.
+- **MDBList ids**: Public JSON `id` is treated as TMDB id.
+- **ARR lookup**: Tries TMDB/TVDB/IMDb then a title search.
 
 ### Added
 
 - **Add modal progress**: After submit, the form is replaced by a per-title list that flips **Adding…** to a green **Added** (or an error) as each title is found.
+- **Seasonal window: delete**: When dormant, a recipe can **delete** Placeholdarr-owned Plex collections (in addition to keep as-is or empty). Collection Sets delete the child collections they manage. Unlabeled same-title shelves are left alone.
 
 ### Changed
 
-- **Add to Radarr/Sonarr**: Import chunks of 20. *arr often never returns `movie/import` / `series/import`, so Placeholdarr waits briefly then **polls the library** until titles appear. Already-in-*arr and reconciled titles still enqueue placeholder ingest.
+- **Add to Radarr/Sonarr**: Import chunks of 20. *arr often never returns `movie/import` / `series/import`, so Placeholdarr waits briefly then **polls the library** until titles appear.
+- **Placeholder ingest**: Already-in-*arr and reconciled titles still enqueue placeholder ingest.
 - **Add tags**: Tags are chips (Enter to add, spaces become dashes); a failed tag no longer aborts the add. API accepts `tags: string[]` (legacy `tag` still works).
 - **Webhook ingest**: Persist is serialized (`WEBHOOK_INGEST_CONCURRENCY`, default 1) so import-list `MovieAdded` floods cannot exhaust the DB pool.
 - **Collections missing list**: Preview and recipe list describe titles **missing from catalog**, not “not in Radarr/Sonarr” (the check is catalog membership).
 - **Sidebar**: New selected-tab and hover styling.
+- **Manual Run now (seasonal)**: Out-of-window Run now follows the same keep / empty / delete policy as scheduled sync instead of creating or filling the collection. Last run shows **Kept**, **Cleared**, or **Removed (out of window)**.
 
 ### Fixed
 

--- a/core/config.py
+++ b/core/config.py
@@ -419,6 +419,11 @@ class Settings(BaseSettings):
     WORKER_FALLBACK_POLL_SECONDS: int = int(
         os.getenv("WORKER_FALLBACK_POLL_SECONDS", "5").split('#')[0].strip() or "5"
     )
+    # Persist ARR/Tautulli webhooks serially (or with a small bound) so a
+    # MovieAdded flood from import lists cannot open one DB session per POST.
+    WEBHOOK_INGEST_CONCURRENCY: int = int(
+        os.getenv("WEBHOOK_INGEST_CONCURRENCY", "1").split('#')[0].strip() or "1"
+    )
 
     # ----------------------------------------------------------------
     # Database connection pool tuning. Phase 2 of the holistic NOTIFY

--- a/core/version.py
+++ b/core/version.py
@@ -3,4 +3,4 @@
 Keep this in sync with CHANGELOG.md when cutting a release.
 """
 
-APP_VERSION = "0.9.18"
+APP_VERSION = "0.9.19"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2152,26 +2152,16 @@ export function App() {
           </div>
 
           {/* Nav */}
-          <nav className="flex-1 space-y-1 font-brand-label pt-4 pb-6">
+          <nav className="flex-1 space-y-1.5 font-brand-label pt-4 pb-6">
             {(() => {
-              const navActiveClass =
-                "flex items-center w-full px-6 py-3 gap-4 font-brand-label text-[16px] uppercase tracking-widest transition-all duration-200 border-l-4";
+              const navItemBase =
+                "nav-item flex items-center w-full px-6 py-3 gap-4 font-brand-label text-[16px] uppercase tracking-widest transition-all duration-200";
               const navInactiveClass =
-                "flex items-center w-full px-6 py-3 gap-4 transition-all duration-200 font-brand-label text-[16px] uppercase tracking-widest group " +
+                `${navItemBase} group ` +
                 (isStudioGlass
                   ? "text-slate-400 hover:text-slate-100 hover:bg-[color:var(--brand-nav-hover)]"
                   : "text-slate-600 hover:text-slate-900 hover:bg-[color:var(--brand-nav-hover)]");
-              const navActiveStyle: CSSProperties = isStudioGlass
-                ? {
-                    backgroundColor: alphaColor(brandSemantic.accent, 0.22),
-                    color: brandSemantic.fg,
-                    borderLeftColor: brandSemantic.accent,
-                  }
-                : {
-                    backgroundColor: brandSemantic.fg,
-                    color: brandSemantic.accent,
-                    borderLeftColor: brandSemantic.accent,
-                  };
+              const navActiveClass = `${navItemBase} nav-sel-pill`;
               const librarySectionActive = isActive("/library");
               const moviesSubActive =
                 location.pathname === LIBRARY_MOVIES_PATH ||
@@ -2190,7 +2180,7 @@ export function App() {
               return (
                 <>
                   {librarySectionActive ? (
-                    <button type="button" onClick={() => tryNavigate(LIBRARY_MOVIES_PATH)} className={navActiveClass} style={navActiveStyle}>
+                    <button type="button" onClick={() => tryNavigate(LIBRARY_MOVIES_PATH)} className={navActiveClass}>
                       <span className="material-symbols-outlined">movie_filter</span>
                       <span>Library</span>
                     </button>
@@ -2226,7 +2216,7 @@ export function App() {
                   ) : null}
 
                   {isActive("/activity") ? (
-                    <button type="button" onClick={() => tryNavigate(ACTIVITY_DEFAULT_PATH)} className={navActiveClass} style={navActiveStyle}>
+                    <button type="button" onClick={() => tryNavigate(ACTIVITY_DEFAULT_PATH)} className={navActiveClass}>
                       <span className="material-symbols-outlined">analytics</span>
                       <span>Activity</span>
                     </button>
@@ -2271,7 +2261,7 @@ export function App() {
                     { icon: "settings", label: "Settings", path: "/settings", beta: false },
                   ].map(({ icon, label, path, beta }) =>
                     isActive(path) ? (
-                      <button key={path} type="button" onClick={() => tryNavigate(path === "/settings" ? firstSettingsPath : path)} className={navActiveClass} style={navActiveStyle}>
+                      <button key={path} type="button" onClick={() => tryNavigate(path === "/settings" ? firstSettingsPath : path)} className={navActiveClass}>
                         <span className="material-symbols-outlined">{icon}</span>
                         <span className="flex items-center gap-1.5">
                           <span>{label}</span>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -95,3 +95,63 @@ export async function postJson<T>(path: string, body?: unknown): Promise<T> {
     body: body === undefined ? undefined : JSON.stringify(body),
   });
 }
+
+export async function postNdjson(
+  path: string,
+  body: unknown,
+  onEvent: (event: Record<string, unknown>) => void,
+): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: mergeHeaders({
+        method: "POST",
+        headers: {
+          Accept: "application/x-ndjson",
+          "Content-Type": "application/json",
+        },
+      }),
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw humanizeFetchFailure(err);
+  }
+
+  if (response.status === 401) {
+    unauthorizedHandler?.();
+    const message = await parseErrorMessage(response, "authentication required");
+    throw new ApiUnauthorizedError(message);
+  }
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response, `Request failed: ${response.status}`);
+    throw new Error(message);
+  }
+
+  if (!response.body) {
+    throw new Error("Add progress stream was empty");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (value) buffer += decoder.decode(value, { stream: !done });
+    if (done) buffer += decoder.decode();
+    const lines = buffer.split("\n");
+    buffer = done ? "" : (lines.pop() ?? "");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        onEvent(JSON.parse(trimmed) as Record<string, unknown>);
+      } catch {
+        // ignore a partial/corrupt line; the next chunk may complete it
+      }
+    }
+    if (done) break;
+  }
+}

--- a/frontend/src/api/collections.ts
+++ b/frontend/src/api/collections.ts
@@ -1,9 +1,8 @@
-import { fetchJson, postJson } from "./client";
+import { fetchJson, postJson, postNdjson } from "./client";
 import type {
   CollectionActiveWindow,
   CollectionArrAddItem,
   CollectionArrAddOptionsResponse,
-  CollectionArrAddResponse,
   CollectionBuilderMeta,
   CollectionDefinition,
   CollectionExplainResponse,
@@ -17,6 +16,14 @@ import type {
 
 /** Must match `ARR_ADD_BATCH_CAP` in `routes/collections.py`. */
 export const ARR_ADD_BATCH_CAP = 100;
+
+export function normalizeArrTagLabel(label: string): string {
+  return label
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
 export interface RecipeWritePayload {
   name: string;
@@ -118,16 +125,43 @@ export function getCollectionArrAddOptions(mediaType: "movie" | "show"): Promise
   return fetchJson(`/api/collections/arr-add-options?${params.toString()}`);
 }
 
-export function addCollectionTitlesToArr(payload: {
-  media_type: "movie" | "show";
-  items: CollectionArrAddItem[];
-  instance_keys: string[];
-  instance_options: Record<string, { quality_profile_id: number; root_folder_path: string }>;
-  monitored: boolean;
-  search: boolean;
-  tag: string;
-}): Promise<CollectionArrAddResponse> {
-  return postJson("/api/collections/arr-add", payload);
+export function arrAddItemKey(
+  instanceKey: string,
+  item: { title?: string; year?: number | null; tmdb_id?: number | null; tvdb_id?: number | null; imdb_id?: string | null },
+): string {
+  return `${instanceKey}:${item.tmdb_id ?? ""}:${item.tvdb_id ?? ""}:${item.imdb_id ?? ""}:${item.title ?? ""}:${item.year ?? ""}`;
+}
+
+export type ArrAddStreamEvent = {
+  type: string;
+  item_key?: string;
+  title?: string;
+  instance_key?: string;
+  status?: "adding" | "ok" | "skipped" | "error";
+  error?: string | null;
+  message?: string;
+  ok?: boolean;
+  added?: number;
+  skipped?: number;
+  errors?: number;
+  warnings?: string[];
+};
+
+export function addCollectionTitlesToArr(
+  payload: {
+    media_type: "movie" | "show";
+    items: CollectionArrAddItem[];
+    instance_keys: string[];
+    instance_options: Record<string, { quality_profile_id: number; root_folder_path: string }>;
+    monitored: boolean;
+    search: boolean;
+    tags: string[];
+  },
+  onEvent: (event: ArrAddStreamEvent) => void,
+): Promise<void> {
+  return postNdjson("/api/collections/arr-add", payload, (raw) => {
+    onEvent(raw as ArrAddStreamEvent);
+  });
 }
 
 export type CollectionSourceValidation = {

--- a/frontend/src/brandSemanticTheme.ts
+++ b/frontend/src/brandSemanticTheme.ts
@@ -180,7 +180,7 @@ export function getBrandSemanticTokens(brand: Brand, mode: ThemeMode, accent: Ac
       chromeSidebar: "#D8E8F6",
       chromeHeader: "#EEF6FC",
       chromeMain: "#EEF5FB",
-      navHover: "#C9E8F5",
+      navHover: "#FDE68A",
       topBarBand: "#FDE047",
     };
   }

--- a/frontend/src/collections/ArrAddModal.tsx
+++ b/frontend/src/collections/ArrAddModal.tsx
@@ -1,13 +1,74 @@
-import { useEffect, useMemo, useState } from "react";
-import { addCollectionTitlesToArr, getCollectionArrAddOptions } from "../api/collections";
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  addCollectionTitlesToArr,
+  arrAddItemKey,
+  getCollectionArrAddOptions,
+  normalizeArrTagLabel,
+} from "../api/collections";
 import { ToggleSwitch } from "../ToggleSwitch";
 import { useCollectionTheme } from "./collectionTheme";
 import type {
   CollectionArrAddItem,
   CollectionArrAddInstanceOptions,
-  CollectionArrAddResponse,
   CollectionMissingFromArrItem,
 } from "../types/api";
+
+function seedTags(defaultTag: string): string[] {
+  const seed = normalizeArrTagLabel(defaultTag || "placeholdarr");
+  return seed ? [seed] : [];
+}
+
+function displayTitle(item: CollectionMissingFromArrItem): string {
+  return item.year ? `${item.title} (${item.year})` : item.title;
+}
+
+type ProgressStatus = "waiting" | "adding" | "ok" | "skipped" | "error";
+
+type ProgressRow = {
+  key: string;
+  title: string;
+  instanceKey: string;
+  instanceLabel: string;
+  status: ProgressStatus;
+  error?: string | null;
+};
+
+function StatusMark(props: { status: ProgressStatus; arrLabel: string; error?: string | null }) {
+  if (props.status === "ok") {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-400">
+        <span className="material-symbols-outlined" style={{ fontSize: 18 }}>
+          check_circle
+        </span>
+        Added
+      </span>
+    );
+  }
+  if (props.status === "skipped") {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-400">
+        <span className="material-symbols-outlined" style={{ fontSize: 18 }}>
+          check_circle
+        </span>
+        Already in {props.arrLabel}
+      </span>
+    );
+  }
+  if (props.status === "error") {
+    return (
+      <span className="inline-flex max-w-[16rem] items-start gap-1 text-red-400">
+        <span className="material-symbols-outlined shrink-0" style={{ fontSize: 18 }}>
+          cancel
+        </span>
+        <span className="text-right leading-snug">{props.error || "Error"}</span>
+      </span>
+    );
+  }
+  if (props.status === "adding") {
+    return <span className="text-slate-400">Adding…</span>;
+  }
+  return <span className="text-slate-500">Waiting…</span>;
+}
 
 export function ArrAddModal(props: {
   mediaType: "movie" | "show";
@@ -26,9 +87,22 @@ export function ArrAddModal(props: {
   const [roots, setRoots] = useState<Record<string, string>>({});
   const [monitored, setMonitored] = useState(true);
   const [search, setSearch] = useState(false);
-  const [tag, setTag] = useState(props.defaultTag || "placeholdarr");
+  const [tags, setTags] = useState<string[]>(() => seedTags(props.defaultTag));
+  const [tagDraft, setTagDraft] = useState("");
+  const tagsRef = useRef(tags);
+  const draftRef = useRef(tagDraft);
+  tagsRef.current = tags;
+  draftRef.current = tagDraft;
   const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<CollectionArrAddResponse | null>(null);
+  const [progressRows, setProgressRows] = useState<ProgressRow[] | null>(null);
+  const [progressSummary, setProgressSummary] = useState<{
+    added: number;
+    skipped: number;
+    errors: number;
+    message: string;
+    warnings: string[];
+    done: boolean;
+  } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -66,12 +140,45 @@ export function ArrAddModal(props: {
     return selectedKeys.every((key) => profiles[key] && roots[key]);
   }, [selectedKeys, profiles, roots, submitting]);
 
+  const normalizedDraft = normalizeArrTagLabel(tagDraft);
+  const draftPreview =
+    tagDraft.trim() && normalizedDraft && normalizedDraft !== tagDraft.trim() ? normalizedDraft : null;
+
+  const commitDraft = () => {
+    const label = normalizeArrTagLabel(draftRef.current);
+    if (!label) {
+      setTagDraft("");
+      draftRef.current = "";
+      return;
+    }
+    setTags((prev) => {
+      const next = prev.some((item) => item.toLowerCase() === label.toLowerCase()) ? prev : [...prev, label];
+      tagsRef.current = next;
+      return next;
+    });
+    setTagDraft("");
+    draftRef.current = "";
+  };
+
+  const onTagKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitDraft();
+      return;
+    }
+    if (event.key === "Backspace" && !tagDraft) {
+      event.preventDefault();
+      setTags((prev) => prev.slice(0, -1));
+    }
+  };
+
   const toggleInstance = (key: string) => {
     setSelectedKeys((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
   };
 
   const submit = async () => {
     if (!canSubmit) return;
+    commitDraft();
     setSubmitting(true);
     setError(null);
     const items: CollectionArrAddItem[] = props.items.map((item) => ({
@@ -88,21 +195,100 @@ export function ArrAddModal(props: {
         root_folder_path: roots[key],
       };
     }
+    const extra = normalizeArrTagLabel(draftRef.current);
+    const committedTags = [...tagsRef.current];
+    if (extra && !committedTags.some((item) => item.toLowerCase() === extra.toLowerCase())) {
+      committedTags.push(extra);
+    }
+    const instanceLabels = new Map(instances.map((row) => [row.instance_key, row.label || row.instance_key]));
+    const rows: ProgressRow[] = [];
+    for (const key of selectedKeys) {
+      for (const item of props.items) {
+        rows.push({
+          key: arrAddItemKey(key, item),
+          title: displayTitle(item),
+          instanceKey: key,
+          instanceLabel: instanceLabels.get(key) || key,
+          status: "waiting",
+        });
+      }
+    }
+    setProgressRows(rows);
+    setProgressSummary(null);
+    const patchRow = (itemKey: string, patch: Partial<ProgressRow>) => {
+      setProgressRows((prev) =>
+        (prev || []).map((row) => (row.key === itemKey ? { ...row, ...patch } : row)),
+      );
+    };
     try {
-      const response = await addCollectionTitlesToArr({
-        media_type: props.mediaType,
-        items,
-        instance_keys: selectedKeys,
-        instance_options,
-        monitored,
-        search,
-        tag: tag.trim(),
-      });
-      setResult(response);
+      await addCollectionTitlesToArr(
+        {
+          media_type: props.mediaType,
+          items,
+          instance_keys: selectedKeys,
+          instance_options,
+          monitored,
+          search,
+          tags: committedTags,
+        },
+        (event) => {
+          if (event.type === "ping") return;
+          if (event.type === "warning" && event.message) {
+            setProgressSummary((prev) => ({
+              added: prev?.added ?? 0,
+              skipped: prev?.skipped ?? 0,
+              errors: prev?.errors ?? 0,
+              message: prev?.message ?? "",
+              warnings: [...(prev?.warnings || []), event.message as string],
+              done: prev?.done ?? false,
+            }));
+            return;
+          }
+          if (event.type === "fatal") {
+            setError(event.message || "Add failed");
+            setProgressRows((prev) =>
+              (prev || []).map((row) =>
+                row.status === "waiting" || row.status === "adding"
+                  ? { ...row, status: "error", error: event.message || "Add failed" }
+                  : row,
+              ),
+            );
+            return;
+          }
+          if (event.type === "item" && event.item_key) {
+            const status = (event.status || "adding") as ProgressStatus;
+            patchRow(event.item_key, {
+              status,
+              ...(event.title ? { title: event.title } : {}),
+              error: event.error,
+            });
+            return;
+          }
+          if (event.type === "done") {
+            setProgressSummary((prev) => ({
+              added: event.added ?? 0,
+              skipped: event.skipped ?? 0,
+              errors: event.errors ?? 0,
+              message: event.message || prev?.message || "",
+              warnings: event.warnings || prev?.warnings || [],
+              done: true,
+            }));
+          }
+        },
+      );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Add failed");
+      const message = err instanceof Error ? err.message : "Add failed";
+      setError(message);
+      setProgressRows((prev) =>
+        (prev || []).map((row) =>
+          row.status === "waiting" || row.status === "adding"
+            ? { ...row, status: "error", error: message }
+            : row,
+        ),
+      );
     } finally {
       setSubmitting(false);
+      setProgressSummary((prev) => (prev ? { ...prev, done: true } : prev));
     }
   };
 
@@ -111,7 +297,7 @@ export function ArrAddModal(props: {
       <div
         role="dialog"
         aria-modal="true"
-        className={`w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl border p-4 ${theme.blockCard}`}
+        className={`w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-xl border p-4 ${theme.blockCard}`}
       >
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -129,7 +315,7 @@ export function ArrAddModal(props: {
         {loading ? <p className={`mt-4 ${theme.muted}`}>Loading instance options…</p> : null}
         {error ? <p className="mt-3 text-[13px] text-red-300">{error}</p> : null}
 
-        {!loading && !result ? (
+        {!loading && !progressRows ? (
           <div className="mt-4 flex flex-col gap-4">
             <div>
               <div className={`${theme.sectionLabel} mb-2`}>Instances</div>
@@ -225,10 +411,40 @@ export function ArrAddModal(props: {
                 ariaLabel="Search right away"
               />
             </label>
-            <label className={`flex flex-col gap-1 ${theme.label}`}>
-              Tag
-              <input className={theme.field} value={tag} onChange={(event) => setTag(event.target.value)} />
-            </label>
+            <div className={`flex flex-col gap-1 ${theme.label}`}>
+              Tags
+              <div className={`${theme.field} flex min-h-[2.25rem] flex-wrap items-center gap-1.5`}>
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center gap-1 rounded-md border border-current/20 bg-black/10 px-1.5 py-0.5 text-[12px]"
+                  >
+                    {tag}
+                    <button
+                      type="button"
+                      className="leading-none opacity-70 hover:opacity-100"
+                      aria-label={`Remove tag ${tag}`}
+                      onClick={() => setTags((prev) => prev.filter((item) => item !== tag))}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+                <input
+                  className="min-w-[8rem] flex-1 bg-transparent outline-none"
+                  value={tagDraft}
+                  placeholder={tags.length ? "Add another, then Enter" : "Type a tag and press Enter"}
+                  onChange={(event) => setTagDraft(event.target.value)}
+                  onKeyDown={onTagKeyDown}
+                  onBlur={commitDraft}
+                />
+              </div>
+              {draftPreview ? (
+                <span className={theme.muted}>Saved as {draftPreview} (spaces become dashes)</span>
+              ) : (
+                <span className={theme.muted}>Press Enter to add a tag. Spaces become dashes, like in {arrLabel}.</span>
+              )}
+            </div>
 
             <button
               type="button"
@@ -237,29 +453,48 @@ export function ArrAddModal(props: {
               className="rounded-lg px-5 py-2 text-[14px] font-headline uppercase tracking-wider text-[#0a0e14] transition-opacity disabled:opacity-40"
               style={{ backgroundColor: props.accentHex }}
             >
-              {submitting ? "Adding…" : `Add to ${arrLabel}`}
+              {`Add to ${arrLabel}`}
             </button>
           </div>
         ) : null}
 
-        {result ? (
-          <div className="mt-4 flex flex-col gap-2">
-            <p className={theme.muted}>{result.message}</p>
-            <p className={theme.label}>
-              Added {result.added}, skipped {result.skipped}, errors {result.errors}
+        {progressRows ? (
+          <div className="mt-4 flex flex-col gap-3">
+            <p className={theme.muted}>
+              {progressSummary?.done
+                ? progressSummary.message
+                : `Adding to ${arrLabel}. Status updates as each title lands in the library.`}
             </p>
-            {result.results.some((row) => row.status === "error") ? (
-              <ul className={`max-h-40 overflow-y-auto text-[12px] ${theme.muted}`}>
-                {result.results
-                  .filter((row) => row.status === "error")
-                  .slice(0, 20)
-                  .map((row, idx) => (
-                    <li key={`${row.title}-${idx}`}>
-                      {row.title}: {row.error}
-                    </li>
-                  ))}
+            <p className={theme.label}>
+              {progressRows.filter((row) => row.status === "ok").length} added
+              {" · "}
+              {progressRows.filter((row) => row.status === "skipped").length} already in {arrLabel}
+              {" · "}
+              {progressRows.filter((row) => row.status === "error").length} errors
+              {!progressSummary?.done
+                ? ` · ${progressRows.filter((row) => row.status === "adding" || row.status === "waiting").length} remaining`
+                : ""}
+            </p>
+            {progressSummary?.warnings.length ? (
+              <ul className={`text-[12px] ${theme.muted}`}>
+                {progressSummary.warnings.map((warning, idx) => (
+                  <li key={`${warning}-${idx}`}>{warning}</li>
+                ))}
               </ul>
             ) : null}
+            <ul className="max-h-[50vh] divide-y divide-white/10 overflow-y-auto">
+              {progressRows.map((row) => (
+                <li key={row.key} className="flex items-start justify-between gap-3 py-2 text-[13px]">
+                  <span className={theme.label}>
+                    {row.title}
+                    {selectedKeys.length > 1 ? (
+                      <span className={`ml-2 ${theme.muted}`}>{row.instanceLabel}</span>
+                    ) : null}
+                  </span>
+                  <StatusMark status={row.status} arrLabel={arrLabel} error={row.error} />
+                </li>
+              ))}
+            </ul>
           </div>
         ) : null}
       </div>

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -2613,14 +2613,30 @@ export function CollectionEditor(props: {
                     value={activeWindow.when_inactive}
                     onChange={(e) =>
                       setActiveWindow((prev) =>
-                        prev ? { ...prev, when_inactive: e.target.value as "keep" | "clear" } : prev,
+                        prev
+                          ? {
+                              ...prev,
+                              when_inactive:
+                                e.target.value === "delete"
+                                  ? "delete"
+                                  : e.target.value === "clear"
+                                    ? "clear"
+                                    : "keep",
+                            }
+                          : prev,
                       )
                     }
                   >
                     <option value="keep">Keep collection as-is</option>
                     <option value="clear">Empty the collection</option>
+                    <option value="delete">Delete the collection</option>
                   </select>
                 </label>
+                {activeWindow.when_inactive === "delete" ? (
+                  <span className={`text-[12px] font-normal normal-case tracking-normal ${theme.muted}`}>
+                    Only collections Placeholdarr owns are deleted.
+                  </span>
+                ) : null}
               </>
             ) : null}
           </div>
@@ -2989,7 +3005,12 @@ export function CollectionEditor(props: {
                         splitMonthDay(activeWindow.end).month,
                         splitMonthDay(activeWindow.end).day,
                       ),
-                      when_inactive: activeWindow.when_inactive === "clear" ? "clear" : "keep",
+                      when_inactive:
+                        activeWindow.when_inactive === "delete"
+                          ? "delete"
+                          : activeWindow.when_inactive === "clear"
+                            ? "clear"
+                            : "keep",
                     }
                   : null,
               });

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -2402,7 +2402,7 @@ export function CollectionEditor(props: {
   const previewStages: { label: string; value: number | null | undefined }[] = [
     { label: "List candidates", value: preview?.tmdb_candidates },
     { label: "Matched in catalog", value: preview?.matched_in_catalog },
-    ...(showMissingPane ? [{ label: "Missing from ARR", value: missingCount }] : []),
+    ...(showMissingPane ? [{ label: "Missing from catalog", value: missingCount }] : []),
     { label: "After filters", value: preview?.after_filters },
     ...(preview?.pinned_out ? [{ label: "Pinned out", value: preview.pinned_out }] : []),
     ...(preview?.pinned_in ? [{ label: "Pinned in", value: preview.pinned_in }] : []),
@@ -3217,7 +3217,7 @@ export function CollectionEditor(props: {
                           }`}
                           style={previewPane === "missing" ? { backgroundColor: accentHex, borderColor: accentHex } : undefined}
                         >
-                          Missing from ARR ({missingCount})
+                          Missing from catalog ({missingCount})
                         </button>
                       </div>
                     ) : (

--- a/frontend/src/collections/CollectionSetEditor.tsx
+++ b/frontend/src/collections/CollectionSetEditor.tsx
@@ -575,14 +575,25 @@ export function CollectionSetEditor(props: {
                   onChange={(e) =>
                     setActiveWindow({
                       ...activeWindow,
-                      when_inactive: e.target.value === "clear" ? "clear" : "keep",
+                      when_inactive:
+                        e.target.value === "delete"
+                          ? "delete"
+                          : e.target.value === "clear"
+                            ? "clear"
+                            : "keep",
                     })
                   }
                 >
-                  <option value="keep">Keep membership</option>
-                  <option value="clear">Clear membership</option>
+                  <option value="keep">Keep collection as-is</option>
+                  <option value="clear">Empty the collection</option>
+                  <option value="delete">Delete the collection</option>
                 </select>
               </label>
+              {activeWindow.when_inactive === "delete" ? (
+                <span className={`text-[12px] font-normal normal-case tracking-normal ${theme.muted}`}>
+                  Only collections Placeholdarr owns are deleted.
+                </span>
+              ) : null}
             </>
           ) : null}
         </div>

--- a/frontend/src/collections/CollectionsPanel.tsx
+++ b/frontend/src/collections/CollectionsPanel.tsx
@@ -770,6 +770,10 @@ export function CollectionsPanel(props: {
                           </>
                         ) : summary.status === "cleared" ? (
                           <span className={`text-[12px] ${theme.muted}`}>Cleared (out of window)</span>
+                        ) : summary.status === "removed" ? (
+                          <span className={`text-[12px] ${theme.muted}`}>Removed (out of window)</span>
+                        ) : summary.status === "dormant" ? (
+                          <span className={`text-[12px] ${theme.muted}`}>Kept (out of window)</span>
                         ) : (
                           <span className="text-[12px] text-red-400" title={summary.error}>
                             Failed

--- a/frontend/src/collections/CollectionsPanel.tsx
+++ b/frontend/src/collections/CollectionsPanel.tsx
@@ -759,10 +759,9 @@ export function CollectionsPanel(props: {
                             {(summary.missing_from_arr_count ?? 0) > 0 ? (
                               <span
                                 className={`block text-[12px] ${theme.muted}`}
-                                title={`Source list titles not in ${recipe.plex_section_type === "show" ? "Sonarr" : "Radarr"} (last run). +N are titles that were not in that set last time.`}
+                                title={`Source list titles not in the Placeholdarr catalog (last run). +N are titles that were not in that set last time.`}
                               >
-                                {summary.missing_from_arr_count} not in{" "}
-                                {recipe.plex_section_type === "show" ? "Sonarr" : "Radarr"}
+                                {summary.missing_from_arr_count} not in catalog
                                 {summary.missing_from_arr_new != null && summary.missing_from_arr_new > 0
                                   ? ` · +${summary.missing_from_arr_new} new`
                                   : ""}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -896,6 +896,44 @@ a { color: inherit; }
   color: #4f7ef7;
 }
 
+/* Sidebar nav: inset pill selected state */
+.brand-theme-scope .nav-item {
+  width: calc(100% - 16px);
+  margin-left: 8px;
+  margin-right: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 12px;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.brand-theme-scope .nav-sel-pill {
+  background-color: color-mix(in srgb, var(--brand-accent) 26%, transparent);
+  color: var(--brand-accent-2);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--brand-accent) 55%, transparent);
+}
+.brand-theme-scope .nav-sel-pill .material-symbols-outlined {
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+  color: inherit;
+}
+
+/* Light mode: navy fill, mid-blue hairline, ice type */
+.brand-theme-scope.theme-light .nav-sel-pill {
+  background-color: var(--brand-fg);
+  color: #7dd3fc;
+  box-shadow: inset 0 0 0 1px var(--brand-fg-label);
+}
+.brand-theme-scope.theme-light .nav-sel-pill .material-symbols-outlined {
+  color: #7dd3fc;
+}
+
+.brand-theme-scope.theme-light .nav-item:not(.nav-sel-pill):hover {
+  background-color: color-mix(in srgb, var(--brand-accent) 42%, #ffffff);
+  color: var(--brand-fg);
+}
+
 /* Sidebar footer */
 .studio-sidebar-footer {
   padding: 20px 24px 24px;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -661,11 +661,12 @@ export interface CollectionDefinition {
 }
 
 export interface CollectionRunSummary {
-  status: "ok" | "error" | "cleared" | "skipped" | "dormant";
+  status: "ok" | "error" | "cleared" | "removed" | "skipped" | "dormant";
   mode?: "collection_set" | string;
   error?: string;
   reason?: string;
   window_cleared?: boolean;
+  when_inactive_applied?: "keep" | "clear" | "delete";
   pinned_in?: number;
   pinned_out?: number;
   tmdb_candidates?: number | null;
@@ -709,7 +710,7 @@ export interface CollectionActiveWindow {
   /** MM-DD, annually recurring; wrap-around (start > end) spans the new year. */
   start: string;
   end: string;
-  when_inactive: "keep" | "clear";
+  when_inactive: "keep" | "clear" | "delete";
 }
 
 export interface CollectionRecipe {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -903,5 +903,6 @@ export interface CollectionArrAddResponse {
   skipped: number;
   errors: number;
   results: CollectionArrAddResult[];
+  warnings?: string[];
   message: string;
 }

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ import contextvars  # noqa: F401
 import asyncio.coroutines  # noqa: F401
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Request, BackgroundTasks, HTTPException
+from fastapi import FastAPI, Request, HTTPException
 from core.logger import logger
 from core.config import settings
 from services.postgres.utils import check_db
@@ -569,7 +569,7 @@ app.add_middleware(
 )
 
 @app.post("/webhook")
-async def webhook(request: Request, background_tasks: BackgroundTasks):
+async def webhook(request: Request):
     try:
         from services.auth import get_auth_mode, verify_webhook_api_key
 
@@ -605,7 +605,6 @@ async def webhook(request: Request, background_tasks: BackgroundTasks):
 
         try:
             from services.handlers import (
-                handle_webhook as new_handle,
                 resolve_canonical_webhook_instance,
                 validate_webhook_payload,
             )
@@ -625,7 +624,9 @@ async def webhook(request: Request, background_tasks: BackgroundTasks):
             )
             raise HTTPException(status_code=400, detail=reason)
 
-        background_tasks.add_task(new_handle, payload, canonical_instance)
+        from services.webhook_ingest import enqueue_webhook_persist
+
+        enqueue_webhook_persist(payload, canonical_instance)
         return {"status": "accepted"}
     except HTTPException:
         raise

--- a/routes/collections.py
+++ b/routes/collections.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import queue
 import threading
 import time
 from datetime import datetime, timezone
@@ -9,8 +11,10 @@ from typing import Any
 
 import requests
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import text
+from starlette.concurrency import iterate_in_threadpool
 
 from core.config import settings
 from core.logger import logger
@@ -579,7 +583,8 @@ class ArrAddPayload(BaseModel):
     instance_options: dict[str, ArrAddInstanceOptions]
     monitored: bool = True
     search: bool = False
-    tag: str = "placeholdarr"
+    tag: str = ""
+    tags: list[str] = []
 
 
 # Keep in sync with `ARR_ADD_BATCH_CAP` in frontend/src/api/collections.ts
@@ -615,17 +620,81 @@ async def arr_add(body: ArrAddPayload):
     if not keys:
         raise HTTPException(status_code=400, detail="Select at least one ARR instance")
 
+    def ndjson_iter():
+        events: queue.Queue = queue.Queue()
+        sentinel = object()
+
+        def on_progress(event: dict[str, Any]) -> None:
+            events.put(event)
+
+        def run() -> None:
+            try:
+                _run_arr_add(body, keys, on_progress)
+            except Exception as exc:
+                logger.error(f"ARR add stream failed: {exc}", extra={"emoji_type": "error"})
+                events.put({"type": "fatal", "message": str(exc)})
+            finally:
+                events.put(sentinel)
+
+        threading.Thread(target=run, name="collections-arr-add", daemon=True).start()
+        while True:
+            try:
+                event = events.get(timeout=2.0)
+            except queue.Empty:
+                yield json.dumps({"type": "ping"}) + "\n"
+                continue
+            if event is sentinel:
+                break
+            yield json.dumps(event, ensure_ascii=False) + "\n"
+
+    return StreamingResponse(
+        iterate_in_threadpool(ndjson_iter()),
+        media_type="application/x-ndjson",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+def _run_arr_add(body: ArrAddPayload, keys: list[str], on_progress) -> None:
+    from services.source_of_truth import arr_api
+
     arr_type = "radarr" if body.media_type == "movie" else "sonarr"
     results: list[dict[str, Any]] = []
-    tag_label = str(body.tag or "").strip()
+    warnings: list[str] = []
+    tag_labels: list[str] = []
+    seen_tags: set[str] = set()
+    for raw in list(body.tags or []):
+        label = arr_api.normalize_arr_tag_label(str(raw))
+        key = label.lower()
+        if not label or key in seen_tags:
+            continue
+        seen_tags.add(key)
+        tag_labels.append(label)
+    if not tag_labels and str(body.tag or "").strip():
+        label = arr_api.normalize_arr_tag_label(body.tag)
+        if label:
+            tag_labels.append(label)
 
     for key in keys:
         instance = settings.resolve_arr_instance(arr_type, instance_key=key)
         if not instance:
             for item in body.items:
+                title = item.title or "Untitled"
+                on_progress(
+                    {
+                        "type": "item",
+                        "item_key": arr_api._arr_add_item_key(item, key),
+                        "title": title,
+                        "instance_key": key,
+                        "status": "error",
+                        "error": f"Unknown {arr_type} instance {key!r}",
+                    }
+                )
                 results.append(
                     {
-                        "title": item.title,
+                        "title": title,
                         "instance_key": key,
                         "status": "error",
                         "error": f"Unknown {arr_type} instance {key!r}",
@@ -635,9 +704,20 @@ async def arr_add(body: ArrAddPayload):
         opts = body.instance_options.get(key)
         if opts is None:
             for item in body.items:
+                title = item.title or "Untitled"
+                on_progress(
+                    {
+                        "type": "item",
+                        "item_key": arr_api._arr_add_item_key(item, key),
+                        "title": title,
+                        "instance_key": key,
+                        "status": "error",
+                        "error": "Quality profile and root folder are required",
+                    }
+                )
                 results.append(
                     {
-                        "title": item.title,
+                        "title": title,
                         "instance_key": key,
                         "status": "error",
                         "error": "Quality profile and root folder are required",
@@ -647,20 +727,15 @@ async def arr_add(body: ArrAddPayload):
         url = str(instance.get("url") or "")
         api_key = str(instance.get("api_key") or "")
         tag_ids: list[int] = []
-        if tag_label:
-            tag_id = arr_api.ensure_arr_tag(url=url, api_key=api_key, label=tag_label)
+        for label in tag_labels:
+            tag_id = arr_api.ensure_arr_tag(url=url, api_key=api_key, label=label)
             if tag_id is None:
-                for item in body.items:
-                    results.append(
-                        {
-                            "title": item.title,
-                            "instance_key": key,
-                            "status": "error",
-                            "error": f"Could not create or find tag {tag_label!r}",
-                        }
-                    )
+                warning = f"Could not create or find tag {label!r} on {key}"
+                warnings.append(warning)
+                on_progress({"type": "warning", "message": warning})
                 continue
-            tag_ids = [tag_id]
+            if tag_id not in tag_ids:
+                tag_ids.append(tag_id)
         results.extend(
             arr_api.add_missing_titles(
                 media_type=body.media_type,
@@ -673,20 +748,24 @@ async def arr_add(body: ArrAddPayload):
                 search=body.search,
                 tag_ids=tag_ids,
                 instance_key=key,
+                on_progress=on_progress,
             )
         )
 
     ok = sum(1 for row in results if row.get("status") == "ok")
     skipped = sum(1 for row in results if row.get("status") == "skipped")
     errors = sum(1 for row in results if row.get("status") == "error")
-    return {
-        "ok": errors == 0,
-        "added": ok,
-        "skipped": skipped,
-        "errors": errors,
-        "results": results,
-        "message": "Titles are in ARR. Collection membership updates after sync and placeholders — not instantly in Plex.",
-    }
+    on_progress(
+        {
+            "type": "done",
+            "ok": errors == 0,
+            "added": ok,
+            "skipped": skipped,
+            "errors": errors,
+            "warnings": warnings,
+            "message": "Titles are in ARR. Collection membership updates after sync and placeholders — not instantly in Plex.",
+        }
+    )
 
 
 class ExplainPayload(BaseModel):

--- a/services/collections/engine.py
+++ b/services/collections/engine.py
@@ -2570,6 +2570,10 @@ def run_recipe(recipe_id: int) -> dict[str, Any]:
             if isinstance(recipe.plex_collection_keys, dict)
             else {}
         )
+        active_window = recipe.active_window if isinstance(recipe.active_window, dict) else None
+
+    if not window_is_active(active_window):
+        return _apply_inactive_window(recipe_id)
 
     summary: dict[str, Any]
     try:
@@ -2726,8 +2730,8 @@ def validate_active_window(window: Any) -> Optional[dict[str, Any]]:
             + ", ".join(bad)
         )
     when_inactive = str(window.get("when_inactive") or "keep")
-    if when_inactive not in ("keep", "clear"):
-        raise RecipeValidationError("active_window when_inactive must be 'keep' or 'clear'")
+    if when_inactive not in ("keep", "clear", "delete"):
+        raise RecipeValidationError("active_window when_inactive must be 'keep', 'clear', or 'delete'")
     return {
         "start": f"{start[0]:02d}-{start[1]:02d}",
         "end": f"{end[0]:02d}-{end[1]:02d}",
@@ -2751,6 +2755,66 @@ def window_is_active(window: Optional[dict[str, Any]], when: Optional[datetime] 
     if start <= end:
         return start <= today <= end
     return today >= start or today <= end
+
+
+def _inactive_action(window: Optional[dict[str, Any]]) -> str:
+    action = str((window or {}).get("when_inactive") or "keep")
+    return action if action in ("keep", "clear", "delete") else "keep"
+
+
+def _applied_inactive_action(summary: Optional[dict[str, Any]]) -> Optional[str]:
+    if not isinstance(summary, dict):
+        return None
+    applied = summary.get("when_inactive_applied")
+    if applied in ("keep", "clear", "delete"):
+        return applied
+    if summary.get("window_cleared") or summary.get("status") == "cleared":
+        return "clear"
+    if summary.get("status") == "removed":
+        return "delete"
+    if summary.get("status") == "dormant":
+        return "keep"
+    return None
+
+
+def _persist_inactive_summary(
+    recipe_id: int,
+    summary: dict[str, Any],
+    *,
+    keys_map: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    with session_scope() as session:
+        recipe = session.query(CollectionRecipe).filter(CollectionRecipe.id == recipe_id).first()
+        if recipe is not None:
+            recipe.last_run_at = datetime.now(timezone.utc)
+            recipe.last_run_summary = summary
+            if keys_map is not None and summary.get("status") in ("cleared", "removed"):
+                recipe.plex_collection_keys = keys_map
+            session.commit()
+    return summary
+
+
+def _apply_inactive_window(recipe_id: int) -> dict[str, Any]:
+    """Apply keep / clear / delete for a recipe that is outside its seasonal window."""
+    with session_scope() as session:
+        recipe = session.query(CollectionRecipe).filter(CollectionRecipe.id == recipe_id).first()
+        if recipe is None:
+            raise RecipeValidationError(f"collection recipe {recipe_id} not found")
+        window = recipe.active_window if isinstance(recipe.active_window, dict) else None
+        recipe_name = str(recipe.name)
+    action = _inactive_action(window)
+    if action == "clear":
+        return _clear_recipe_collection(recipe_id)
+    if action == "delete":
+        return _delete_recipe_collection(recipe_id)
+    logger.info(
+        f"Collections: recipe {recipe_name!r} is outside its active window — keeping collection as-is",
+        extra={"emoji_type": "info"},
+    )
+    return _persist_inactive_summary(
+        recipe_id,
+        {"status": "dormant", "when_inactive_applied": "keep"},
+    )
 
 
 def smallest_enabled_recipe_interval_hours() -> Optional[int]:
@@ -2834,6 +2898,7 @@ def _clear_recipe_collection(recipe_id: int) -> dict[str, Any]:
                 or {"added": 0, "removed": removed, "total": 0, "created": False},
                 "libraries": libraries,
                 "window_cleared": True,
+                "when_inactive_applied": "clear",
             }
         else:
             for sid in section_ids:
@@ -2859,6 +2924,7 @@ def _clear_recipe_collection(recipe_id: int) -> dict[str, Any]:
                 or {"added": 0, "removed": removed, "total": 0, "created": False},
                 "libraries": libraries,
                 "window_cleared": True,
+                "when_inactive_applied": "clear",
             }
         logger.info(
             f"Collections: recipe {recipe_name!r} left its active window — collection cleared "
@@ -2883,11 +2949,97 @@ def _clear_recipe_collection(recipe_id: int) -> dict[str, Any]:
     return summary
 
 
+def _delete_recipe_collection(recipe_id: int) -> dict[str, Any]:
+    """Delete Placeholdarr-owned Plex collections for a recipe leaving its window."""
+    with session_scope() as session:
+        recipe = session.query(CollectionRecipe).filter(CollectionRecipe.id == recipe_id).first()
+        if recipe is None:
+            raise RecipeValidationError(f"recipe {recipe_id} not found")
+        section_ids = recipe_section_ids(recipe)
+        section_type = str(recipe.plex_section_type)
+        collection_title = str(recipe.collection_title)
+        recipe_name = str(recipe.name)
+        definition = dict(recipe.definition or {})
+        previous_summary = recipe.last_run_summary if isinstance(recipe.last_run_summary, dict) else None
+        keys_map: dict[str, Any] = (
+            dict(recipe.plex_collection_keys)
+            if isinstance(recipe.plex_collection_keys, dict)
+            else {}
+        )
+
+    try:
+        libraries: list[dict[str, Any]] = []
+        deleted = 0
+        if sets_mod.is_collection_set_definition(definition):
+            set_cfg = (definition.get("collection_set") or {}) if isinstance(definition.get("collection_set"), dict) else {}
+            for sid in section_ids:
+                titles = sets_mod.previous_managed_titles(set_cfg, previous_summary, sid)
+                section_deleted = 0
+                for title in titles:
+                    known_key = plex_collections.lookup_stored_key(keys_map, sid, title)
+                    stats = plex_collections.delete_collection(
+                        sid,
+                        section_type,
+                        title,
+                        recipe_id=recipe_id,
+                        known_rating_key=known_key,
+                    )
+                    keys_map = plex_collections.set_stored_key(keys_map, sid, title, None)
+                    if stats.get("deleted"):
+                        section_deleted += 1
+                libraries.append({"plex_section_id": sid, "deleted_titles": titles, "deleted": section_deleted})
+                deleted += section_deleted
+            summary = {
+                "status": "removed",
+                "mode": "collection_set",
+                "libraries": libraries,
+                "deleted": deleted,
+                "when_inactive_applied": "delete",
+            }
+        else:
+            for sid in section_ids:
+                known_key = plex_collections.lookup_stored_key(keys_map, sid, collection_title)
+                stats = plex_collections.delete_collection(
+                    sid,
+                    section_type,
+                    collection_title,
+                    recipe_id=recipe_id,
+                    known_rating_key=known_key,
+                )
+                keys_map = plex_collections.set_stored_key(keys_map, sid, collection_title, None)
+                libraries.append({"plex_section_id": sid, "deleted": bool(stats.get("deleted"))})
+                if stats.get("deleted"):
+                    deleted += 1
+            summary = {
+                "status": "removed",
+                "libraries": libraries,
+                "deleted": deleted,
+                "when_inactive_applied": "delete",
+            }
+        logger.info(
+            f"Collections: recipe {recipe_name!r} left its active window — collection deleted "
+            f"(libraries={len(section_ids)}, deleted={deleted})",
+            extra={"emoji_type": "info"},
+        )
+    except plex_collections.PlexCollectionsError as exc:
+        summary = {"status": "error", "error": str(exc)}
+        logger.error(
+            f"Collections: failed to delete collection for dormant recipe {recipe_name!r}: {exc}",
+            extra={"emoji_type": "error"},
+        )
+
+    return _persist_inactive_summary(
+        recipe_id,
+        summary,
+        keys_map=keys_map if summary.get("status") == "removed" else None,
+    )
+
+
 def run_all_enabled_recipes(*, force: bool = False, default_interval_hours: int = 24) -> dict[str, Any]:
     """Run enabled recipes that are due and inside their active window.
 
     `force=True` (manual task trigger) ignores due-ness but still respects
-    seasonal windows; dormant recipes are skipped (cleared once if configured).
+    seasonal windows; dormant recipes apply keep/clear/delete once per policy.
     """
     now = datetime.now(timezone.utc)
     with session_scope() as session:
@@ -2918,20 +3070,20 @@ def run_all_enabled_recipes(*, force: bool = False, default_interval_hours: int 
         window = row["active_window"] if isinstance(row["active_window"], dict) else None
 
         if not window_is_active(window, now):
-            if (
-                window
-                and window.get("when_inactive") == "clear"
-                and not (row["last_run_summary"] or {}).get("window_cleared")
-            ):
-                summary = _clear_recipe_collection(recipe_id)
+            action = _inactive_action(window)
+            applied = _applied_inactive_action(
+                row["last_run_summary"] if isinstance(row["last_run_summary"], dict) else None
+            )
+            if action == "keep" or applied == action:
+                results["recipes"][str(recipe_id)] = {"status": "dormant"}
+                results["dormant"] += 1
+            else:
+                summary = _apply_inactive_window(recipe_id)
                 results["recipes"][str(recipe_id)] = summary
                 if summary.get("status") == "error":
                     results["failed"] += 1
                 else:
                     results["dormant"] += 1
-            else:
-                results["recipes"][str(recipe_id)] = {"status": "dormant"}
-                results["dormant"] += 1
             continue
 
         interval = int(row["run_interval_hours"] or default_interval_hours or 24)

--- a/services/handlers.py
+++ b/services/handlers.py
@@ -295,6 +295,51 @@ def handle_webhook(
         session.close()
 
 
+def enqueue_synthetic_arr_adds(
+    *,
+    instance_key: str,
+    movie: bool,
+    lookups: list[Dict[str, Any]],
+) -> int:
+    """Enqueue MovieAdded/SeriesAdd-equivalent jobs for titles already in *arr.
+
+    Used after Collections add (including skipped / timeout-reconciled titles)
+    so placeholders are created even when *arr does not fire a webhook.
+    """
+    queued = 0
+    key = str(instance_key or "").strip().lower()
+    if not key or not lookups:
+        return 0
+    for lookup in lookups:
+        if not isinstance(lookup, dict):
+            continue
+        try:
+            arr_id = int(lookup.get("id") or 0)
+        except (TypeError, ValueError):
+            arr_id = 0
+        if arr_id <= 0:
+            continue
+        payload: Dict[str, Any] = (
+            {"eventType": "MovieAdded", "movie": {"id": arr_id}}
+            if movie
+            else {"eventType": "SeriesAdd", "series": {"id": arr_id}}
+        )
+        try:
+            handle_webhook(payload, instance=key)
+            queued += 1
+        except Exception as exc:
+            logger.warning(
+                f"Failed to enqueue synthetic ARR add ingest instance={key} arr_id={arr_id}: {exc}",
+                extra={"emoji_type": "warning"},
+            )
+    if queued:
+        logger.info(
+            f"Enqueued {queued} synthetic {'movie' if movie else 'series'} add ingest job(s) instance={key}",
+            extra={"emoji_type": "info"},
+        )
+    return queued
+
+
 def handle_event(event: Dict[str, Any]) -> bool:
     """Compatibility entrypoint used by some scripts/tests."""
     instance = None

--- a/services/list_sources.py
+++ b/services/list_sources.py
@@ -179,7 +179,8 @@ def fetch_mdblist(reference: str, media_type: str, limit: int = 200) -> list[dic
             continue
         imdb_id = raw.get("imdb_id") or None
         tvdb_id = raw.get("tvdbid") or raw.get("tvdb_id") or None
-        tmdb_id = raw.get("tmdbid") or raw.get("tmdb_id") or None
+        # Public JSON export uses `id` as the TMDB id; `tmdbid` appears on some API payloads.
+        tmdb_id = raw.get("tmdbid") or raw.get("tmdb_id") or raw.get("id") or None
         dedupe_key = str(imdb_id or f"tvdb:{tvdb_id}" or f"tmdb:{tmdb_id}")
         if not (imdb_id or tvdb_id or tmdb_id) or dedupe_key in seen:
             continue

--- a/services/postgres/models.py
+++ b/services/postgres/models.py
@@ -308,7 +308,7 @@ class CollectionRecipe(Base):
     definition = Column(JSON, nullable=False, default=dict)
     # Per-recipe schedule override in hours; null = follow COLLECTIONS_SYNC_INTERVAL_HOURS.
     run_interval_hours = Column(Integer, nullable=True)
-    # Annually recurring active window: {"start": "MM-DD", "end": "MM-DD", "when_inactive": "keep"|"clear"}.
+    # Annually recurring active window: {"start": "MM-DD", "end": "MM-DD", "when_inactive": "keep"|"clear"|"delete"}.
     # Wrap-around windows (start > end, e.g. Dec 15 -> Jan 6) are supported. Null = always active.
     active_window = Column(JSON, nullable=True)
     last_run_at = Column(DateTime(timezone=True), nullable=True)

--- a/services/source_of_truth/arr_api.py
+++ b/services/source_of_truth/arr_api.py
@@ -1,7 +1,8 @@
+import re
 import threading
 import time
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
@@ -18,11 +19,14 @@ _cache = {}
 _DEFAULT_TTL_SECONDS = 120
 # Bulk *arr reads (e.g. GET /api/v3/movie) can exceed 30s on large libraries over user-share I/O.
 ARR_HTTP_TIMEOUT_SECONDS = 120
-# Collections missing-from-ARR add: lookup stays snappy; import can sit while Radarr
-# writes many titles (Kometa/arrapi default is 90s).
+# Collections add: *arr often never finishes POST /movie/import (or /series/import)
+# even for ~10 titles — the add still proceeds server-side. Wait briefly for a body,
+# then poll the library until titles appear (or this deadline).
 ARR_LOOKUP_TIMEOUT_SECONDS = 30
-ARR_ADD_TIMEOUT_SECONDS = 90
-ARR_IMPORT_CHUNK_SIZE = 100
+ARR_ADD_TIMEOUT_SECONDS = 15
+ARR_ADD_RECONCILE_SECONDS = 90
+ARR_ADD_RECONCILE_INTERVAL_SECONDS = 3
+ARR_IMPORT_CHUNK_SIZE = 20
 
 _last_write_error: dict[str, str | bool | int | None] = {}
 
@@ -87,6 +91,7 @@ def _request_json(
     payload: Optional[dict] = None,
     api_key: Optional[str] = None,
     timeout: int = ARR_HTTP_TIMEOUT_SECONDS,
+    isolated: bool = False,
 ):
     safe_url = url
     try:
@@ -99,8 +104,11 @@ def _request_json(
     if api_key:
         headers['X-Api-Key'] = api_key
 
+    # Import POSTs can hang until client timeout. Use a throwaway Session so the
+    # shared pool is free for library polls after we give up waiting for a body.
+    client = requests.Session() if isolated else _session
     try:
-        response = _session.request(
+        response = client.request(
             method=method.upper(),
             url=url,
             params=params,
@@ -130,9 +138,10 @@ def _request_json(
         )
         return None
     except Timeout as e:
-        logger.error(
-            f'ARR write failed method={method.upper()} url={safe_url} error_type={type(e).__name__}',
-            extra={'emoji_type': 'error'},
+        logger.warning(
+            f'ARR write timed out method={method.upper()} url={safe_url} timeout={timeout}s '
+            f'error_type={type(e).__name__}; *arr may still apply the write',
+            extra={'emoji_type': 'warning'},
         )
         _last_write_error.clear()
         _last_write_error.update(
@@ -159,9 +168,20 @@ def _request_json(
         _last_write_error.clear()
         _last_write_error.update({"timed_out": False, "status_code": None, "message": str(e) or type(e).__name__})
         return None
+    finally:
+        if isolated:
+            try:
+                client.close()
+            except Exception:
+                pass
 
 
-def fetch_radarr_movies(url: Optional[str] = None, api_key: Optional[str] = None) -> List[Dict]:
+def fetch_radarr_movies(
+    url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    *,
+    bypass_cache: bool = False,
+) -> List[Dict]:
     url = url or _default_radarr_endpoint()[0]
     api_key = api_key or _default_radarr_endpoint()[1]
     if not url or not api_key:
@@ -169,11 +189,12 @@ def fetch_radarr_movies(url: Optional[str] = None, api_key: Optional[str] = None
 
     endpoint = _build_endpoint(url, 'movie')
     cache_key = f'radarr_movies:{endpoint}'
-    cached = _cache_get(cache_key)
-    if cached is not None:
-        return cached
+    if not bypass_cache:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return cached
 
-    data = _get_json(endpoint, {'apikey': api_key}) or []
+    data = _get_json(endpoint, {'apikey': api_key}, timeout=30 if bypass_cache else ARR_HTTP_TIMEOUT_SECONDS) or []
     _cache_set(cache_key, data)
     return data
 
@@ -198,7 +219,12 @@ def fetch_radarr_movie(movie_id: int, url: Optional[str] = None, api_key: Option
     return None
 
 
-def fetch_sonarr_series(url: Optional[str] = None, api_key: Optional[str] = None) -> List[Dict]:
+def fetch_sonarr_series(
+    url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    *,
+    bypass_cache: bool = False,
+) -> List[Dict]:
     url = url or _default_sonarr_endpoint()[0]
     api_key = api_key or _default_sonarr_endpoint()[1]
     if not url or not api_key:
@@ -206,11 +232,16 @@ def fetch_sonarr_series(url: Optional[str] = None, api_key: Optional[str] = None
 
     endpoint = _build_endpoint(url, 'series')
     cache_key = f'sonarr_series:season_images:{endpoint}'
-    cached = _cache_get(cache_key)
-    if cached is not None:
-        return cached
+    if not bypass_cache:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            return cached
 
-    data = _get_json(endpoint, {'apikey': api_key, 'includeSeasonImages': 'true'}) or []
+    data = _get_json(
+        endpoint,
+        {'apikey': api_key, 'includeSeasonImages': 'true'},
+        timeout=30 if bypass_cache else ARR_HTTP_TIMEOUT_SECONDS,
+    ) or []
     _cache_set(cache_key, data)
     return data
 
@@ -599,17 +630,79 @@ def trigger_sonarr_search(
     return result is not None
 
 
-def lookup_movie(*, url: str, api_key: str, tmdb_id: Optional[int] = None, imdb_id: Optional[str] = None) -> Optional[dict]:
+def _coerce_lookup_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _first_lookup_row(result: Any) -> Optional[dict]:
+    if isinstance(result, list):
+        return result[0] if result and isinstance(result[0], dict) else None
+    return result if isinstance(result, dict) else None
+
+
+def _lookup_year(row: dict) -> Optional[int]:
+    try:
+        parsed = int(row.get("year") or 0)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _pick_title_lookup(result: Any, *, title: str, year: Optional[int]) -> Optional[dict]:
+    """Prefer an exact title (and year when known); otherwise the first *arr hit."""
+    rows = result if isinstance(result, list) else [result] if isinstance(result, dict) else []
+    dicts = [row for row in rows if isinstance(row, dict)]
+    if not dicts:
+        return None
+    want = str(title or "").strip().lower()
+    want_year = _coerce_lookup_int(year)
+    exact = [row for row in dicts if str(row.get("title") or "").strip().lower() == want]
+    if want_year:
+        year_exact = [row for row in exact if _lookup_year(row) == want_year]
+        if year_exact:
+            return year_exact[0]
+    if exact:
+        return exact[0]
+    return dicts[0]
+
+
+def _arr_lookup(url: str, api_key: str, resource: str, term: str) -> Any:
+    endpoint = _build_endpoint(url, resource)
+    return _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=ARR_LOOKUP_TIMEOUT_SECONDS)
+
+
+def lookup_movie(
+    *,
+    url: str,
+    api_key: str,
+    tmdb_id: Optional[int] = None,
+    imdb_id: Optional[str] = None,
+    title: Optional[str] = None,
+    year: Optional[int] = None,
+) -> Optional[dict]:
+    """Resolve a movie in Radarr: TMDB id, then IMDb, then title search."""
     if not url or not api_key:
         return None
-    term = f"tmdb:{int(tmdb_id)}" if tmdb_id else (f"imdb:{imdb_id}" if imdb_id else None)
-    if not term:
+    tmdb = _coerce_lookup_int(tmdb_id)
+    imdb = str(imdb_id or "").strip() or None
+    terms: list[str] = []
+    if tmdb:
+        terms.append(f"tmdb:{tmdb}")
+    if imdb:
+        terms.append(f"imdb:{imdb}")
+    for term in terms:
+        hit = _first_lookup_row(_arr_lookup(url, api_key, "movie/lookup", term))
+        if hit:
+            return hit
+    name = str(title or "").strip()
+    if not name:
         return None
-    endpoint = _build_endpoint(url, "movie/lookup")
-    result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=ARR_LOOKUP_TIMEOUT_SECONDS)
-    if isinstance(result, list) and result:
-        return result[0] if isinstance(result[0], dict) else None
-    return result if isinstance(result, dict) else None
+    query = f"{name} {int(year)}" if _coerce_lookup_int(year) else name
+    return _pick_title_lookup(_arr_lookup(url, api_key, "movie/lookup", query), title=name, year=year)
 
 
 def lookup_series(
@@ -619,29 +712,46 @@ def lookup_series(
     tvdb_id: Optional[int] = None,
     tmdb_id: Optional[int] = None,
     imdb_id: Optional[str] = None,
+    title: Optional[str] = None,
+    year: Optional[int] = None,
 ) -> Optional[dict]:
+    """Resolve a series in Sonarr: TVDB, then TMDB, then IMDb, then title search."""
     if not url or not api_key:
         return None
     terms: list[str] = []
-    if tvdb_id:
-        terms.append(f"tvdb:{int(tvdb_id)}")
-    if tmdb_id:
-        terms.append(f"tmdb:{int(tmdb_id)}")
-    if imdb_id:
-        terms.append(f"imdb:{imdb_id}")
+    tvdb = _coerce_lookup_int(tvdb_id)
+    tmdb = _coerce_lookup_int(tmdb_id)
+    imdb = str(imdb_id or "").strip() or None
+    if tvdb:
+        terms.append(f"tvdb:{tvdb}")
+    if tmdb:
+        terms.append(f"tmdb:{tmdb}")
+    if imdb:
+        terms.append(f"imdb:{imdb}")
     for term in terms:
-        endpoint = _build_endpoint(url, "series/lookup")
-        result = _get_json(endpoint, {"apikey": api_key, "term": term}, timeout=ARR_LOOKUP_TIMEOUT_SECONDS)
-        if isinstance(result, list) and result and isinstance(result[0], dict):
-            return result[0]
-        if isinstance(result, dict):
-            return result
-    return None
+        hit = _first_lookup_row(_arr_lookup(url, api_key, "series/lookup", term))
+        if hit:
+            return hit
+    name = str(title or "").strip()
+    if not name:
+        return None
+    query = f"{name} {int(year)}" if _coerce_lookup_int(year) else name
+    return _pick_title_lookup(_arr_lookup(url, api_key, "series/lookup", query), title=name, year=year)
+
+
+def normalize_arr_tag_label(label: str) -> str:
+    """Match Radarr/Sonarr tag slugs: trim and collapse whitespace to dashes."""
+    text = str(label or "").strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text
 
 
 def ensure_arr_tag(*, url: str, api_key: str, label: str) -> Optional[int]:
     """Return the id of an existing tag, creating it if needed."""
-    name = str(label or "").strip()
+    name = normalize_arr_tag_label(label)
     if not name or not url or not api_key:
         return None
     endpoint = _build_endpoint(url, "tag")
@@ -743,16 +853,212 @@ def _lookup_identity_key(lookup: dict, *, movie: bool) -> Optional[str]:
     return None
 
 
-def _imported_identity_keys(imported: Any, *, movie: bool) -> set[str]:
-    keys: set[str] = set()
+def _imported_rows_by_identity(imported: Any, *, movie: bool) -> dict[str, dict]:
+    mapping: dict[str, dict] = {}
     rows = imported if isinstance(imported, list) else [imported] if isinstance(imported, dict) else []
     for row in rows:
         if not isinstance(row, dict):
             continue
         key = _lookup_identity_key(row, movie=movie)
         if key:
-            keys.add(key)
-    return keys
+            mapping[key] = row
+    return mapping
+
+
+def _apply_arr_id(lookup: dict, row: dict) -> None:
+    try:
+        arr_id = int(row.get("id") or 0)
+    except (TypeError, ValueError):
+        arr_id = 0
+    if arr_id > 0:
+        lookup["id"] = arr_id
+
+
+def _refresh_lookup(*, url: str, api_key: str, lookup: dict, movie: bool) -> Optional[dict]:
+    if movie:
+        tmdb = lookup.get("tmdbId") or lookup.get("tmdb_id")
+        imdb = lookup.get("imdbId") or lookup.get("imdb_id")
+        tmdb_id = None
+        try:
+            tmdb_id = int(tmdb) if tmdb else None
+        except (TypeError, ValueError):
+            tmdb_id = None
+        return lookup_movie(url=url, api_key=api_key, tmdb_id=tmdb_id, imdb_id=str(imdb) if imdb else None)
+    tvdb = lookup.get("tvdbId") or lookup.get("tvdb_id")
+    tmdb = lookup.get("tmdbId") or lookup.get("tmdb_id")
+    imdb = lookup.get("imdbId") or lookup.get("imdb_id")
+    tvdb_id = None
+    tmdb_id = None
+    try:
+        tvdb_id = int(tvdb) if tvdb else None
+    except (TypeError, ValueError):
+        tvdb_id = None
+    try:
+        tmdb_id = int(tmdb) if tmdb else None
+    except (TypeError, ValueError):
+        tmdb_id = None
+    return lookup_series(
+        url=url,
+        api_key=api_key,
+        tvdb_id=tvdb_id,
+        tmdb_id=tmdb_id,
+        imdb_id=str(imdb) if imdb else None,
+    )
+
+
+ArrAddProgress = Callable[[dict[str, Any]], None]
+ArrAddIndexStatus = Callable[[int, str, Optional[str]], None]
+
+
+def _notify_index_status(
+    on_status: Optional[ArrAddIndexStatus],
+    index: int,
+    status: str,
+    error: Optional[str] = None,
+) -> None:
+    if on_status is None:
+        return
+    try:
+        on_status(index, status, error)
+    except Exception:
+        pass
+
+
+def _arr_add_item_key(item: Any, instance_key: str) -> str:
+    tmdb = getattr(item, "tmdb_id", None)
+    tvdb = getattr(item, "tvdb_id", None)
+    imdb = getattr(item, "imdb_id", None) or ""
+    title = getattr(item, "title", None) or ""
+    year = getattr(item, "year", None) or ""
+    return f"{instance_key}:{tmdb or ''}:{tvdb or ''}:{imdb}:{title}:{year}"
+
+
+def _emit_arr_add_progress(
+    on_progress: Optional[ArrAddProgress],
+    event: dict[str, Any],
+) -> None:
+    if on_progress is None:
+        return
+    try:
+        on_progress(event)
+    except Exception:
+        pass
+
+
+def _library_identity_map(*, url: str, api_key: str, movie: bool) -> dict[str, dict]:
+    if movie:
+        library = fetch_radarr_movies(url, api_key, bypass_cache=True)
+    else:
+        endpoint = _build_endpoint(url, "series")
+        library = _get_json(endpoint, {"apikey": api_key}, timeout=30) or []
+    return _imported_rows_by_identity(library if isinstance(library, list) else [], movie=movie)
+
+
+def _reconcile_unconfirmed_chunk(
+    *,
+    url: str,
+    api_key: str,
+    chunk: list[tuple[int, dict, dict]],
+    results: list[Optional[tuple[dict, str, Optional[str]]]],
+    movie: bool,
+    failure_message: str,
+    on_status: Optional[ArrAddIndexStatus] = None,
+) -> None:
+    """Poll *arr until titles from a hung/empty import actually appear in the library."""
+    pending: list[tuple[int, dict]] = [(index, lookup) for index, lookup, _payload in chunk]
+    if not pending:
+        return
+    arr_name = "Radarr" if movie else "Sonarr"
+    logger.info(
+        f"{arr_name} import body missing; polling library for {len(pending)} title(s) "
+        f"up to {ARR_ADD_RECONCILE_SECONDS}s",
+        extra={"emoji_type": "info"},
+    )
+    deadline = time.monotonic() + ARR_ADD_RECONCILE_SECONDS
+    while pending and time.monotonic() < deadline:
+        by_key = _library_identity_map(url=url, api_key=api_key, movie=movie)
+        still: list[tuple[int, dict]] = []
+        for index, lookup in pending:
+            key = _lookup_identity_key(lookup, movie=movie)
+            row = by_key.get(key) if key else None
+            if row and _existing_arr_id(row):
+                _apply_arr_id(lookup, row)
+                results[index] = (lookup, "ok", None)
+                _notify_index_status(on_status, index, "ok")
+                continue
+            still.append((index, lookup))
+        pending = still
+        if pending:
+            remaining = max(0.0, deadline - time.monotonic())
+            time.sleep(min(ARR_ADD_RECONCILE_INTERVAL_SECONDS, remaining) if remaining else 0)
+    leftover = list(pending)
+    for index, lookup in leftover:
+        refreshed = _refresh_lookup(url=url, api_key=api_key, lookup=lookup, movie=movie)
+        if refreshed and _existing_arr_id(refreshed):
+            _apply_arr_id(lookup, refreshed)
+            results[index] = (lookup, "ok", None)
+            _notify_index_status(on_status, index, "ok")
+        else:
+            results[index] = (lookup, "error", failure_message)
+            _notify_index_status(on_status, index, "error", failure_message)
+
+
+def _import_body_usable(imported: Any) -> bool:
+    if imported is None:
+        return False
+    if isinstance(imported, list):
+        return bool(imported)
+    if isinstance(imported, dict):
+        return bool(imported)
+    return False
+
+
+def _finish_import_chunk(
+    *,
+    url: str,
+    api_key: str,
+    chunk: list[tuple[int, dict, dict]],
+    imported: Any,
+    results: list[Optional[tuple[dict, str, Optional[str]]]],
+    movie: bool,
+    arr_name: str,
+    on_status: Optional[ArrAddIndexStatus] = None,
+) -> None:
+    if not _import_body_usable(imported):
+        _reconcile_unconfirmed_chunk(
+            url=url,
+            api_key=api_key,
+            chunk=chunk,
+            results=results,
+            movie=movie,
+            failure_message=_arr_write_failure_message(arr_name),
+            on_status=on_status,
+        )
+        return
+    by_key = _imported_rows_by_identity(imported, movie=movie)
+    unconfirmed: list[tuple[int, dict, dict]] = []
+    for index, lookup, payload in chunk:
+        key = _lookup_identity_key(lookup, movie=movie)
+        row = by_key.get(key) if key else None
+        if row and _existing_arr_id(row):
+            _apply_arr_id(lookup, row)
+            results[index] = (lookup, "ok", None)
+            _notify_index_status(on_status, index, "ok")
+        elif key and key in by_key:
+            results[index] = (lookup, "ok", None)
+            _notify_index_status(on_status, index, "ok")
+        else:
+            unconfirmed.append((index, lookup, payload))
+    if unconfirmed:
+        _reconcile_unconfirmed_chunk(
+            url=url,
+            api_key=api_key,
+            chunk=unconfirmed,
+            results=results,
+            movie=movie,
+            failure_message=f"{arr_name} did not confirm this title in the import response",
+            on_status=on_status,
+        )
 
 
 def add_movies_to_radarr(
@@ -765,16 +1071,19 @@ def add_movies_to_radarr(
     monitored: bool,
     search: bool,
     tag_ids: Optional[List[int]] = None,
+    on_status: Optional[ArrAddIndexStatus] = None,
 ) -> list[tuple[dict, str, Optional[str]]]:
     """Bulk-add looked-up movies via POST /movie/import.
 
     Returns one (lookup, status, error) per input lookup, in the same order.
+    Lookups that succeed (including after a timeout reconcile) have ARR ``id`` set.
     """
     results: list[Optional[tuple[dict, str, Optional[str]]]] = [None] * len(lookups)
     pending: list[tuple[int, dict, dict]] = []
     for index, lookup in enumerate(lookups):
         if _existing_arr_id(lookup):
             results[index] = (lookup, "skipped", "Already in this Radarr instance")
+            _notify_index_status(on_status, index, "skipped", "Already in this Radarr instance")
             continue
         payload = _movie_add_payload(
             lookup,
@@ -797,19 +1106,22 @@ def add_movies_to_radarr(
             payload=payloads,
             api_key=api_key,
             timeout=ARR_ADD_TIMEOUT_SECONDS,
+            isolated=True,
         )
-        if imported is None:
-            message = _arr_write_failure_message("Radarr")
-            for _index, lookup, _payload in chunk:
-                results[_index] = (lookup, "error", message)
-            continue
-        accepted = _imported_identity_keys(imported, movie=True)
-        if not accepted:
-            continue
-        for index, lookup, _payload in chunk:
-            key = _lookup_identity_key(lookup, movie=True)
-            if key and key not in accepted:
-                results[index] = (lookup, "error", "Radarr did not confirm this title in the import response")
+        _finish_import_chunk(
+            url=url,
+            api_key=api_key,
+            chunk=chunk,
+            imported=imported,
+            results=results,
+            movie=True,
+            arr_name="Radarr",
+            on_status=on_status,
+        )
+    for i, row in enumerate(results):
+        if row is None:
+            results[i] = (lookups[i], "error", "Radarr import did not return a result")
+            _notify_index_status(on_status, i, "error", "Radarr import did not return a result")
     return [row if row is not None else (lookups[i], "error", "Radarr import did not return a result") for i, row in enumerate(results)]
 
 
@@ -823,6 +1135,7 @@ def add_series_to_sonarr_bulk(
     monitored: bool,
     search: bool,
     tag_ids: Optional[List[int]] = None,
+    on_status: Optional[ArrAddIndexStatus] = None,
 ) -> list[tuple[dict, str, Optional[str]]]:
     """Bulk-add looked-up series via POST /series/import."""
     results: list[Optional[tuple[dict, str, Optional[str]]]] = [None] * len(lookups)
@@ -830,6 +1143,7 @@ def add_series_to_sonarr_bulk(
     for index, lookup in enumerate(lookups):
         if _existing_arr_id(lookup):
             results[index] = (lookup, "skipped", "Already in this Sonarr instance")
+            _notify_index_status(on_status, index, "skipped", "Already in this Sonarr instance")
             continue
         payload = _series_add_payload(
             lookup,
@@ -852,19 +1166,22 @@ def add_series_to_sonarr_bulk(
             payload=payloads,
             api_key=api_key,
             timeout=ARR_ADD_TIMEOUT_SECONDS,
+            isolated=True,
         )
-        if imported is None:
-            message = _arr_write_failure_message("Sonarr")
-            for _index, lookup, _payload in chunk:
-                results[_index] = (lookup, "error", message)
-            continue
-        accepted = _imported_identity_keys(imported, movie=False)
-        if not accepted:
-            continue
-        for index, lookup, _payload in chunk:
-            key = _lookup_identity_key(lookup, movie=False)
-            if key and key not in accepted:
-                results[index] = (lookup, "error", "Sonarr did not confirm this title in the import response")
+        _finish_import_chunk(
+            url=url,
+            api_key=api_key,
+            chunk=chunk,
+            imported=imported,
+            results=results,
+            movie=False,
+            arr_name="Sonarr",
+            on_status=on_status,
+        )
+    for i, row in enumerate(results):
+        if row is None:
+            results[i] = (lookups[i], "error", "Sonarr import did not return a result")
+            _notify_index_status(on_status, i, "error", "Sonarr import did not return a result")
     return [row if row is not None else (lookups[i], "error", "Sonarr import did not return a result") for i, row in enumerate(results)]
 
 
@@ -929,6 +1246,7 @@ def add_missing_titles(
     search: bool,
     tag_ids: Optional[List[int]] = None,
     instance_key: str = "",
+    on_progress: Optional[ArrAddProgress] = None,
 ) -> list[dict[str, Any]]:
     """Lookup each title, then bulk-import into Radarr or Sonarr."""
 
@@ -946,11 +1264,27 @@ def add_missing_titles(
     def row(title: str, status: str, error: Optional[str] = None) -> dict[str, Any]:
         return {"title": title, "instance_key": instance_key, "status": status, "error": error}
 
+    def emit(item: Any, title: str, status: str, error: Optional[str] = None) -> None:
+        _emit_arr_add_progress(
+            on_progress,
+            {
+                "type": "item",
+                "item_key": _arr_add_item_key(item, instance_key),
+                "title": title,
+                "instance_key": instance_key,
+                "status": status,
+                "error": error,
+            },
+        )
+
     results: list[dict[str, Any]] = []
     pending_items: list[Any] = []
     pending_lookups: list[dict] = []
+    ingest_lookups: list[dict] = []
     movie = media_type == "movie"
     for item in items:
+        display = result_title(item)
+        emit(item, display, "adding")
         try:
             if movie:
                 lookup = lookup_movie(
@@ -958,6 +1292,8 @@ def add_missing_titles(
                     api_key=api_key,
                     tmdb_id=getattr(item, "tmdb_id", None),
                     imdb_id=getattr(item, "imdb_id", None),
+                    title=getattr(item, "title", None),
+                    year=getattr(item, "year", None),
                 )
                 missing = "Radarr lookup found nothing"
             else:
@@ -967,17 +1303,27 @@ def add_missing_titles(
                     tvdb_id=getattr(item, "tvdb_id", None),
                     tmdb_id=getattr(item, "tmdb_id", None),
                     imdb_id=getattr(item, "imdb_id", None),
+                    title=getattr(item, "title", None),
+                    year=getattr(item, "year", None),
                 )
                 missing = "Sonarr lookup found nothing"
             if not lookup:
-                results.append(row(result_title(item), "error", missing))
+                results.append(row(display, "error", missing))
+                emit(item, display, "error", missing)
                 continue
             pending_items.append(item)
             pending_lookups.append(lookup)
         except Exception as extra:
-            results.append(row(result_title(item), "error", str(extra)))
+            results.append(row(display, "error", str(extra)))
+            emit(item, display, "error", str(extra))
     if not pending_lookups:
         return results
+
+    def on_status(index: int, status: str, error: Optional[str] = None) -> None:
+        item = pending_items[index]
+        lookup = pending_lookups[index]
+        emit(item, result_title(item, lookup), status, error)
+
     adder = add_movies_to_radarr if movie else add_series_to_sonarr_bulk
     added = adder(
         url=url,
@@ -988,8 +1334,36 @@ def add_missing_titles(
         monitored=monitored,
         search=search,
         tag_ids=tag_ids,
+        on_status=on_status,
     )
     for item, lookup, (_lookup, status, error) in zip(pending_items, pending_lookups, added):
-        results.append(row(result_title(item, lookup), status, error))
+        arr_id = None
+        try:
+            arr_id = int(lookup.get("id") or 0) or None
+        except (TypeError, ValueError):
+            arr_id = None
+        results.append({
+            "title": result_title(item, lookup),
+            "instance_key": instance_key,
+            "status": status,
+            "error": error,
+            "arr_id": arr_id,
+        })
+        if status in {"ok", "skipped"} and arr_id:
+            ingest_lookups.append(lookup)
+    if ingest_lookups and instance_key:
+        try:
+            from services.handlers import enqueue_synthetic_arr_adds
+
+            enqueue_synthetic_arr_adds(
+                instance_key=instance_key,
+                movie=movie,
+                lookups=ingest_lookups,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to enqueue placeholder ingest after ARR add: {exc}",
+                extra={"emoji_type": "warning"},
+            )
     return results
 

--- a/services/webhook_ingest.py
+++ b/services/webhook_ingest.py
@@ -1,0 +1,89 @@
+"""Bounded webhook persist so ARR import-list bursts cannot exhaust the DB pool.
+
+The HTTP handler returns 200 immediately. Persist (EventLog + Job) runs on a
+small worker pool instead of unbounded FastAPI background tasks.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from typing import Any
+
+from core.config import settings
+from core.logger import logger
+
+_ingest_queue: queue.Queue[tuple[dict[str, Any], str | None, int]] = queue.Queue()
+_started = False
+_start_lock = threading.Lock()
+_MAX_ATTEMPTS = 4
+_RETRY_SLEEP_SECONDS = 0.25
+
+
+def _concurrency() -> int:
+    try:
+        return max(1, int(getattr(settings, "WEBHOOK_INGEST_CONCURRENCY", 1) or 1))
+    except Exception:
+        return 1
+
+
+def _ensure_started() -> None:
+    global _started
+    if _started:
+        return
+    with _start_lock:
+        if _started:
+            return
+        workers = _concurrency()
+        for index in range(workers):
+            thread = threading.Thread(
+                target=_ingest_loop,
+                name=f"webhook-ingest-{index}",
+                daemon=True,
+            )
+            thread.start()
+        _started = True
+        logger.info(
+            f"Webhook ingest queue started concurrency={workers}",
+            extra={"emoji_type": "gear"},
+        )
+
+
+def enqueue_webhook_persist(payload: dict[str, Any], instance: str | None) -> None:
+    """Queue validated webhook persist. HTTP should already have returned 200."""
+    _ensure_started()
+    depth = _ingest_queue.qsize()
+    if depth >= 200:
+        logger.warning(
+            f"Webhook ingest queue depth={depth} instance={instance or 'unknown'}",
+            extra={"emoji_type": "warning"},
+        )
+    _ingest_queue.put((payload, instance, 0))
+
+
+def _ingest_loop() -> None:
+    from services.handlers import handle_webhook
+
+    while True:
+        payload, instance, attempt = _ingest_queue.get()
+        try:
+            handle_webhook(payload, instance)
+        except Exception as exc:
+            next_attempt = attempt + 1
+            if next_attempt < _MAX_ATTEMPTS:
+                logger.warning(
+                    f"Webhook ingest retry {next_attempt}/{_MAX_ATTEMPTS - 1} "
+                    f"instance={instance or 'unknown'}: {exc}",
+                    extra={"emoji_type": "warning"},
+                )
+                time.sleep(_RETRY_SLEEP_SECONDS * next_attempt)
+                _ingest_queue.put((payload, instance, next_attempt))
+            else:
+                logger.error(
+                    f"Webhook ingest dropped after {_MAX_ATTEMPTS} attempts "
+                    f"instance={instance or 'unknown'}: {exc}",
+                    extra={"emoji_type": "error"},
+                )
+        finally:
+            _ingest_queue.task_done()


### PR DESCRIPTION
## Summary
### Collections (Beta)
- Add to Radarr now Import chunks of 20; after a silent *arr `movie/import` / `series/import`, poll the library until titles appear.
- Add modal lists each title and flips **Adding…** to **Added** (or an error) as it is found.
- Already-in-*arr and reconciled titles still enqueue placeholder ingest.
- Tags are chips (Enter to add, spaces become dashes); a failed tag no longer aborts the add.
- Webhook persist is serialized so import-list `MovieAdded` floods cannot exhaust the DB pool.
- MDBList public JSON `id` is treated as TMDB id; *arr lookup tries TMDB/TVDB/IMDb then title search.
- Missing-list copy says **missing from catalog**. Sidebar selected-tab and hover styling.
- Out-of-window **Run now** follows the same keep / empty / delete policy as scheduled sync (no more filling a dormant collection).
- Seasonal window gains **delete** for Placeholdarr-owned Plex collections (Sets delete managed children). Last run shows **Kept**, **Cleared**, or **Removed (out of window)**.

Cut changelog and `APP_VERSION` for **0.9.19**.