### PR TITLE
Release 0.9.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ debug_*.json
 # IDE
 .idea/
 .vscode/
+.cursor/
 *.swp
 *.swo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Sonarr episode sync**: Bulk `/episode?seriesId=` requests use `includeEpisodeFile` and `includeImages` (one call per series); per-id GET only when still art is missing.
 - **media_refresh coalesce**: Merge pending delayed_final and overlap_path_batch jobs into one path batch.
 - **Phase metric logs**: RSS, ARR cache size, elapsed_s, and rows/sec at phase start/end.
-- **Lookahead Season mode copy**: Settings and onboarding now say the next season is monitored and searched when you play the last episode of a season.
+- **Season mode lookahead**: Lookahead range controls when the next season is monitored and searched; the current season is always included.
+- **Lookahead settings copy**: Settings and onboarding describe lookahead for Episode and Season modes.
 - **Determination explain**: When a title is pinned but a real file is on disk, summary and the policy step explain that calendar, monitored, and sibling rules would be overridden, but no placeholder is needed.
 - **Determination explain (policy)**: Why? uses one Placeholder policy step (Auto / Never / Pinned) instead of separate Never and Pin rows.
 - **Placeholder policy cycle**: Movie meta strip and episode rows use Auto / Never / Pinned; save after a short pause; sync immediately; no confirm modals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+### Changed
+
+- **Lookahead Season mode copy**: Settings and onboarding now say the next season is monitored and searched when you play the last episode of a season.
+- **Determination explain**: When a title is pinned but a real file is on disk, summary and the pin step explain that calendar, monitored, and sibling rules would be overridden, but no placeholder is needed.
+- **Placeholder policy cycle**: Movie meta strip and episode rows use Auto / Never / Pinned; save after a short pause; sync immediately; no confirm modals.
+- **Placeholder policy feedback**: Episodes show Creating… / Removing… on the status chip; movies show the same text beside the pin.
+- **Pinned / Never apply**: Create or remove the placeholder immediately from the stated policy (no full Arr reconcile). Auto still runs a full title sync.
+- **Placeholder policy chip**: Stays clickable during apply so the latest cycle wins.
+
+### Fixed
+
+- **Obsolete settle**: After a placeholder is removed, determination settles to `not needed` instead of staying on `obsolete placeholder`.
+
+### Added
+
+- **Never placeholder**: Block placeholder creation per title; existing placeholders can be removed on sync.
+- **Pinned placeholder**: Pin movies and episodes to create a placeholder despite calendar/monitored/specials rules. Does not create a placeholder when a real file exists.
+- **Pinned vs shared instances**: Multi-instance sibling behavior follows Shared Placeholder Cleanup settings (no per-title override in the UI).
+- **Determination explain**: "Why?" on movie detail and episode rows opens a step-by-step audit of placeholder determination.
+
 ### Fixed
 
 - **Playback future-episode suppress**: "Do not search future episodes on playback" now skips any episode whose air date is still in the future, instead of only episodes beyond the calendar lookahead window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+## [0.9.23] - 2026-09-04
+
+### Summary
+
+- **Placeholder policy**: Auto, Never, and Pinned on movies and episodes; save applies immediately with Creating… / Removing… feedback.
+- **Determination explain**: Why? on movie detail and episode rows opens a step-by-step placeholder audit.
+- **Pinned Coming Soon**: Pinned titles show countdowns outside the calendar window; missing dates show TBD/TBA; calendar phase keeps days updated.
+- **Full sync performance**: Bounded ARR cache, chunked determination and reconcile, bulk Sonarr episode sync, and phase RSS/timing logs.
+- **Season mode lookahead**: Lookahead range triggers next-season monitor and search when the first next-season episode enters the window.
+- **Playback future episodes**: Suppress-on-playback skips any not-yet-aired episode, not only titles outside calendar lookahead.
+
+### Added
+
+- **Never placeholder**: Block placeholder creation per title; existing placeholders can be removed on sync.
+- **Pinned placeholder**: Pin movies and episodes to create a placeholder despite calendar/monitored/specials rules. Does not create a placeholder when a real file exists.
+- **Pinned vs shared instances**: Multi-instance sibling behavior follows Shared Placeholder Cleanup settings (no per-title override in the UI).
+- **Determination explain**: "Why?" on movie detail and episode rows opens a step-by-step audit of placeholder determination.
+- **What's new (0.9.23)**: Startup ack notice for placeholder policy, pinned Coming Soon/TBD, and Season mode lookahead.
+
 ### Changed
 
 - **ARR HTTP cache**: Cap size with LRU eviction (512 entries); phase logs report entry count.
@@ -29,16 +48,6 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 ### Fixed
 
 - **Obsolete settle**: After a placeholder is removed, determination settles to `not needed` instead of staying on `obsolete placeholder`.
-
-### Added
-
-- **Never placeholder**: Block placeholder creation per title; existing placeholders can be removed on sync.
-- **Pinned placeholder**: Pin movies and episodes to create a placeholder despite calendar/monitored/specials rules. Does not create a placeholder when a real file exists.
-- **Pinned vs shared instances**: Multi-instance sibling behavior follows Shared Placeholder Cleanup settings (no per-title override in the UI).
-- **Determination explain**: "Why?" on movie detail and episode rows opens a step-by-step audit of placeholder determination.
-
-### Fixed
-
 - **Playback future-episode suppress**: "Do not search future episodes on playback" now skips any episode whose air date is still in the future, instead of only episodes beyond the calendar lookahead window.
 
 ## [0.9.22] - 2026-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Playback future-episode suppress**: "Do not search future episodes on playback" now skips any episode whose air date is still in the future, instead of only episodes beyond the calendar lookahead window.
+
 ## [0.9.22] - 2026-08-31
 
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 - **Placeholder policy cycle**: Movie meta strip and episode rows use Auto / Never / Pinned; save after a short pause; sync immediately; no confirm modals.
 - **Placeholder policy feedback**: Episodes show Creating… / Removing… on the status chip; movies show the same text beside the pin.
 - **Pinned / Never apply**: Create or remove the placeholder immediately from the stated policy (no full Arr reconcile). Auto still runs a full title sync.
-- **Placeholder policy chip**: Stays clickable during apply so the latest cycle wins.
+- **Pinned placeholder status**: Pinned titles show Coming Soon countdowns outside the calendar window; missing dates show TBD/TBA (e.g. Theatrical TBD).
+- **Pinned status refresh**: Saving pin on an existing placeholder updates status immediately; calendar phase includes pinned rows for daily countdown updates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ and this project follows Semantic Versioning while in pre-1.0 stabilization.
 
 ### Changed
 
+- **ARR HTTP cache**: Cap size with LRU eviction (512 entries); phase logs report entry count.
+- **Determination pass**: Episode full scan runs in 2000-row chunks with commit/expunge; progress logs rows/sec.
+- **Placeholder reconcile**: Stream active placeholder rows; chunk movie/episode link updates.
+- **Placeholder reconcile cursor**: Validate pass uses ID-chunked queries instead of server-side cursors so mid-pass commits are safe.
+- **Sonarr episode sync**: Bulk `/episode?seriesId=` requests use `includeEpisodeFile` and `includeImages` (one call per series); per-id GET only when still art is missing.
+- **media_refresh coalesce**: Merge pending delayed_final and overlap_path_batch jobs into one path batch.
+- **Phase metric logs**: RSS, ARR cache size, elapsed_s, and rows/sec at phase start/end.
 - **Lookahead Season mode copy**: Settings and onboarding now say the next season is monitored and searched when you play the last episode of a season.
-- **Determination explain**: When a title is pinned but a real file is on disk, summary and the pin step explain that calendar, monitored, and sibling rules would be overridden, but no placeholder is needed.
+- **Determination explain**: When a title is pinned but a real file is on disk, summary and the policy step explain that calendar, monitored, and sibling rules would be overridden, but no placeholder is needed.
+- **Determination explain (policy)**: Why? uses one Placeholder policy step (Auto / Never / Pinned) instead of separate Never and Pin rows.
 - **Placeholder policy cycle**: Movie meta strip and episode rows use Auto / Never / Pinned; save after a short pause; sync immediately; no confirm modals.
 - **Placeholder policy feedback**: Episodes show Creating… / Removing… on the status chip; movies show the same text beside the pin.
 - **Pinned / Never apply**: Create or remove the placeholder immediately from the stated policy (no full Arr reconcile). Auto still runs a full title sync.

--- a/alembic/versions/0026_force_placeholder_pin.py
+++ b/alembic/versions/0026_force_placeholder_pin.py
@@ -1,0 +1,50 @@
+"""force placeholder pin on movie and episode
+
+Revision ID: 0026_force_placeholder_pin
+Revises: 0025_collection_recipe_plex_keys
+Create Date: 2026-09-02 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0026_force_placeholder_pin"
+down_revision = "0025_collection_recipe_plex_keys"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "movie",
+        sa.Column("force_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "movie",
+        sa.Column(
+            "force_placeholder_despite_sibling",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "episode",
+        sa.Column("force_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "episode",
+        sa.Column(
+            "force_placeholder_despite_sibling",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("episode", "force_placeholder_despite_sibling")
+    op.drop_column("episode", "force_placeholder")
+    op.drop_column("movie", "force_placeholder_despite_sibling")
+    op.drop_column("movie", "force_placeholder")

--- a/alembic/versions/0027_block_placeholder.py
+++ b/alembic/versions/0027_block_placeholder.py
@@ -1,0 +1,30 @@
+"""block placeholder (never pin) on movie and episode
+
+Revision ID: 0027_block_placeholder
+Revises: 0026_force_placeholder_pin
+Create Date: 2026-09-02 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0027_block_placeholder"
+down_revision = "0026_force_placeholder_pin"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "movie",
+        sa.Column("block_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "episode",
+        sa.Column("block_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_column("episode", "block_placeholder")
+    op.drop_column("movie", "block_placeholder")

--- a/alembic/versions/0028_series_season_placeholder_policy.py
+++ b/alembic/versions/0028_series_season_placeholder_policy.py
@@ -1,0 +1,42 @@
+"""placeholder policy flags on series and season
+
+Revision ID: 0028_series_season_placeholder_policy
+Revises: 0027_block_placeholder
+Create Date: 2026-09-03 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0028_series_season_placeholder_policy"
+down_revision = "0027_block_placeholder"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for table in ("series", "season"):
+        op.add_column(
+            table,
+            sa.Column("force_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "force_placeholder_despite_sibling",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column("block_placeholder", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+
+
+def downgrade():
+    for table in ("season", "series"):
+        op.drop_column(table, "block_placeholder")
+        op.drop_column(table, "force_placeholder_despite_sibling")
+        op.drop_column(table, "force_placeholder")

--- a/core/version.py
+++ b/core/version.py
@@ -3,4 +3,4 @@
 Keep this in sync with CHANGELOG.md when cutting a release.
 """
 
-APP_VERSION = "0.9.22"
+APP_VERSION = "0.9.23"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5248,8 +5248,8 @@ function LookaheadSectionIntro(props: { variant: LookaheadIntroVariant; embedded
         </li>
         <li>
           <span className="font-medium text-slate-200">Season</span>
-          {" — "}Only the played episode&apos;s season is monitored and searched. When you finish a season, Placeholdarr
-          automatically monitors and searches the next one.
+          {" — "}Only the played episode&apos;s season is monitored and searched. When you play the last episode of a
+          season, Placeholdarr automatically monitors and searches the next one.
         </li>
         <li>
           <span className="font-medium text-slate-200">Episode</span>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5248,8 +5248,10 @@ function LookaheadSectionIntro(props: { variant: LookaheadIntroVariant; embedded
         </li>
         <li>
           <span className="font-medium text-slate-200">Season</span>
-          {" — "}Only the played episode&apos;s season is monitored and searched. When you play the last episode of a
-          season, Placeholdarr automatically monitors and searches the next one.
+          {" — "}Missing episodes in the played season are always monitored and searched. When the first episode of the
+          next season enters your configured{" "}
+          <span className="font-medium text-slate-200">Lookahead Range</span>, Placeholdarr monitors and searches that
+          next season too.
         </li>
         <li>
           <span className="font-medium text-slate-200">Episode</span>
@@ -5258,12 +5260,13 @@ function LookaheadSectionIntro(props: { variant: LookaheadIntroVariant; embedded
         </li>
       </ul>
       <p className="ui-field-description mt-3 text-slate-400 leading-relaxed">
-        Regardless of which mode you choose, Placeholdarr will monitor the full series once you&apos;re approaching the
-        end of available content, ensuring Sonarr can pick up new episodes as they air.
+        Regardless of which mode you choose, Placeholdarr will monitor the full series once your lookahead window reaches
+        the end of available content, ensuring Sonarr can pick up new episodes as they air.
       </p>
       <p className="ui-field-description mt-3 text-slate-400 leading-relaxed">
-        <span className="font-medium text-slate-200">Lookahead Range</span> sets how many episodes ahead of the one you
-        just watched Placeholdarr will monitor and search in Episode mode.
+        <span className="font-medium text-slate-200">Lookahead Range</span> applies to Episode and Season modes. In
+        Episode mode it sets how many episodes forward from the one you played are included. In Season mode it sets how
+        many episodes ahead before the next season is included.
       </p>
     </div>
   );
@@ -5396,6 +5399,32 @@ function PosterOverlayExamples(props: { selectedMode: string; compact?: boolean 
         </div>
       </div>
     </details>
+  );
+}
+
+/** Lookahead range: copy lives here; `EPISODES_LOOKAHEAD.description` in app_config is intentionally empty. */
+function EpisodesLookaheadDescription(props: { spacing: "settings" | "wizard"; tvPlayMode: string }) {
+  const top = props.spacing === "settings" ? "mt-1" : "mb-2";
+  const mode = String(props.tvPlayMode ?? "episode").trim().toLowerCase();
+  if (mode === "season") {
+    return (
+      <p className={`ui-field-description leading-relaxed ${top}`}>
+        In Season mode, how many episodes ahead of the one you played before Placeholdarr monitors and searches the next
+        season. Missing episodes in the current season are always included.
+      </p>
+    );
+  }
+  if (mode === "series") {
+    return (
+      <p className={`ui-field-description leading-relaxed ${top}`}>
+        Lookahead range applies to Episode and Season search modes. Series mode monitors the full show.
+      </p>
+    );
+  }
+  return (
+    <p className={`ui-field-description leading-relaxed ${top}`}>
+      In Episode mode, how many upcoming episodes without files to include forward from the played episode.
+    </p>
   );
 }
 
@@ -5918,7 +5947,7 @@ function SettingsPanel(props: {
     const statusUpdatesOff = String(props.values.PLACEHOLDER_STATUS_UPDATES ?? "").toUpperCase() === "OFF";
     const projectionFieldLocked = field.key === "PLACEHOLDER_STATUS_PROJECTION_MODE" && statusUpdatesOff;
     const tvPlayMode = String(props.values.TV_PLAY_MODE ?? "episode").trim().toLowerCase();
-    const lookaheadRangeLocked = field.key === "EPISODES_LOOKAHEAD" && tvPlayMode !== "episode";
+    const lookaheadRangeLocked = field.key === "EPISODES_LOOKAHEAD" && tvPlayMode === "series";
     const parentDisabled = settingsFieldParentDisabled(field, props.values);
     const rowMuted = projectionFieldLocked || lookaheadRangeLocked || parentDisabled;
     const isNested = settingsFieldIsNested(field);
@@ -5947,6 +5976,8 @@ function SettingsPanel(props: {
                 <PlaceholderPosterOverlayDescription spacing="settings" />
               ) : field.key === "ENABLE_COMING_SOON_COUNTDOWN" ? (
                 <ComingSoonCountdownDescription spacing="settings" />
+              ) : field.key === "EPISODES_LOOKAHEAD" ? (
+                <EpisodesLookaheadDescription spacing="settings" tvPlayMode={tvPlayMode} />
               ) : field.description && !isPlexSectionIdField(field.key) ? (
                 <p className="ui-field-description mt-1">{field.description}</p>
               ) : null)}
@@ -9178,7 +9209,7 @@ function OnboardingWizard(props: {
     const statusUpdatesOff = String(props.values.PLACEHOLDER_STATUS_UPDATES ?? "").toUpperCase() === "OFF";
     const projectionFieldLocked = field.key === "PLACEHOLDER_STATUS_PROJECTION_MODE" && statusUpdatesOff;
     const tvPlayMode = String(props.values.TV_PLAY_MODE ?? "episode").trim().toLowerCase();
-    const lookaheadRangeLocked = field.key === "EPISODES_LOOKAHEAD" && tvPlayMode !== "episode";
+    const lookaheadRangeLocked = field.key === "EPISODES_LOOKAHEAD" && tvPlayMode === "series";
     const parentDisabled = settingsFieldParentDisabled(field, props.values);
     const rowMuted = projectionFieldLocked || lookaheadRangeLocked || parentDisabled;
     const isNested = settingsFieldIsNested(field);
@@ -9198,6 +9229,8 @@ function OnboardingWizard(props: {
             <PlaceholderPosterOverlayDescription spacing="wizard" />
           ) : field.key === "ENABLE_COMING_SOON_COUNTDOWN" ? (
             <ComingSoonCountdownDescription spacing="wizard" />
+          ) : field.key === "EPISODES_LOOKAHEAD" ? (
+            <EpisodesLookaheadDescription spacing="wizard" tvPlayMode={tvPlayMode} />
           ) : field.description ? (
             <p className="ui-field-description mb-2 leading-relaxed">{field.description}</p>
           ) : null)}

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -17,6 +17,11 @@ import type {
   SettingsPayload,
   SettingsStatus,
   StatsResponse,
+  DeterminationExplainResponse,
+  ForcePlaceholderPreviewResponse,
+  ForcePlaceholderSetResponse,
+  PlaceholderPolicyPreviewResponse,
+  PlaceholderPolicySetResponse,
 } from "../types/api";
 
 export function getStats(): Promise<StatsResponse> {
@@ -194,6 +199,74 @@ export function refreshSeriesPlaceholder(seriesId: number): Promise<EntityReconc
   return fetchJson<EntityReconcileStartResponse>(`/api/library/series/${seriesId}/refresh-placeholder`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
+  });
+}
+
+export function getEpisodeDeterminationExplain(episodeId: number): Promise<DeterminationExplainResponse> {
+  return fetchJson<DeterminationExplainResponse>(`/api/library/episode/${episodeId}/determination-explain`);
+}
+
+export function getMovieDeterminationExplain(movieId: number): Promise<DeterminationExplainResponse> {
+  return fetchJson<DeterminationExplainResponse>(`/api/library/movie/${movieId}/determination-explain`);
+}
+
+export function getMovieForcePlaceholderPreview(movieId: number): Promise<ForcePlaceholderPreviewResponse> {
+  return fetchJson<ForcePlaceholderPreviewResponse>(`/api/library/movie/${movieId}/force-placeholder-preview`);
+}
+
+export function getEpisodeForcePlaceholderPreview(episodeId: number): Promise<ForcePlaceholderPreviewResponse> {
+  return fetchJson<ForcePlaceholderPreviewResponse>(`/api/library/episode/${episodeId}/force-placeholder-preview`);
+}
+
+export function setMovieForcePlaceholder(
+  movieId: number,
+  body: { enabled: boolean; despite_sibling: boolean },
+): Promise<ForcePlaceholderSetResponse> {
+  return fetchJson<ForcePlaceholderSetResponse>(`/api/library/movie/${movieId}/force-placeholder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function setEpisodeForcePlaceholder(
+  episodeId: number,
+  body: { enabled: boolean; despite_sibling: boolean },
+): Promise<ForcePlaceholderSetResponse> {
+  return fetchJson<ForcePlaceholderSetResponse>(`/api/library/episode/${episodeId}/force-placeholder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function getMoviePlaceholderPolicyPreview(movieId: number): Promise<PlaceholderPolicyPreviewResponse> {
+  return fetchJson<PlaceholderPolicyPreviewResponse>(`/api/library/movie/${movieId}/placeholder-policy-preview`);
+}
+
+export function getEpisodePlaceholderPolicyPreview(episodeId: number): Promise<PlaceholderPolicyPreviewResponse> {
+  return fetchJson<PlaceholderPolicyPreviewResponse>(`/api/library/episode/${episodeId}/placeholder-policy-preview`);
+}
+
+export function setMoviePlaceholderPolicy(
+  movieId: number,
+  body: { policy: "auto" | "never" | "pinned" },
+): Promise<PlaceholderPolicySetResponse> {
+  return fetchJson<PlaceholderPolicySetResponse>(`/api/library/movie/${movieId}/placeholder-policy`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function setEpisodePlaceholderPolicy(
+  episodeId: number,
+  body: { policy: "auto" | "never" | "pinned" },
+): Promise<PlaceholderPolicySetResponse> {
+  return fetchJson<PlaceholderPolicySetResponse>(`/api/library/episode/${episodeId}/placeholder-policy`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
   });
 }
 

--- a/frontend/src/collections/CollectionEditor.tsx
+++ b/frontend/src/collections/CollectionEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { ThemeMode } from "../brandTypes";
 import { FG_ON_ACCENT_TEXT_CLASS, accentFilledStyle } from "../brandAccentUi";
+import { ExplainStatusIcon } from "../components/explain/ExplainStatusIcon";
 import {
   checkCollectionTitleConflicts,
   explainCollectionItem,
@@ -769,28 +770,6 @@ function ExplainTreeNodeView(props: { node: CollectionExplainNode }) {
         ))}
       </div>
     </div>
-  );
-}
-
-function ExplainStatusIcon(props: { status: "pass" | "fail" | "skip" }) {
-  if (props.status === "pass") {
-    return (
-      <span className="material-symbols-outlined text-emerald-400" style={{ fontSize: 16 }}>
-        check_circle
-      </span>
-    );
-  }
-  if (props.status === "fail") {
-    return (
-      <span className="material-symbols-outlined text-red-400" style={{ fontSize: 16 }}>
-        cancel
-      </span>
-    );
-  }
-  return (
-    <span className="material-symbols-outlined text-slate-600" style={{ fontSize: 16 }}>
-      radio_button_unchecked
-    </span>
   );
 }
 

--- a/frontend/src/components/explain/ExplainStatusIcon.tsx
+++ b/frontend/src/components/explain/ExplainStatusIcon.tsx
@@ -1,0 +1,28 @@
+export function ExplainStatusIcon(props: { status: "pass" | "fail" | "skip" | "applied" }) {
+  if (props.status === "pass") {
+    return (
+      <span className="material-symbols-outlined text-emerald-400" style={{ fontSize: 16 }}>
+        check_circle
+      </span>
+    );
+  }
+  if (props.status === "fail") {
+    return (
+      <span className="material-symbols-outlined text-red-400" style={{ fontSize: 16 }}>
+        cancel
+      </span>
+    );
+  }
+  if (props.status === "applied") {
+    return (
+      <span className="material-symbols-outlined text-amber-400" style={{ fontSize: 16 }}>
+        change_circle
+      </span>
+    );
+  }
+  return (
+    <span className="material-symbols-outlined text-slate-600" style={{ fontSize: 16 }}>
+      radio_button_unchecked
+    </span>
+  );
+}

--- a/frontend/src/library/detail/DetailFactCard.tsx
+++ b/frontend/src/library/detail/DetailFactCard.tsx
@@ -22,6 +22,7 @@ export function DetailFactRow(props: {
   value?: string | null;
   href?: string | null;
   themeMode: ThemeMode;
+  action?: ReactNode;
 }) {
   const isLight = props.themeMode === "light";
   const display = props.value?.trim() || "—";
@@ -32,18 +33,21 @@ export function DetailFactRow(props: {
       <span className="shrink-0 text-[12px] font-headline uppercase tracking-wider text-slate-500">
         {props.label}
       </span>
-      {props.href ? (
-        <a
-          href={props.href}
-          target="_blank"
-          rel="noreferrer"
-          className={`${valueClass} hover:underline`}
-        >
-          {display}
-        </a>
-      ) : (
-        <span className={valueClass}>{display}</span>
-      )}
+      <div className="flex items-start justify-end gap-2 min-w-0">
+        {props.href ? (
+          <a
+            href={props.href}
+            target="_blank"
+            rel="noreferrer"
+            className={`${valueClass} hover:underline`}
+          >
+            {display}
+          </a>
+        ) : (
+          <span className={valueClass}>{display}</span>
+        )}
+        {props.action}
+      </div>
     </div>
   );
 }

--- a/frontend/src/library/detail/DetailMetaStrip.tsx
+++ b/frontend/src/library/detail/DetailMetaStrip.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import type { ThemeMode } from "../../brandTypes";
 import { FG_ON_ACCENT_TEXT_CLASS, accentFilledStyle } from "../../brandAccentUi";
 import type { DetailRatingDisplay } from "./detailFormatters";
@@ -150,6 +150,8 @@ export function DetailMetaStrip(props: {
   tmdbTvId?: number | null;
   accentHex: string;
   themeMode: ThemeMode;
+  /** Pin control; rendered on row 2 left. */
+  policyControl?: ReactNode;
 }) {
   void props.is4k;
   void props.monitored;
@@ -186,53 +188,77 @@ export function DetailMetaStrip(props: {
   }
 
   const trailerHref = youtubeTrailerUrl(props.trailerUrl);
-  const valueClass = (soft?: boolean) =>
-    `text-[26px] sm:text-[28px] font-headline font-bold leading-none tabular-nums ${
-      soft
-        ? isLight
-          ? "text-slate-500"
-          : "text-slate-400"
-        : isLight
-          ? "text-slate-900"
-          : "text-white"
-    }`;
+  const showActionsRow = Boolean(props.policyControl) || Boolean(trailerHref);
 
   return (
     <div
       className={`rounded-xl border px-6 py-6 mb-6 ${isLight ? "bg-white border-[#d7e2f0]" : "bg-[#171c22] border-[#424753]/40"}`}
     >
-      <div className="flex flex-wrap items-end justify-between gap-x-8 gap-y-5">
-        <div className="flex flex-wrap items-end gap-x-8 gap-y-5 min-w-0">
+      {/* Row 1: facts only. Scale down instead of wrapping under trailer/pin. */}
+      {facts.length ? (
+        <div
+          className="flex flex-nowrap items-end gap-x-6 sm:gap-x-8 min-w-0 overflow-hidden"
+          style={{ containerType: "inline-size" }}
+        >
           {facts.map((fact) => (
-            <div key={fact.key} className="min-w-[4.5rem]">
+            <div key={fact.key} className="min-w-0 shrink">
               {fact.logoUrl ? (
                 <img
                   src={fact.logoUrl}
                   alt={fact.value}
-                  className="h-8 w-auto max-w-[100px] object-contain object-left"
+                  className="h-7 sm:h-8 w-auto max-w-[100px] object-contain object-left"
                 />
               ) : (
-                <div className={valueClass(fact.soft)}>{fact.value}</div>
+                <div
+                  className={`font-headline font-bold leading-none tabular-nums truncate ${
+                    fact.soft
+                      ? isLight
+                        ? "text-slate-500"
+                        : "text-slate-400"
+                      : isLight
+                        ? "text-slate-900"
+                        : "text-white"
+                  }`}
+                  style={{ fontSize: "clamp(1.125rem, 2.6cqi + 0.65rem, 1.75rem)" }}
+                  title={fact.value}
+                >
+                  {fact.value}
+                </div>
               )}
-              <div className="mt-1.5 text-[13px] font-headline uppercase tracking-wider text-slate-500">
+              <div className="mt-1.5 text-[11px] sm:text-[13px] font-headline uppercase tracking-wider text-slate-500">
                 {fact.label}
               </div>
             </div>
           ))}
         </div>
-        {trailerHref ? (
-          <a
-            href={trailerHref}
-            target="_blank"
-            rel="noreferrer"
-            className={`inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-[14px] font-headline uppercase tracking-wider shrink-0 ${FG_ON_ACCENT_TEXT_CLASS}`}
-            style={accentFilledStyle(props.accentHex)}
-          >
-            <span className="material-symbols-outlined" style={{ fontSize: 18 }}>play_circle</span>
-            Trailer
-          </a>
-        ) : null}
-      </div>
+      ) : null}
+
+      {/* Row 2: pin left, trailer right. */}
+      {showActionsRow ? (
+        <div
+          className={`flex flex-nowrap items-center justify-between gap-4 ${
+            facts.length ? "mt-5" : ""
+          }`}
+        >
+          <div className="min-w-0 shrink">{props.policyControl}</div>
+          {trailerHref ? (
+            <a
+              href={trailerHref}
+              target="_blank"
+              rel="noreferrer"
+              className={`inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-[14px] font-headline uppercase tracking-wider shrink-0 ${FG_ON_ACCENT_TEXT_CLASS}`}
+              style={accentFilledStyle(props.accentHex)}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: 18 }}>
+                play_circle
+              </span>
+              Trailer
+            </a>
+          ) : (
+            <span />
+          )}
+        </div>
+      ) : null}
 
       {ratings.length ? (
         <div className={`mt-5 pt-5 border-t ${isLight ? "border-slate-200" : "border-[#424753]/40"}`}>

--- a/frontend/src/library/detail/DetailRoutePage.tsx
+++ b/frontend/src/library/detail/DetailRoutePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   getMovieDetail,
@@ -52,9 +52,8 @@ export function DetailRoutePage(props: {
     window.scrollTo(0, 0);
   }, [loading, props.scrollContainerRef]);
 
-  useEffect(() => {
-    let stopped = false;
-    async function load() {
+  const reloadDetail = useCallback(
+    async (opts?: { silent?: boolean }) => {
       if (!entityType || !itemId) return;
       const numericId = Number(itemId);
       if (!Number.isFinite(numericId) || numericId <= 0) {
@@ -63,43 +62,53 @@ export function DetailRoutePage(props: {
         setError("Invalid library item");
         return;
       }
-      setLoading(true);
+      if (!opts?.silent) {
+        setLoading(true);
+      }
       setError(null);
       try {
         if (entityType === "movie") {
           const result = await getMovieDetail(numericId);
-          if (result.ok && !stopped) {
+          if (result.ok) {
             setPayload(result);
-          } else if (!stopped && !result.ok) {
+          } else {
             const msg = (result as { message?: unknown }).message;
             setError(typeof msg === "string" && msg.trim() ? msg : "Movie not found");
-          } else if (!stopped) {
-            setError("Movie not found");
           }
         } else if (entityType === "series") {
           const result = await getSeriesDetail(numericId);
-          if (result.ok && result.type === "series" && !stopped) {
+          if (result.ok && result.type === "series") {
             setPayload(result);
-          } else if (!stopped && !result.ok) {
+          } else if (!result.ok) {
             const msg = (result as { message?: unknown }).message;
             setError(typeof msg === "string" && msg.trim() ? msg : "Series not found");
-          } else if (!stopped) {
+          } else {
             setError("Series not found");
           }
-        } else if (!stopped) {
+        } else {
           setError("Unsupported detail type");
         }
       } catch (err) {
-        if (!stopped) setError(err instanceof Error ? err.message : "Failed to load detail");
+        setError(err instanceof Error ? err.message : "Failed to load detail");
       } finally {
-        if (!stopped) setLoading(false);
+        if (!opts?.silent) {
+          setLoading(false);
+        }
       }
-    }
-    void load();
+    },
+    [entityType, itemId],
+  );
+
+  useEffect(() => {
+    let stopped = false;
+    void (async () => {
+      if (stopped) return;
+      await reloadDetail();
+    })();
     return () => {
       stopped = true;
     };
-  }, [entityType, itemId]);
+  }, [reloadDetail]);
 
   return (
     <div className={`min-h-screen ${isLight ? "bg-[#eef3f8]" : "bg-[#0f1419]"}`}>
@@ -150,6 +159,9 @@ export function DetailRoutePage(props: {
             brand={props.brand}
             themeMode={props.themeMode}
             accent={accent}
+            onPolicyApplied={() => {
+              void reloadDetail({ silent: true });
+            }}
           />
           <div className="px-6 md:px-10 lg:px-12 pb-10 -mt-2">
             <LibraryReconcileControl
@@ -166,6 +178,9 @@ export function DetailRoutePage(props: {
             brand={props.brand}
             themeMode={props.themeMode}
             accent={accent}
+            onPolicyApplied={() => {
+              void reloadDetail({ silent: true });
+            }}
           />
           <div className="px-6 md:px-10 lg:px-12 pb-10 -mt-2">
             <LibraryReconcileControl

--- a/frontend/src/library/detail/DeterminationExplainModal.tsx
+++ b/frontend/src/library/detail/DeterminationExplainModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from "react";
+import type { ThemeMode } from "../../brandTypes";
+import type { DeterminationExplainResponse } from "../../types/api";
+import { ExplainStatusIcon } from "../../components/explain/ExplainStatusIcon";
+import { formatDeterminationLabel } from "./detailFormatters";
+
+function modalTitleForDetermination(determination: string | null | undefined): string {
+  const label = formatDeterminationLabel(determination);
+  if (!label || label === "—") return "Why this determination?";
+  return `Why ${label}?`;
+}
+
+export function DeterminationExplainModal(props: {
+  open: boolean;
+  onClose: () => void;
+  result: DeterminationExplainResponse | null;
+  loading: boolean;
+  error: string | null;
+  determination?: string | null;
+  themeMode: ThemeMode;
+}) {
+  const isLight = props.themeMode === "light";
+
+  useEffect(() => {
+    if (!props.open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") props.onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [props.open, props.onClose]);
+
+  if (!props.open) return null;
+
+  const title = modalTitleForDetermination(props.determination ?? props.result?.determination);
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) props.onClose();
+      }}
+    >
+      <div
+        className={`w-full max-w-lg rounded-lg border shadow-lg shadow-black/15 overflow-hidden ${
+          isLight ? "border-slate-200 bg-white" : "border-[#424753]/40 bg-[#171c22]"
+        }`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="determination-explain-title"
+      >
+        <div className={`px-5 py-4 border-b ${isLight ? "border-slate-200" : "border-[#424753]/30"}`}>
+          <h3
+            id="determination-explain-title"
+            className={`text-[18px] font-bold font-headline ${isLight ? "text-slate-900" : "text-white"}`}
+          >
+            {title}
+          </h3>
+          {props.result?.title ? (
+            <p className={`mt-1 text-[14px] ${isLight ? "text-slate-600" : "text-slate-400"}`}>
+              {props.result.title}
+            </p>
+          ) : null}
+          {props.result?.summary ? (
+            <p className={`mt-2 text-[14px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-300"}`}>
+              {props.result.summary}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="px-5 py-4 max-h-[min(60vh,420px)] overflow-y-auto">
+          {props.loading ? (
+            <p className={`text-[14px] ${isLight ? "text-slate-500" : "text-slate-400"}`}>Loading…</p>
+          ) : null}
+          {props.error ? <p className="text-[14px] text-red-400">{props.error}</p> : null}
+          {props.result ? (
+            <div className="flex flex-col gap-2">
+              {props.result.steps.map((step) => {
+                const highlighted = step.key === props.result?.deciding_step_key;
+                return (
+                  <div
+                    key={step.key}
+                    className={`rounded-lg border px-3 py-2 ${
+                      highlighted
+                        ? isLight
+                          ? "border-sky-200 bg-sky-50"
+                          : "border-sky-500/30 bg-sky-500/10"
+                        : isLight
+                          ? "border-slate-200 bg-slate-50"
+                          : "border-[#424753]/40 bg-[#1e2430]/40"
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <ExplainStatusIcon status={step.status} />
+                      <div className="min-w-0 flex-1">
+                        <div
+                          className={`text-[13px] font-medium ${
+                            isLight ? "text-slate-800" : "text-slate-200"
+                          }`}
+                        >
+                          {step.label}
+                        </div>
+                        {step.detail ? (
+                          <p className={`mt-0.5 text-[12px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-400"}`}>
+                            {step.detail}
+                          </p>
+                        ) : null}
+                        {step.outcome ? (
+                          <p className={`mt-1 text-[11px] font-headline uppercase tracking-wider ${isLight ? "text-slate-500" : "text-slate-500"}`}>
+                            Outcome: {formatDeterminationLabel(step.outcome)}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          className={`px-5 py-4 flex justify-end border-t ${
+            isLight ? "border-slate-200" : "border-[#424753]/30"
+          }`}
+        >
+          <button
+            type="button"
+            onClick={props.onClose}
+            className={`text-[14px] font-headline uppercase tracking-wider ${
+              isLight ? "text-slate-500 hover:text-slate-900" : "text-slate-400 hover:text-slate-200"
+            }`}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/library/detail/DeterminationWhyLink.tsx
+++ b/frontend/src/library/detail/DeterminationWhyLink.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { ThemeMode } from "../../brandTypes";
+import type { DeterminationExplainResponse } from "../../types/api";
+import { getEpisodeDeterminationExplain, getMovieDeterminationExplain } from "../../api/dashboard";
+import { DeterminationExplainModal } from "./DeterminationExplainModal";
+
+export function DeterminationWhyLink(props: {
+  mediaType: "movie" | "episode";
+  entityId: number;
+  determination?: string | null;
+  themeMode: ThemeMode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DeterminationExplainResponse | null>(null);
+  const isLight = props.themeMode === "light";
+
+  const openModal = () => {
+    setOpen(true);
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    const fetcher =
+      props.mediaType === "movie"
+        ? () => getMovieDeterminationExplain(props.entityId)
+        : () => getEpisodeDeterminationExplain(props.entityId);
+    void fetcher()
+      .then((payload) => {
+        setResult(payload);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Could not load explanation");
+        setLoading(false);
+      });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        className={`shrink-0 text-[11px] font-headline uppercase tracking-wider ${
+          isLight ? "text-slate-500 hover:text-sky-700" : "text-slate-500 hover:text-sky-300"
+        }`}
+      >
+        Why?
+      </button>
+      <DeterminationExplainModal
+        open={open}
+        onClose={() => setOpen(false)}
+        result={result}
+        loading={loading}
+        error={error}
+        determination={props.determination}
+        themeMode={props.themeMode}
+      />
+    </>
+  );
+}

--- a/frontend/src/library/detail/EpisodeRow.tsx
+++ b/frontend/src/library/detail/EpisodeRow.tsx
@@ -2,16 +2,34 @@ import { useState, type ReactNode } from "react";
 import type { ThemeMode } from "../../brandTypes";
 import type { SeriesEpisodeDetail } from "../../types/api";
 import { detailMutedChipClass, detailStatusChipClass } from "./detailFormatters";
+import { DeterminationWhyLink } from "./DeterminationWhyLink";
+import { PlaceholderPolicyCycle, type PolicySyncPhase } from "./PlaceholderPolicyCycle";
 
 export function EpisodeRow(props: {
   episode: SeriesEpisodeDetail;
   themeMode: ThemeMode;
+  accentHex: string;
   refreshControl?: ReactNode;
+  onPolicyApplied?: () => void;
 }) {
   const isLight = props.themeMode === "light";
   const ep = props.episode;
   const [open, setOpen] = useState(false);
+  const [policyPhase, setPolicyPhase] = useState<PolicySyncPhase>("idle");
   const hasOverview = Boolean(ep.overview?.trim());
+
+  let statusChip: ReactNode;
+  if (policyPhase === "creating") {
+    statusChip = <span className={detailStatusChipClass(isLight, "placeholder")}>Creating…</span>;
+  } else if (policyPhase === "removing") {
+    statusChip = <span className={detailStatusChipClass(isLight, "missing")}>Removing…</span>;
+  } else if (ep.has_placeholder) {
+    statusChip = <span className={detailStatusChipClass(isLight, "placeholder")}>Placeholder</span>;
+  } else if (ep.has_file) {
+    statusChip = <span className={detailStatusChipClass(isLight, "file")}>Downloaded</span>;
+  } else {
+    statusChip = <span className={detailStatusChipClass(isLight, "missing")}>Missing</span>;
+  }
 
   return (
     <div className={`border-t ${isLight ? "border-slate-200" : "border-[#424753]/15"}`}>
@@ -19,7 +37,9 @@ export function EpisodeRow(props: {
         <div className="flex-none w-16 h-10 rounded overflow-hidden bg-[#1e2430] border border-[#424753]/40">
           {ep.still_url ? <img src={ep.still_url} alt="" className="w-full h-full object-cover" /> : null}
         </div>
-        <span className="flex-none w-8 text-[14px] text-slate-500 font-mono pt-0.5">E{String(ep.episode_number).padStart(2, "0")}</span>
+        <span className="flex-none w-8 text-[14px] text-slate-500 font-mono pt-0.5">
+          E{String(ep.episode_number).padStart(2, "0")}
+        </span>
         <div className="flex-1 min-w-0">
           <button
             type="button"
@@ -33,23 +53,42 @@ export function EpisodeRow(props: {
             <div className="ui-field-description-compact mt-0.5">{ep.air_date || "No air date"}</div>
           </button>
           {open && ep.overview ? (
-            <p className={`mt-2 text-[14px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-400"}`}>{ep.overview}</p>
+            <p className={`mt-2 text-[14px] leading-relaxed ${isLight ? "text-slate-600" : "text-slate-400"}`}>
+              {ep.overview}
+            </p>
           ) : null}
         </div>
         <div className="flex flex-col items-end gap-1 flex-none">
-          {ep.sonarr_quality ? (
-            <span className={detailMutedChipClass(isLight)}>
-              {ep.sonarr_quality}
-            </span>
-          ) : null}
-          {ep.has_placeholder
-            ? <span className={detailStatusChipClass(isLight, "placeholder")}>Placeholder</span>
-            : ep.has_file
-              ? <span className={detailStatusChipClass(isLight, "file")}>Downloaded</span>
-              : <span className={detailStatusChipClass(isLight, "missing")}>Missing</span>}
+          {ep.sonarr_quality ? <span className={detailMutedChipClass(isLight)}>{ep.sonarr_quality}</span> : null}
+          {statusChip}
           {ep.sonarr_monitored === false ? (
             <span className="text-[10px] uppercase tracking-wider text-slate-500">Unmonitored</span>
           ) : null}
+          <div className="flex items-center gap-2">
+            {ep.determination ? (
+              <DeterminationWhyLink
+                mediaType="episode"
+                entityId={ep.id}
+                determination={ep.determination}
+                themeMode={props.themeMode}
+              />
+            ) : null}
+            <PlaceholderPolicyCycle
+              mediaType="episode"
+              entityId={ep.id}
+              placeholderPolicy={ep.placeholder_policy}
+              forcePlaceholder={ep.force_placeholder}
+              blockPlaceholder={ep.block_placeholder}
+              hasPlaceholder={ep.has_placeholder}
+              hasFile={ep.has_file}
+              accentHex={props.accentHex}
+              themeMode={props.themeMode}
+              size="sm"
+              showInlineProgress={false}
+              onPhaseChange={setPolicyPhase}
+              onApplied={props.onPolicyApplied}
+            />
+          </div>
           {props.refreshControl}
         </div>
       </div>

--- a/frontend/src/library/detail/MovieDetailView.tsx
+++ b/frontend/src/library/detail/MovieDetailView.tsx
@@ -5,6 +5,8 @@ import { DetailFactCard, DetailFactRow } from "./DetailFactCard";
 import { DetailHero } from "./DetailHero";
 import { DetailMetaStrip } from "./DetailMetaStrip";
 import { MovieFileStateSection } from "./FileStateSections";
+import { DeterminationWhyLink } from "./DeterminationWhyLink";
+import { PlaceholderPolicyCycle } from "./PlaceholderPolicyCycle";
 import {
   formatDeterminationLabel,
   formatDisplayStatusLabel,
@@ -19,6 +21,7 @@ export function MovieDetailView(props: {
   brand: Brand;
   themeMode: ThemeMode;
   accent: { hex: string; icon: string; label: string };
+  onPolicyApplied?: () => void;
 }) {
   const payload = props.payload;
   const isLight = props.themeMode === "light";
@@ -54,6 +57,21 @@ export function MovieDetailView(props: {
           tmdbid={payload.tmdbid}
           accentHex={props.accent.hex}
           themeMode={props.themeMode}
+          policyControl={
+            <PlaceholderPolicyCycle
+              mediaType="movie"
+              entityId={payload.id}
+              placeholderPolicy={payload.placeholder_policy}
+              forcePlaceholder={payload.force_placeholder}
+              blockPlaceholder={payload.block_placeholder}
+              hasPlaceholder={payload.has_placeholder}
+              hasFile={payload.has_file}
+              accentHex={props.accent.hex}
+              themeMode={props.themeMode}
+              showInlineProgress
+              onApplied={props.onPolicyApplied}
+            />
+          }
         />
 
         <MovieFileStateSection
@@ -117,7 +135,19 @@ export function MovieDetailView(props: {
                 <DetailFactRow label="Radarr ID" value={payload.radarr_id != null ? String(payload.radarr_id) : null} themeMode={props.themeMode} />
               </DetailFactCard>
               <DetailFactCard title="Placeholdarr" themeMode={props.themeMode}>
-                <DetailFactRow label="Determination" value={formatDeterminationLabel(payload.determination)} themeMode={props.themeMode} />
+                <DetailFactRow
+                  label="Determination"
+                  value={formatDeterminationLabel(payload.determination)}
+                  themeMode={props.themeMode}
+                  action={
+                    <DeterminationWhyLink
+                      mediaType="movie"
+                      entityId={payload.id}
+                      determination={payload.determination}
+                      themeMode={props.themeMode}
+                    />
+                  }
+                />
                 <DetailFactRow label="Status" value={formatDisplayStatusLabel(payload.display_status)} themeMode={props.themeMode} />
                 <DetailFactRow label="Placeholder path" value={payload.placeholder_filepath} themeMode={props.themeMode} />
                 <DetailFactRow label="Last search" value={payload.last_search} themeMode={props.themeMode} />

--- a/frontend/src/library/detail/PinGlyph.tsx
+++ b/frontend/src/library/detail/PinGlyph.tsx
@@ -1,0 +1,33 @@
+import type { ThemeMode } from "../../brandTypes";
+
+export type PlaceholderPolicy = "auto" | "never" | "pinned";
+
+export function PinGlyph(props: {
+  policy: PlaceholderPolicy;
+  size?: number;
+  accentHex: string;
+  themeMode: ThemeMode;
+}) {
+  const size = props.size ?? 18;
+  const isLight = props.themeMode === "light";
+  const muted = isLight ? "#64748b" : "#94a3b8";
+  const danger = isLight ? "#b91c1c" : "#f87171";
+  const stroke =
+    props.policy === "never" ? danger : props.policy === "pinned" ? props.accentHex : muted;
+  const fill = props.policy === "auto" ? "none" : stroke;
+
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <path
+        d="M12 2c1.8 0 3.2 1.4 3.2 3.1 0 .7-.2 1.3-.6 1.8l1.7 1.7c.8.8.8 2 0 2.8l-.7.7-2.1-2.1-.4.4V19l-1.1 3-1.1-3v-8.6l-.4-.4-2.1 2.1-.7-.7c-.8-.8-.8-2 0-2.8l1.7-1.7c-.4-.5-.6-1.1-.6-1.8C8.8 3.4 10.2 2 12 2z"
+        fill={fill}
+        stroke={stroke}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      {props.policy === "never" ? (
+        <line x1="4" y1="4" x2="20" y2="20" stroke={danger} strokeWidth="2" />
+      ) : null}
+    </svg>
+  );
+}

--- a/frontend/src/library/detail/PlaceholderPolicyCycle.tsx
+++ b/frontend/src/library/detail/PlaceholderPolicyCycle.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ThemeMode } from "../../brandTypes";
+import {
+  getEntityReconcileStatus,
+  setEpisodePlaceholderPolicy,
+  setMoviePlaceholderPolicy,
+} from "../../api/dashboard";
+import { PinGlyph, type PlaceholderPolicy } from "./PinGlyph";
+import {
+  nextPlaceholderPolicy,
+  POLICY_LABEL,
+  POLICY_TOOLTIP,
+  policyFromFlags,
+} from "./placeholderPolicyUtils";
+
+/** Pause after last click before save so Auto → Never → Pinned can settle. */
+const APPLY_DEBOUNCE_MS = 1100;
+
+export type PolicySyncPhase = "idle" | "creating" | "removing" | "working" | "saved";
+
+async function waitForReconcileJob(jobId: number): Promise<void> {
+  for (let i = 0; i < 80; i += 1) {
+    const status = await getEntityReconcileStatus(jobId);
+    if (status.status === "done") return;
+    if (status.status === "failed") {
+      throw new Error(status.error_message || "Sync failed");
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 1000));
+  }
+  throw new Error("Timed out waiting for placeholder sync");
+}
+
+function phaseForPolicy(
+  policy: PlaceholderPolicy,
+  hasPlaceholder: boolean,
+  hasFile: boolean,
+): PolicySyncPhase {
+  if (hasFile) return "working";
+  if (policy === "never" && hasPlaceholder) return "removing";
+  if (policy === "pinned" && !hasPlaceholder) return "creating";
+  return "working";
+}
+
+export function PlaceholderPolicyCycle(props: {
+  mediaType: "movie" | "episode";
+  entityId: number;
+  placeholderPolicy?: PlaceholderPolicy | null;
+  forcePlaceholder?: boolean;
+  blockPlaceholder?: boolean;
+  hasPlaceholder?: boolean;
+  hasFile?: boolean;
+  accentHex: string;
+  themeMode: ThemeMode;
+  size?: "sm" | "md";
+  /** When true, show Creating…/Removing… beside the pin (movie meta). Episodes use onPhaseChange. */
+  showInlineProgress?: boolean;
+  onPhaseChange?: (phase: PolicySyncPhase) => void;
+  onApplied?: () => void;
+}) {
+  const isLight = props.themeMode === "light";
+  const size = props.size ?? "md";
+  const hasPlaceholder = Boolean(props.hasPlaceholder);
+  const hasFile = Boolean(props.hasFile);
+  const serverPolicy = policyFromFlags(
+    props.forcePlaceholder,
+    props.blockPlaceholder,
+    props.placeholderPolicy,
+  );
+
+  const [displayPolicy, setDisplayPolicy] = useState<PlaceholderPolicy>(serverPolicy);
+  const [phase, setPhase] = useState<PolicySyncPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const generationRef = useRef(0);
+  const displayPolicyRef = useRef<PlaceholderPolicy>(serverPolicy);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const updatePhase = useCallback(
+    (next: PolicySyncPhase) => {
+      setPhase(next);
+      props.onPhaseChange?.(next);
+    },
+    [props.onPhaseChange],
+  );
+
+  useEffect(() => {
+    setDisplayPolicy(serverPolicy);
+    displayPolicyRef.current = serverPolicy;
+  }, [serverPolicy]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, []);
+
+  const savePolicy = useCallback(
+    async (policy: PlaceholderPolicy) => {
+      const gen = ++generationRef.current;
+      updatePhase(phaseForPolicy(policy, hasPlaceholder, hasFile));
+      setError(null);
+      try {
+        const setter =
+          props.mediaType === "movie" ? setMoviePlaceholderPolicy : setEpisodePlaceholderPolicy;
+        const out = await setter(props.entityId, { policy });
+        if (gen !== generationRef.current) return;
+        if (!out.ok) {
+          throw new Error(out.message || "Failed to update placeholder policy");
+        }
+        if (out.job_id != null) {
+          await waitForReconcileJob(out.job_id);
+        }
+        if (gen !== generationRef.current) return;
+        if (out.followup_job_id != null) {
+          await waitForReconcileJob(out.followup_job_id);
+        }
+        if (gen !== generationRef.current) return;
+        updatePhase("saved");
+        if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = setTimeout(() => updatePhase("idle"), 1500);
+        props.onApplied?.();
+      } catch (err) {
+        if (gen !== generationRef.current) return;
+        updatePhase("idle");
+        setDisplayPolicy(serverPolicy);
+        displayPolicyRef.current = serverPolicy;
+        setError(err instanceof Error ? err.message : "Failed to update placeholder policy");
+      }
+    },
+    [
+      props.mediaType,
+      props.entityId,
+      props.onApplied,
+      serverPolicy,
+      hasPlaceholder,
+      hasFile,
+      updatePhase,
+    ],
+  );
+
+  const commitPolicy = useCallback(
+    async (policy: PlaceholderPolicy) => {
+      if (policy !== displayPolicyRef.current) return;
+      if (policy === serverPolicy) {
+        updatePhase("idle");
+        return;
+      }
+      await savePolicy(policy);
+    },
+    [savePolicy, serverPolicy, updatePhase],
+  );
+
+  const cycle = () => {
+    // Latest click wins: abandon any in-flight wait so a mid-sync flip can settle.
+    if (phase === "creating" || phase === "removing" || phase === "working") {
+      generationRef.current += 1;
+      updatePhase("idle");
+    }
+    const next = nextPlaceholderPolicy(displayPolicyRef.current);
+    displayPolicyRef.current = next;
+    setDisplayPolicy(next);
+    setError(null);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void commitPolicy(next);
+    }, APPLY_DEBOUNCE_MS);
+  };
+
+  const pad = size === "sm" ? "px-2 py-0.5" : "px-2.5 py-1";
+  const glyphSize = size === "sm" ? 16 : 18;
+  const textSize = size === "sm" ? "text-[10px]" : "text-[11px]";
+
+  let chipStyle: { borderColor?: string; color?: string; backgroundColor?: string } | undefined;
+  if (displayPolicy === "never") {
+    const danger = isLight ? "#b91c1c" : "#f87171";
+    chipStyle = {
+      borderColor: `${danger}66`,
+      color: danger,
+      backgroundColor: isLight ? "#fef2f2" : "rgba(248,113,113,0.12)",
+    };
+  } else if (displayPolicy === "pinned") {
+    chipStyle = {
+      borderColor: `${props.accentHex}66`,
+      color: props.accentHex,
+      backgroundColor: isLight ? `${props.accentHex}12` : `${props.accentHex}18`,
+    };
+  }
+
+  const busy = phase === "creating" || phase === "removing" || phase === "working";
+  const inlineLabel =
+    props.showInlineProgress === false
+      ? null
+      : phase === "creating"
+        ? "Creating…"
+        : phase === "removing"
+          ? "Removing…"
+          : phase === "working"
+            ? "Saving…"
+            : phase === "saved"
+              ? "Saved"
+              : null;
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={cycle}
+          className={`inline-flex items-center gap-1.5 rounded-full border ${pad} ${textSize} font-headline uppercase tracking-wider cursor-pointer ${
+            displayPolicy === "auto"
+              ? isLight
+                ? "border-slate-200 text-slate-600 bg-white"
+                : "border-[#424753]/50 text-slate-400 bg-transparent"
+              : ""
+          } ${busy ? "opacity-90" : ""}`}
+          style={displayPolicy !== "auto" ? chipStyle : undefined}
+          title={POLICY_TOOLTIP[displayPolicy]}
+        >
+          <PinGlyph
+            policy={displayPolicy}
+            size={glyphSize}
+            accentHex={props.accentHex}
+            themeMode={props.themeMode}
+          />
+          {POLICY_LABEL[displayPolicy]}
+        </button>
+        {inlineLabel ? (
+          <span
+            className={`${textSize} font-headline uppercase tracking-wider text-slate-500`}
+            aria-live="polite"
+          >
+            {inlineLabel}
+          </span>
+        ) : null}
+      </div>
+      {error ? <p className="text-[11px] text-red-400 max-w-[16rem]">{error}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/library/detail/SeriesDetailView.tsx
+++ b/frontend/src/library/detail/SeriesDetailView.tsx
@@ -21,6 +21,7 @@ export function SeriesDetailView(props: {
   brand: Brand;
   themeMode: ThemeMode;
   accent: { hex: string; icon: string; label: string };
+  onPolicyApplied?: () => void;
 }) {
   const payload = props.payload;
   const isLight = props.themeMode === "light";
@@ -175,6 +176,8 @@ export function SeriesDetailView(props: {
                             key={ep.id}
                             episode={ep}
                             themeMode={props.themeMode}
+                            accentHex={props.accent.hex}
+                            onPolicyApplied={props.onPolicyApplied}
                             refreshControl={
                               <LibraryReconcileControl
                                 label="Refresh"

--- a/frontend/src/library/detail/placeholderPolicyUtils.ts
+++ b/frontend/src/library/detail/placeholderPolicyUtils.ts
@@ -1,0 +1,33 @@
+import type { PlaceholderPolicy } from "./PinGlyph";
+
+export const POLICY_LABEL: Record<PlaceholderPolicy, string> = {
+  auto: "Auto",
+  never: "Never",
+  pinned: "Pinned",
+};
+
+export const POLICY_TOOLTIP: Record<PlaceholderPolicy, string> = {
+  auto: "Auto: follow Placeholdarr settings",
+  never: "Never create a placeholder. Does not remove real files on disk.",
+  pinned: "Pin placeholder creation. Does not apply when a real file is on disk.",
+};
+
+const CYCLE_ORDER: PlaceholderPolicy[] = ["auto", "never", "pinned"];
+
+export function nextPlaceholderPolicy(current: PlaceholderPolicy): PlaceholderPolicy {
+  const index = CYCLE_ORDER.indexOf(current);
+  return CYCLE_ORDER[(index + 1) % CYCLE_ORDER.length];
+}
+
+export function policyFromFlags(
+  forcePlaceholder?: boolean,
+  blockPlaceholder?: boolean,
+  placeholderPolicy?: PlaceholderPolicy | null,
+): PlaceholderPolicy {
+  if (placeholderPolicy === "auto" || placeholderPolicy === "never" || placeholderPolicy === "pinned") {
+    return placeholderPolicy;
+  }
+  if (forcePlaceholder) return "pinned";
+  if (blockPlaceholder) return "never";
+  return "auto";
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -285,6 +285,10 @@ export interface MovieDetailResponse {
   /** Placeholder display status (REQUEST, SEARCHING, …) — not legacy movie.status. */
   display_status?: string | null;
   determination?: string | null;
+  placeholder_policy?: "auto" | "never" | "pinned";
+  force_placeholder?: boolean;
+  block_placeholder?: boolean;
+  force_placeholder_despite_sibling?: boolean;
   has_file: boolean;
   has_placeholder: boolean;
   placeholder_filepath?: string | null;
@@ -314,6 +318,10 @@ export interface SeriesEpisodeDetail {
   has_file: boolean;
   has_placeholder: boolean;
   determination?: string | null;
+  placeholder_policy?: "auto" | "never" | "pinned";
+  force_placeholder?: boolean;
+  block_placeholder?: boolean;
+  force_placeholder_despite_sibling?: boolean;
   status?: string | null;
   display_status?: string | null;
   sonarr_quality?: string | null;
@@ -835,6 +843,72 @@ export interface CollectionBuilderMeta {
   /** Tags from configured *arr instances for arr_tag sources. */
   arr_tags?: { instance_key: string; instance_label: string; tag_id: number; label: string }[];
   tautulli_configured?: boolean;
+}
+
+export interface DeterminationExplainStep {
+  key: string;
+  label: string;
+  status: "pass" | "fail" | "skip" | "applied";
+  detail?: string | null;
+  outcome?: string | null;
+}
+
+export interface DeterminationExplainResponse {
+  ok: true;
+  media_type: "movie" | "episode";
+  title: string;
+  determination: string;
+  deciding_step_key: string;
+  summary?: string | null;
+  steps: DeterminationExplainStep[];
+}
+
+export interface ForcePlaceholderPreviewResponse {
+  ok: true;
+  media_type: "movie" | "episode";
+  title: string;
+  placeholder_policy?: "auto" | "never" | "pinned";
+  force_placeholder: boolean;
+  block_placeholder?: boolean;
+  force_placeholder_despite_sibling: boolean;
+  can_force: boolean;
+  block_message?: string | null;
+  has_file: boolean;
+  has_placeholder?: boolean;
+  is_deleted: boolean;
+  blocking_reasons: string[];
+  sibling_has_file: boolean;
+  shared_suppression_enabled: boolean;
+  sibling_option_available: boolean;
+  sibling_would_suppress: boolean;
+}
+
+export type PlaceholderPolicyPreviewResponse = ForcePlaceholderPreviewResponse;
+
+export interface PlaceholderPolicySetResponse {
+  ok: boolean;
+  placeholder_policy?: "auto" | "never" | "pinned";
+  force_placeholder?: boolean;
+  block_placeholder?: boolean;
+  force_placeholder_despite_sibling?: boolean;
+  has_file?: boolean;
+  has_placeholder?: boolean;
+  action?: string | null;
+  job_id?: number | null;
+  followup_job_id?: number | null;
+  step_label?: string;
+  reused?: boolean;
+  message?: string;
+}
+
+export interface ForcePlaceholderSetResponse {
+  ok: boolean;
+  force_placeholder?: boolean;
+  force_placeholder_despite_sibling?: boolean;
+  job_id?: number;
+  step_label?: string;
+  reused?: boolean;
+  message?: string;
 }
 
 export type CollectionExplainStatus = "pass" | "fail" | "skip";

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -4343,6 +4343,18 @@ async def movie_detail(movie_id: int):
             "status": movie.status,
             "display_status": _placeholder_display_status_for_movie(session, int(movie.id)),
             "determination": movie.determination,
+            "placeholder_policy": (
+                "pinned"
+                if bool(getattr(movie, "force_placeholder", False))
+                else "never"
+                if bool(getattr(movie, "block_placeholder", False))
+                else "auto"
+            ),
+            "force_placeholder": bool(getattr(movie, "force_placeholder", False)),
+            "block_placeholder": bool(getattr(movie, "block_placeholder", False)),
+            "force_placeholder_despite_sibling": bool(
+                getattr(movie, "force_placeholder_despite_sibling", False)
+            ),
             "has_file": bool(movie.has_file),
             "has_placeholder": bool(movie.has_placeholder),
             "placeholder_filepath": movie.placeholder_filepath,
@@ -4428,6 +4440,18 @@ async def series_detail(series_id: int):
                     "has_file": bool(ep.has_file),
                     "has_placeholder": bool(ep.has_placeholder),
                     "determination": ep.determination,
+                    "placeholder_policy": (
+                        "pinned"
+                        if bool(getattr(ep, "force_placeholder", False))
+                        else "never"
+                        if bool(getattr(ep, "block_placeholder", False))
+                        else "auto"
+                    ),
+                    "force_placeholder": bool(getattr(ep, "force_placeholder", False)),
+                    "block_placeholder": bool(getattr(ep, "block_placeholder", False)),
+                    "force_placeholder_despite_sibling": bool(
+                        getattr(ep, "force_placeholder_despite_sibling", False)
+                    ),
                     "status": ep.status,
                     "display_status": ep_display.get(int(ep.id)),
                     "sonarr_quality": ep.sonarr_quality,
@@ -4609,6 +4633,296 @@ async def refresh_episode_placeholder(episode_id: int):
         "step_label": out.get("step_label"),
         "reused": bool(out.get("reused")),
     }
+
+
+@router.get("/api/library/movie/{movie_id}/determination-explain")
+async def movie_determination_explain(movie_id: int):
+    from services.source_of_truth.determination_explain import explain_movie_determination
+
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id), Movie.is_deleted == False).first()  # noqa: E712
+        if not movie:
+            return JSONResponse({"ok": False, "message": "Movie not found"}, status_code=404)
+        return explain_movie_determination(session, movie)
+    finally:
+        session.close()
+
+
+@router.get("/api/library/episode/{episode_id}/determination-explain")
+async def episode_determination_explain(episode_id: int):
+    from services.source_of_truth.determination_explain import explain_episode_determination
+
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id), Episode.is_deleted == False).first()  # noqa: E712
+        if not episode:
+            return JSONResponse({"ok": False, "message": "Episode not found"}, status_code=404)
+        return explain_episode_determination(session, episode)
+    finally:
+        session.close()
+
+
+@router.get("/api/library/movie/{movie_id}/force-placeholder-preview")
+async def movie_force_placeholder_preview(movie_id: int):
+    from services.source_of_truth.force_placeholder import preview_movie_force_placeholder
+
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id), Movie.is_deleted == False).first()  # noqa: E712
+        if not movie:
+            return JSONResponse({"ok": False, "message": "Movie not found"}, status_code=404)
+        return preview_movie_force_placeholder(session, movie)
+    finally:
+        session.close()
+
+
+@router.get("/api/library/episode/{episode_id}/force-placeholder-preview")
+async def episode_force_placeholder_preview(episode_id: int):
+    from services.source_of_truth.force_placeholder import preview_episode_force_placeholder
+
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id), Episode.is_deleted == False).first()  # noqa: E712
+        if not episode:
+            return JSONResponse({"ok": False, "message": "Episode not found"}, status_code=404)
+        return preview_episode_force_placeholder(session, episode)
+    finally:
+        session.close()
+
+
+@router.post("/api/library/movie/{movie_id}/force-placeholder")
+async def movie_force_placeholder_set(movie_id: int, request: Request):
+    from services.source_of_truth.entity_reconcile import enqueue_entity_reconcile
+    from services.source_of_truth.force_placeholder import apply_force_placeholder_flags
+
+    payload = await request.json()
+    enabled = bool(payload.get("enabled"))
+    despite_sibling = bool(payload.get("despite_sibling"))
+
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id), Movie.is_deleted == False).first()  # noqa: E712
+        if not movie:
+            return JSONResponse({"ok": False, "message": "Movie not found"}, status_code=404)
+        if enabled and bool(movie.is_deleted):
+            return JSONResponse(
+                {"ok": False, "message": "Cannot pin a placeholder for a removed title."},
+                status_code=400,
+            )
+        apply_force_placeholder_flags(movie, enabled=enabled, despite_sibling=despite_sibling)
+        session.add(movie)
+        session.commit()
+        force_placeholder = bool(movie.force_placeholder)
+        despite = bool(movie.force_placeholder_despite_sibling)
+    finally:
+        session.close()
+
+    out = enqueue_entity_reconcile(
+        entity_type="movie",
+        entity_id=int(movie_id),
+        source=f"library_movie_force:{movie_id}",
+    )
+    return {
+        "ok": bool(out.get("ok", True)),
+        "force_placeholder": force_placeholder,
+        "force_placeholder_despite_sibling": despite,
+        "job_id": out.get("job_id"),
+        "step_label": out.get("step_label"),
+        "reused": bool(out.get("reused")),
+        "message": out.get("message"),
+    }
+
+
+@router.post("/api/library/episode/{episode_id}/force-placeholder")
+async def episode_force_placeholder_set(episode_id: int, request: Request):
+    from services.source_of_truth.entity_reconcile import enqueue_entity_reconcile
+    from services.source_of_truth.force_placeholder import apply_force_placeholder_flags
+
+    payload = await request.json()
+    enabled = bool(payload.get("enabled"))
+    despite_sibling = bool(payload.get("despite_sibling"))
+
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id), Episode.is_deleted == False).first()  # noqa: E712
+        if not episode:
+            return JSONResponse({"ok": False, "message": "Episode not found"}, status_code=404)
+        if enabled and bool(episode.is_deleted):
+            return JSONResponse(
+                {"ok": False, "message": "Cannot pin a placeholder for a removed episode."},
+                status_code=400,
+            )
+        apply_force_placeholder_flags(episode, enabled=enabled, despite_sibling=despite_sibling)
+        session.add(episode)
+        session.commit()
+        force_placeholder = bool(episode.force_placeholder)
+        despite = bool(episode.force_placeholder_despite_sibling)
+    finally:
+        session.close()
+
+    out = enqueue_entity_reconcile(
+        entity_type="episode",
+        entity_id=int(episode_id),
+        source=f"library_episode_force:{episode_id}",
+    )
+    return {
+        "ok": bool(out.get("ok", True)),
+        "force_placeholder": force_placeholder,
+        "force_placeholder_despite_sibling": despite,
+        "job_id": out.get("job_id"),
+        "step_label": out.get("step_label"),
+        "reused": bool(out.get("reused")),
+        "message": out.get("message"),
+    }
+
+
+@router.get("/api/library/movie/{movie_id}/placeholder-policy-preview")
+async def movie_placeholder_policy_preview(movie_id: int):
+    from services.source_of_truth.placeholder_policy import preview_movie_placeholder_policy
+
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id), Movie.is_deleted == False).first()  # noqa: E712
+        if not movie:
+            return JSONResponse({"ok": False, "message": "Movie not found"}, status_code=404)
+        return preview_movie_placeholder_policy(session, movie)
+    finally:
+        session.close()
+
+
+@router.get("/api/library/episode/{episode_id}/placeholder-policy-preview")
+async def episode_placeholder_policy_preview(episode_id: int):
+    from services.source_of_truth.placeholder_policy import preview_episode_placeholder_policy
+
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id), Episode.is_deleted == False).first()  # noqa: E712
+        if not episode:
+            return JSONResponse({"ok": False, "message": "Episode not found"}, status_code=404)
+        return preview_episode_placeholder_policy(session, episode)
+    finally:
+        session.close()
+
+
+def _placeholder_policy_snapshot(entity) -> dict:
+    """Capture policy flags while the session is still open (expire_on_commit)."""
+    from services.source_of_truth.placeholder_policy import policy_from_entity
+
+    return {
+        "placeholder_policy": policy_from_entity(entity),
+        "force_placeholder": bool(getattr(entity, "force_placeholder", False)),
+        "block_placeholder": bool(getattr(entity, "block_placeholder", False)),
+    }
+
+
+def _placeholder_policy_set_response(snapshot: dict, out: dict) -> dict:
+    return {
+        "ok": bool(out.get("ok", True)),
+        **snapshot,
+        "action": out.get("action"),
+        "has_file": out.get("has_file", snapshot.get("has_file")),
+        "has_placeholder": out.get("has_placeholder", snapshot.get("has_placeholder")),
+        "job_id": out.get("job_id"),
+        "followup_job_id": out.get("followup_job_id"),
+        "step_label": out.get("step_label"),
+        "reused": bool(out.get("reused")),
+        "message": out.get("message"),
+    }
+
+
+@router.post("/api/library/movie/{movie_id}/placeholder-policy")
+async def movie_placeholder_policy_set(movie_id: int, request: Request):
+    from services.source_of_truth.entity_reconcile import enqueue_entity_reconcile
+    from services.source_of_truth.placeholder_policy import (
+        apply_movie_placeholder_policy_fast,
+        apply_placeholder_policy,
+    )
+
+    payload = await request.json()
+    policy = str(payload.get("policy") or "auto").strip().lower()
+    if policy not in ("auto", "pinned", "never"):
+        return JSONResponse({"ok": False, "message": "Invalid placeholder policy."}, status_code=400)
+
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id), Movie.is_deleted == False).first()  # noqa: E712
+        if not movie:
+            return JSONResponse({"ok": False, "message": "Movie not found"}, status_code=404)
+        if bool(movie.is_deleted) and policy != "auto":
+            return JSONResponse(
+                {"ok": False, "message": "Cannot set placeholder policy for a removed title."},
+                status_code=400,
+            )
+        apply_placeholder_policy(movie, policy=policy)
+        session.add(movie)
+        session.commit()
+        snapshot = _placeholder_policy_snapshot(movie)
+    finally:
+        session.close()
+
+    if policy == "auto":
+        out = enqueue_entity_reconcile(
+            entity_type="movie",
+            entity_id=int(movie_id),
+            source=f"library_movie_policy:{movie_id}",
+        )
+        return _placeholder_policy_set_response(snapshot, out)
+
+    fast = apply_movie_placeholder_policy_fast(int(movie_id))
+    if not fast.get("ok", False):
+        return JSONResponse(
+            {"ok": False, "message": fast.get("message") or "Placeholder update failed", **snapshot},
+            status_code=500,
+        )
+    return _placeholder_policy_set_response(snapshot, fast)
+
+
+@router.post("/api/library/episode/{episode_id}/placeholder-policy")
+async def episode_placeholder_policy_set(episode_id: int, request: Request):
+    from services.source_of_truth.entity_reconcile import enqueue_entity_reconcile
+    from services.source_of_truth.placeholder_policy import (
+        apply_episode_placeholder_policy_fast,
+        apply_placeholder_policy,
+    )
+
+    payload = await request.json()
+    policy = str(payload.get("policy") or "auto").strip().lower()
+    if policy not in ("auto", "pinned", "never"):
+        return JSONResponse({"ok": False, "message": "Invalid placeholder policy."}, status_code=400)
+
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id), Episode.is_deleted == False).first()  # noqa: E712
+        if not episode:
+            return JSONResponse({"ok": False, "message": "Episode not found"}, status_code=404)
+        if bool(episode.is_deleted) and policy != "auto":
+            return JSONResponse(
+                {"ok": False, "message": "Cannot set placeholder policy for a removed episode."},
+                status_code=400,
+            )
+        apply_placeholder_policy(episode, policy=policy)
+        session.add(episode)
+        session.commit()
+        snapshot = _placeholder_policy_snapshot(episode)
+    finally:
+        session.close()
+
+    if policy == "auto":
+        out = enqueue_entity_reconcile(
+            entity_type="episode",
+            entity_id=int(episode_id),
+            source=f"library_episode_policy:{episode_id}",
+        )
+        return _placeholder_policy_set_response(snapshot, out)
+
+    fast = apply_episode_placeholder_policy_fast(int(episode_id))
+    if not fast.get("ok", False):
+        return JSONResponse(
+            {"ok": False, "message": fast.get("message") or "Placeholder update failed", **snapshot},
+            status_code=500,
+        )
+    return _placeholder_policy_set_response(snapshot, fast)
 
 
 @router.get("/api/library/reconcile-jobs/{job_id}")

--- a/services/app_config.py
+++ b/services/app_config.py
@@ -524,7 +524,7 @@ SETTINGS_SCHEMA: "OrderedDict[str, dict[str, Any]]" = OrderedDict(
             {
                 "section": "Lookahead",
                 "label": "Lookahead range",
-                "description": "In Episode mode, how many upcoming episodes without files to include forward from the played episode.",
+                "description": "",
                 "type": "int",
                 "min": 1,
                 "restart_required": False,

--- a/services/library_future_semantics.py
+++ b/services/library_future_semantics.py
@@ -220,19 +220,18 @@ def episode_is_future_for_playback_search(
     series_max_known_order_within_horizon: tuple[int, int] | None,
     now_date: date | None = None,
 ) -> bool:
-    """True when a playback lookahead target should not be searched yet."""
+    """True when a playback lookahead target should not be searched yet.
+
+    Playback suppress treats "future" as not aired yet (air date after today), not the
+    calendar lookahead window used for library-grid Future rows.
+    """
     eff = now_date or datetime.now(timezone.utc).date()
-    lk = _lookahead_int()
     air_date = getattr(episode, "air_date", None)
 
     if air_date is not None:
-        if lk < 0:
-            return air_date > eff
-        days_until = (air_date - eff).days
-        if lk == 0:
-            return days_until > 0
-        return days_until > lk
+        return air_date > eff
 
+    lk = _lookahead_int()
     if not _placeholders_enabled() or lk < 0:
         return False
 

--- a/services/messages/registry.py
+++ b/services/messages/registry.py
@@ -515,6 +515,34 @@ def _build_registry() -> tuple[MessageKey, ...]:
             sample_context={},
         )
     )
+    keys.append(
+        MessageKey(
+            key="calendar.movie.tba",
+            label="Movie release date TBD (pinned)",
+            default="{ReleaseLabel} TBD",
+            group="Calendar Coming Soon",
+            subgroup="Movie",
+            tooltip=(
+                "Shown for pinned movies when the preferred release type has no date yet. "
+                "{ReleaseLabel} resolves to Theatrical / Digital / Physical from your movie date type setting."
+            ),
+            allowed_tokens=cal_movie_tokens,
+            sample_context={"ReleaseLabel": "Theatrical"},
+            alt_defaults={"no_release_type": "TBD"},
+        )
+    )
+    keys.append(
+        MessageKey(
+            key="calendar.tv.tba",
+            label="TV air date TBD (pinned)",
+            default="TBA",
+            group="Calendar Coming Soon",
+            subgroup="TV",
+            tooltip="Shown for pinned episodes when Sonarr has no air date yet.",
+            allowed_tokens=cal_tv_tokens,
+            sample_context={},
+        )
+    )
 
     # --- Queue monitor ---
     queue_tokens = ("Sep", "Progress") + _MEDIA_TOKENS + _EPISODE_TOKENS

--- a/services/postgres/models.py
+++ b/services/postgres/models.py
@@ -574,6 +574,10 @@ class Series(Base):
     updated_at = Column(DateTime(timezone=True), server_default=text('now()'))
     # Last time this season metadata was observed in Sonarr
     last_found_in_sonarr = Column(DateTime(timezone=True), nullable=True)
+    # Series gate: Never/Pinned lock season and episode chips without rewriting their flags
+    force_placeholder = Column(Boolean, nullable=False, default=False)
+    force_placeholder_despite_sibling = Column(Boolean, nullable=False, default=False)
+    block_placeholder = Column(Boolean, nullable=False, default=False)
 
     subflows = relationship('SubFlow', back_populates='series')
     season = relationship('Season', back_populates='series')
@@ -627,6 +631,10 @@ class Season(Base):
     is_deleted = Column(Boolean, default=False)
     created_at = Column(DateTime(timezone=True), server_default=text('now()'))
     updated_at = Column(DateTime(timezone=True), server_default=text('now()'), onupdate=func.now())
+    # Season stamp: Never/Pinned bulk-writes episode flags (when the series is Auto)
+    force_placeholder = Column(Boolean, nullable=False, default=False)
+    force_placeholder_despite_sibling = Column(Boolean, nullable=False, default=False)
+    block_placeholder = Column(Boolean, nullable=False, default=False)
 
     subflows = relationship('SubFlow', back_populates='season')
     series = relationship('Series', back_populates='season')

--- a/services/postgres/models.py
+++ b/services/postgres/models.py
@@ -88,6 +88,12 @@ class Movie(Base):
     # persisted canonical determination (one of: obsolete_placeholder, not_needed, placeholder_exists, needs_placeholder)
     determination = Column(String, nullable=True)
     determination_updated_at = Column(DateTime(timezone=True), nullable=True)
+    # User pin: create placeholder despite calendar/monitored/specials policy (ignored when has_file/deleted)
+    force_placeholder = Column(Boolean, nullable=False, default=False)
+    # When shared-instance sibling has a file, also override sibling suppression
+    force_placeholder_despite_sibling = Column(Boolean, nullable=False, default=False)
+    # User block: never create a placeholder (ignored when has_file/deleted)
+    block_placeholder = Column(Boolean, nullable=False, default=False)
     # Creation timestamp (DB authoritative). Set once at INSERT and do not change.
     created_at = Column(DateTime(timezone=True), server_default=text('now()'))
     # Last time this row was updated by the application/DB
@@ -683,6 +689,12 @@ class Episode(Base):
     is_deleted = Column(Boolean, default=False)
     determination = Column(String, nullable=True)
     determination_updated_at = Column(DateTime(timezone=True), nullable=True)
+    # User pin: create placeholder despite calendar/monitored/specials policy (ignored when has_file/deleted)
+    force_placeholder = Column(Boolean, nullable=False, default=False)
+    # When shared-instance sibling has a file, also override sibling suppression
+    force_placeholder_despite_sibling = Column(Boolean, nullable=False, default=False)
+    # User block: never create a placeholder (ignored when has_file/deleted)
+    block_placeholder = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime(timezone=True), server_default=text('now()'))
     updated_at = Column(DateTime(timezone=True), server_default=text('now()'), onupdate=func.now())
     # Last time this episode was observed in Sonarr

--- a/services/source_of_truth/arr_api.py
+++ b/services/source_of_truth/arr_api.py
@@ -1,6 +1,7 @@
 import re
 import threading
 import time
+from collections import OrderedDict
 from datetime import date
 from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
@@ -15,8 +16,21 @@ from core.logger import logger
 
 _session = requests.Session()
 _cache_lock = threading.Lock()
-_cache = {}
+_cache: OrderedDict[str, dict] = OrderedDict()
 _DEFAULT_TTL_SECONDS = 120
+_CACHE_MAX_ENTRIES = 512
+
+
+def cache_stats() -> dict[str, int]:
+    """Return ARR HTTP cache size for phase metric logs."""
+    with _cache_lock:
+        return {"entries": len(_cache), "max_entries": _CACHE_MAX_ENTRIES}
+
+
+def clear_arr_cache() -> None:
+    """Drop all cached ARR responses (tests or manual reset)."""
+    with _cache_lock:
+        _cache.clear()
 # Bulk *arr reads (e.g. GET /api/v3/movie) can exceed 30s on large libraries over user-share I/O.
 ARR_HTTP_TIMEOUT_SECONDS = 120
 # Collections add: *arr often never finishes POST /movie/import (or /series/import)
@@ -37,13 +51,19 @@ def _cache_get(key: str, ttl_seconds: int = _DEFAULT_TTL_SECONDS):
         if not rec:
             return None
         if (time.time() - rec['ts']) > ttl_seconds:
+            _cache.pop(key, None)
             return None
+        _cache.move_to_end(key)
         return rec['value']
 
 
 def _cache_set(key: str, value):
     with _cache_lock:
+        if key in _cache:
+            _cache.move_to_end(key)
         _cache[key] = {'ts': time.time(), 'value': value}
+        while len(_cache) > _CACHE_MAX_ENTRIES:
+            _cache.popitem(last=False)
 
 
 def _build_endpoint(base_url: str, resource: str) -> str:
@@ -292,11 +312,18 @@ def fetch_sonarr_episodes(
         return []
 
     endpoint = _build_endpoint(url, 'episode')
-    base_params: Dict = {'apikey': api_key, 'seriesId': series_id}
+    # Sonarr defaults omit embedded episodeFile and images on list responses; single GET /episode/{id}
+    # always maps with includeEpisodeFile/includeImages true. Request both on bulk sync (one call/series).
+    base_params: Dict = {
+        'apikey': api_key,
+        'seriesId': series_id,
+        'includeEpisodeFile': 'true',
+        'includeImages': 'true',
+    }
 
     # Specials: never rely on ?seasonNumber=0 — fetch full list, filter locally.
     if season_number is not None and int(season_number) == 0:
-        cache_all_key = f'sonarr_episodes:{endpoint}:{series_id}:all'
+        cache_all_key = f'sonarr_episodes:rich:{endpoint}:{series_id}:all'
         cached_all = _cache_get(cache_all_key)
         if cached_all is not None:
             all_rows = cached_all
@@ -311,7 +338,7 @@ def fetch_sonarr_episodes(
         ]
 
     cache_scope = 'all' if season_number is None else str(int(season_number))
-    cache_key = f'sonarr_episodes:{endpoint}:{series_id}:{cache_scope}'
+    cache_key = f'sonarr_episodes:rich:{endpoint}:{series_id}:{cache_scope}'
     cached = _cache_get(cache_key)
     if cached is not None:
         return cached

--- a/services/source_of_truth/calendar_phase.py
+++ b/services/source_of_truth/calendar_phase.py
@@ -15,7 +15,6 @@ from services.placeholders import ensure_placeholder_file, resolve_calendar_vari
 from services.postgres.db import get_session
 from services.postgres.models import Episode, Movie, Placeholder
 from services.source_of_truth.status_intent import DisplayStatus, StatusIntent, StatusSource
-from services.source_of_truth.status_orchestrator import StatusOrchestrator
 
 
 @dataclass
@@ -62,6 +61,15 @@ def _preferred_movie_release_date(movie: Movie) -> tuple[date | None, str | None
     return (None, preferred, True)
 
 
+def _pinned_tba_reason(*, media_type: str, release_type: str | None) -> str:
+    """User-facing TBD/TBA label for pinned placeholders with no release/air date."""
+    if media_type == "movie":
+        release_label = _release_type_label(release_type) if release_type else ""
+        cal_ctx = {"ReleaseLabel": release_label} if release_label else {}
+        return render_message("calendar.movie.tba", cal_ctx)
+    return render_message("calendar.tv.tba", {})
+
+
 def _compute_calendar_decision(
     *,
     target_date: date | None,
@@ -73,6 +81,7 @@ def _compute_calendar_decision(
     now_date: date,
     release_type: str | None = None,
     release_type_preferred: bool = False,
+    force_pinned: bool = False,
 ) -> CalendarDecision:
     release_label = _release_type_label(release_type) if media_type == "movie" else ""
 
@@ -90,6 +99,14 @@ def _compute_calendar_decision(
         )
 
     if not target_date:
+        if force_pinned:
+            return CalendarDecision(
+                status=DisplayStatus.COMING_SOON.value,
+                reason=_pinned_tba_reason(media_type=media_type, release_type=release_type),
+                days_until=None,
+                release_type=release_type,
+                release_type_preferred=release_type_preferred,
+            )
         # TBA is only used in infinite lookahead mode; strict lookahead treats unknown as out-of-window.
         reason = "No release date available"
         if media_type == "movie" and release_type:
@@ -107,7 +124,7 @@ def _compute_calendar_decision(
 
     days_until = (target_date - now_date).days
 
-    if not placeholders_enabled:
+    if not placeholders_enabled and not force_pinned:
         return CalendarDecision(
             status=DisplayStatus.REQUEST.value,
             reason="Calendar placeholders disabled",
@@ -116,7 +133,7 @@ def _compute_calendar_decision(
             release_type_preferred=release_type_preferred,
         )
 
-    if lookahead_disabled:
+    if lookahead_disabled and not force_pinned:
         return CalendarDecision(
             status=DisplayStatus.REQUEST.value,
             reason="Calendar lookahead disabled",
@@ -138,7 +155,12 @@ def _compute_calendar_decision(
             release_type_preferred=release_type_preferred,
         )
 
-    if not infinite_lookahead and lookahead_days > 0 and days_until > lookahead_days:
+    if (
+        not force_pinned
+        and not infinite_lookahead
+        and lookahead_days > 0
+        and days_until > lookahead_days
+    ):
         return CalendarDecision(
             status=DisplayStatus.REQUEST.value,
             reason=f"Outside lookahead window ({lookahead_days} days)",
@@ -263,6 +285,157 @@ def _dummy_variant_for_status(status: str | None) -> str:
     return "coming_soon" if _is_coming_soon_status(status) else "request"
 
 
+def _calendar_settings_snapshot(*, now_date: date | None = None) -> dict[str, Any]:
+    """Shared calendar settings used by status, calendar phase, and materializer."""
+    resolved_now = now_date or datetime.now(timezone.utc).date()
+    return {
+        "lookahead_days": int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30),
+        "placeholders_enabled": bool(settings.coming_soon_placeholders_enabled),
+        "countdown_enabled": bool(getattr(settings, "ENABLE_COMING_SOON_COUNTDOWN", True)),
+        "now_date": resolved_now,
+    }
+
+
+def _placeholder_force_pinned(session, placeholder: Placeholder) -> bool:
+    """True when the linked movie or episode has force_placeholder set."""
+    movie_id = getattr(placeholder, "movie_id", None)
+    if movie_id is not None:
+        movie = session.get(Movie, int(movie_id))
+        return bool(movie and getattr(movie, "force_placeholder", False))
+    episode_id = getattr(placeholder, "episode_id", None)
+    if episode_id is not None:
+        episode = session.get(Episode, int(episode_id))
+        return bool(episode and getattr(episode, "force_placeholder", False))
+    return False
+
+
+def compute_calendar_decision_for_movie(movie: Movie, *, now_date: date | None = None) -> CalendarDecision:
+    """Calendar status decision for a movie row (used by materializer dummy variant selection)."""
+    snap = _calendar_settings_snapshot(now_date=now_date)
+    target_date, release_type, is_preferred = _preferred_movie_release_date(movie)
+    return _compute_calendar_decision(
+        target_date=target_date,
+        has_file=bool(getattr(movie, "has_file", False)),
+        media_type="movie",
+        lookahead_days=snap["lookahead_days"],
+        countdown_enabled=snap["countdown_enabled"],
+        placeholders_enabled=snap["placeholders_enabled"],
+        now_date=snap["now_date"],
+        release_type=release_type,
+        release_type_preferred=is_preferred,
+        force_pinned=bool(getattr(movie, "force_placeholder", False)),
+    )
+
+
+def compute_calendar_decision_for_episode(episode: Episode, *, now_date: date | None = None) -> CalendarDecision:
+    """Calendar status decision for an episode row (used by materializer dummy variant selection)."""
+    snap = _calendar_settings_snapshot(now_date=now_date)
+    return _compute_calendar_decision(
+        target_date=getattr(episode, "air_date", None),
+        has_file=bool(getattr(episode, "has_file", False)),
+        media_type="episode",
+        lookahead_days=snap["lookahead_days"],
+        countdown_enabled=snap["countdown_enabled"],
+        placeholders_enabled=snap["placeholders_enabled"],
+        now_date=snap["now_date"],
+        release_type=None,
+        release_type_preferred=False,
+        force_pinned=bool(getattr(episode, "force_placeholder", False)),
+    )
+
+
+def compute_dummy_variant_for_movie(movie: Movie, *, now_date: date | None = None) -> str:
+    decision = compute_calendar_decision_for_movie(movie, now_date=now_date)
+    return _dummy_variant_for_status(decision.status)
+
+
+def compute_dummy_variant_for_episode(episode: Episode, *, now_date: date | None = None) -> str:
+    decision = compute_calendar_decision_for_episode(episode, now_date=now_date)
+    return _dummy_variant_for_status(decision.status)
+
+
+def refresh_placeholder_calendar_status(session, placeholder: Placeholder) -> bool:
+    """Recompute calendar status for one on-disk placeholder (e.g. after pin apply)."""
+    if not bool(getattr(placeholder, "has_placeholder", False)):
+        return False
+
+    media_type, target_date, has_file, release_type, release_type_preferred = _placeholder_target(
+        session, placeholder
+    )
+    if not media_type:
+        return False
+
+    snap = _calendar_settings_snapshot()
+    force_pinned = _placeholder_force_pinned(session, placeholder)
+    decision = _compute_calendar_decision(
+        target_date=target_date,
+        has_file=has_file,
+        media_type=media_type,
+        lookahead_days=snap["lookahead_days"],
+        countdown_enabled=snap["countdown_enabled"],
+        placeholders_enabled=snap["placeholders_enabled"],
+        now_date=snap["now_date"],
+        release_type=release_type,
+        release_type_preferred=release_type_preferred,
+        force_pinned=force_pinned,
+    )
+
+    current_status = str(getattr(placeholder, "display_status", "") or "")
+    current_reason = _normalize_reason(getattr(placeholder, "display_reason", None))
+    desired_reason = _normalize_reason(decision.reason)
+    if current_status == decision.status and current_reason == desired_reason:
+        return False
+
+    from services.source_of_truth.status_orchestrator import StatusOrchestrator
+
+    orchestrator = StatusOrchestrator(session=session)
+    intent = StatusIntent(
+        placeholder_id=int(placeholder.id),
+        new_status=decision.status,
+        reason=decision.reason,
+        source=StatusSource.CALENDAR_RELEASE_WINDOW,
+        trigger_nfo_refresh=True,
+        metadata={
+            "days_until_release": decision.days_until,
+            "media_type": media_type,
+            "target_date": str(target_date) if target_date else None,
+            "force_pinned": force_pinned,
+        },
+    )
+    orchestrator.apply_and_project_statuses([intent])
+
+    desired_variant = _dummy_variant_for_status(decision.status)
+    try:
+        _switch_placeholder_dummy_variant(
+            placeholder,
+            desired_variant,
+            _calendar_variant_settings_fingerprint(),
+        )
+    except Exception as exc:
+        logger.warning(
+            f"Calendar variant switch failed placeholder_id={placeholder.id}: {exc}",
+            extra={"emoji_type": "warning"},
+        )
+    return True
+
+
+def refresh_pinned_entity_calendar_status(session, entity: Movie | Episode) -> bool:
+    """Refresh calendar status when a pinned title already has an on-disk placeholder."""
+    if not bool(getattr(entity, "force_placeholder", False)):
+        return False
+    if not bool(getattr(entity, "has_placeholder", False)):
+        return False
+    q = session.query(Placeholder).filter(Placeholder.has_placeholder == True)  # noqa: E712
+    if isinstance(entity, Movie):
+        q = q.filter(Placeholder.movie_id == int(entity.id))
+    else:
+        q = q.filter(Placeholder.episode_id == int(entity.id))
+    placeholder = q.order_by(Placeholder.id.desc()).first()
+    if not placeholder:
+        return False
+    return refresh_placeholder_calendar_status(session, placeholder)
+
+
 def _normalize_reason(value: str | None) -> str:
     return str(value or "").strip()
 
@@ -317,7 +490,7 @@ def _switch_placeholder_dummy_variant(
 
 
 def _query_placeholders_for_calendar_phase(session, win_start: date, win_end: date):
-    """Placeholders to evaluate: coming-soon rows, TBA (no date), or date in [win_start, win_end].
+    """Placeholders to evaluate: coming-soon rows, TBA (no date), date in window, or pinned.
 
     Skips rows with no movie/episode link (same as the per-row target resolver).
     """
@@ -336,6 +509,14 @@ def _query_placeholders_for_calendar_phase(session, win_start: date, win_end: da
             Episode.air_date.between(win_start, win_end),
         ),
     )
+    pinned_movie = and_(
+        Placeholder.movie_id.isnot(None),
+        Movie.force_placeholder == True,  # noqa: E712
+    )
+    pinned_episode = and_(
+        Placeholder.episode_id.isnot(None),
+        Episode.force_placeholder == True,  # noqa: E712
+    )
     return (
         session.query(Placeholder)
         .outerjoin(Movie, Placeholder.movie_id == Movie.id)
@@ -347,6 +528,8 @@ def _query_placeholders_for_calendar_phase(session, win_start: date, win_end: da
                 Placeholder.display_status.in_(_COMING_SOON_STATUS_VALUES),
                 in_window_movie,
                 in_window_episode,
+                pinned_movie,
+                pinned_episode,
             )
         )
     )
@@ -521,6 +704,7 @@ def _run_calendar_phase_inner(stats: dict[str, Any]) -> dict[str, Any]:
                 if not media_type:
                     continue
 
+                force_pinned = _placeholder_force_pinned(session, placeholder)
                 decision = _compute_calendar_decision(
                     target_date=target_date,
                     has_file=has_file,
@@ -531,6 +715,7 @@ def _run_calendar_phase_inner(stats: dict[str, Any]) -> dict[str, Any]:
                     now_date=now_date,
                     release_type=release_type,
                     release_type_preferred=release_type_preferred,
+                    force_pinned=force_pinned,
                 )
 
                 desired_variant = _dummy_variant_for_status(decision.status)
@@ -573,6 +758,8 @@ def _run_calendar_phase_inner(stats: dict[str, Any]) -> dict[str, Any]:
 
             chunk_applied = 0
             if chunk_intents:
+                from services.source_of_truth.status_orchestrator import StatusOrchestrator
+
                 orchestrator = StatusOrchestrator(session=session)
                 chunk_applied = int(orchestrator.apply_and_project_statuses(chunk_intents) or 0)
 

--- a/services/source_of_truth/determination_explain.py
+++ b/services/source_of_truth/determination_explain.py
@@ -1,0 +1,921 @@
+"""On-demand explanation of placeholder determination for library detail UI."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from core.config import settings
+from services.placeholders import episode_placeholder_path, movie_placeholder_path
+from services.postgres.models import Episode, Movie, Season, Series
+from services.source_of_truth.arr_share_guard import (
+    shared_placeholder_suppresses_creation,
+    sibling_episode_has_file,
+    sibling_movie_has_file,
+)
+from services.source_of_truth.determiner import (
+    DETERMINATION_EXISTS,
+    DETERMINATION_NEEDS,
+    DETERMINATION_NOT_NEEDED,
+    DETERMINATION_OBSOLETE,
+    _apply_force_placeholder,
+    _apply_block_placeholder,
+    _apply_monitored_placeholder_suppression,
+    _apply_sibling_placeholder_suppression,
+    _episode_placeholder_path_drifts,
+    _movie_placeholder_path_drifts,
+    _preferred_movie_release_date,
+    _series_monitored_for_episode,
+    _sibling_would_suppress_creation,
+    _skip_placeholders_when_monitored_enabled,
+    _skip_placeholders_when_series_monitored_enabled,
+)
+
+
+ExplainStatus = str  # pass | fail | skip | applied
+
+
+def _format_determination_label(value: str) -> str:
+    return str(value or "").replace("_", " ")
+
+
+def _preferred_movie_date_label() -> str:
+    preferred = str(getattr(settings, "PREFERRED_MOVIE_DATE_TYPE", "inCinemas") or "inCinemas").strip()
+    mapping = {
+        "inCinemas": "theatrical release",
+        "digitalRelease": "digital release",
+        "physicalRelease": "physical release",
+    }
+    return mapping.get(preferred, "theatrical release")
+
+
+def _step(
+    key: str,
+    label: str,
+    status: ExplainStatus,
+    *,
+    detail: str | None = None,
+    outcome: str | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {"key": key, "label": label, "status": status}
+    if detail:
+        row["detail"] = detail
+    if outcome:
+        row["outcome"] = outcome
+    return row
+
+
+def _deciding_step_key(steps: list[dict[str, Any]], final: str) -> str:
+    for step in steps:
+        if step.get("outcome") == final and step.get("status") in {"fail", "applied"}:
+            return str(step.get("key") or "final")
+    for step in steps:
+        if step.get("status") == "fail":
+            return str(step.get("key") or "final")
+    return str(steps[-1].get("key") if steps else "final")
+
+
+def _build_summary(final: str, deciding_key: str, steps: list[dict[str, Any]]) -> str:
+    deciding = next((s for s in steps if s.get("key") == deciding_key), None)
+    detail = str(deciding.get("detail") or "").strip() if deciding else ""
+    label = _format_determination_label(final)
+    if detail:
+        return f"Determination is {label}. {detail}"
+    return f"Determination is {label}."
+
+
+def _pin_blocked_by_file_detail(is_deleted: bool) -> str:
+    if is_deleted:
+        return (
+            "Pinned on this title, but the title was removed from the library so no placeholder "
+            "is created."
+        )
+    return (
+        "Pinned on this title. Placeholdarr would override calendar, monitored, and sibling "
+        "rules, but a real file is on disk so no placeholder is needed."
+    )
+
+
+def _explain_deciding_step_key(
+    steps: list[dict[str, Any]],
+    final: str,
+    entity,
+    *,
+    has_file: bool,
+    is_deleted: bool,
+) -> str:
+    pinned = bool(getattr(entity, "force_placeholder", False))
+    blocked = bool(getattr(entity, "block_placeholder", False))
+    if pinned and (has_file or is_deleted) and final == DETERMINATION_NOT_NEEDED:
+        return "force_placeholder"
+    if blocked and (has_file or is_deleted) and final == DETERMINATION_NOT_NEEDED:
+        return "block_placeholder"
+    if blocked and final in (DETERMINATION_NOT_NEEDED, DETERMINATION_OBSOLETE):
+        return "block_placeholder"
+    return _deciding_step_key(steps, final)
+
+
+def _explain_summary(
+    final: str,
+    deciding_key: str,
+    steps: list[dict[str, Any]],
+    entity,
+    *,
+    has_file: bool,
+    is_deleted: bool,
+) -> str:
+    pinned = bool(getattr(entity, "force_placeholder", False))
+    blocked = bool(getattr(entity, "block_placeholder", False))
+    label = _format_determination_label(final)
+    if pinned and has_file and final == DETERMINATION_NOT_NEEDED:
+        return (
+            f"Determination is {label}. This title is pinned, so calendar, monitored, and sibling "
+            "rules would be overridden, but a real file is on disk so no placeholder is needed."
+        )
+    if pinned and is_deleted and final == DETERMINATION_NOT_NEEDED:
+        return (
+            f"Determination is {label}. This title is pinned, but it was removed from the library "
+            "so no placeholder is created."
+        )
+    if blocked and has_file and final == DETERMINATION_NOT_NEEDED:
+        return (
+            f"Determination is {label}. Never is set on this title, but a real file is on disk so "
+            "no placeholder is needed."
+        )
+    return _build_summary(final, deciding_key, steps)
+
+
+def _calendar_guard_result(
+    *,
+    has_placeholder: bool,
+    has_file: bool,
+    is_deleted: bool,
+    target_date: date | None,
+    release_status: str | None,
+    lookahead_days: int,
+    placeholders_enabled: bool,
+    now_date: date,
+    date_label: str,
+) -> tuple[str | None, dict[str, Any]]:
+    """Return (outcome_if_calendar_decided, step) or (None, step) when calendar passes."""
+    if not placeholders_enabled:
+        return None, _step(
+            "calendar_window",
+            "Within calendar window",
+            "skip",
+            detail="Coming-soon placeholders are disabled.",
+        )
+    if has_file or is_deleted:
+        return None, _step(
+            "calendar_window",
+            "Within calendar window",
+            "skip",
+            detail="Skipped because the title already has a file or is removed from the library.",
+        )
+
+    lookahead = int(lookahead_days)
+    if lookahead < 0:
+        return None, _step(
+            "calendar_window",
+            "Within calendar window",
+            "pass",
+            detail="Calendar lookahead is unlimited.",
+        )
+
+    if target_date is None:
+        released = str(release_status or "").strip().lower() == "released"
+        if released:
+            return None, _step(
+                "calendar_window",
+                "Within calendar window",
+                "pass",
+                detail=f"No {date_label} date on file, but Radarr reports released.",
+            )
+        outcome = DETERMINATION_OBSOLETE if has_placeholder else DETERMINATION_NOT_NEEDED
+        return outcome, _step(
+            "calendar_window",
+            "Within calendar window",
+            "fail",
+            detail=f"No {date_label} date and Radarr does not report released.",
+            outcome=outcome,
+        )
+
+    days_until = (target_date - now_date).days
+    date_str = target_date.isoformat()
+    if lookahead == 0:
+        if days_until > 0:
+            outcome = DETERMINATION_OBSOLETE if has_placeholder else DETERMINATION_NOT_NEEDED
+            return outcome, _step(
+                "calendar_window",
+                "Within calendar window",
+                "fail",
+                detail=f"{date_label} is {date_str} ({days_until} day(s) away). Future placeholders are off.",
+                outcome=outcome,
+            )
+        return None, _step(
+            "calendar_window",
+            "Within calendar window",
+            "pass",
+            detail=f"{date_label} is {date_str} (today or in the past).",
+        )
+
+    if days_until > lookahead:
+        outcome = DETERMINATION_OBSOLETE if has_placeholder else DETERMINATION_NOT_NEEDED
+        return outcome, _step(
+            "calendar_window",
+            "Within calendar window",
+            "fail",
+            detail=(
+                f"{date_label} is {date_str} ({days_until} days away). "
+                f"Calendar lookahead is {lookahead} days."
+            ),
+            outcome=outcome,
+        )
+    return None, _step(
+        "calendar_window",
+        "Within calendar window",
+        "pass",
+        detail=f"{date_label} is {date_str} ({days_until} days away). Within {lookahead}-day lookahead.",
+    )
+
+
+def _file_state_result(
+    *,
+    has_placeholder: bool,
+    has_file: bool,
+    is_deleted: bool,
+    prior_outcome: str | None,
+) -> tuple[str, dict[str, Any]]:
+    if prior_outcome is not None:
+        return prior_outcome, _step(
+            "file_state",
+            "File and placeholder state",
+            "skip",
+            detail="Calendar window already decided the outcome.",
+            outcome=prior_outcome,
+        )
+
+    if has_placeholder and (has_file or is_deleted):
+        return DETERMINATION_OBSOLETE, _step(
+            "file_state",
+            "File and placeholder state",
+            "fail",
+            detail="Placeholder exists but a real file is on disk or the title was removed.",
+            outcome=DETERMINATION_OBSOLETE,
+        )
+    if has_file or is_deleted:
+        return DETERMINATION_NOT_NEEDED, _step(
+            "file_state",
+            "File and placeholder state",
+            "fail",
+            detail="Real file on disk or title removed from the library.",
+            outcome=DETERMINATION_NOT_NEEDED,
+        )
+    if has_placeholder:
+        return DETERMINATION_EXISTS, _step(
+            "file_state",
+            "File and placeholder state",
+            "pass",
+            detail="Placeholder on disk and no real file yet.",
+            outcome=DETERMINATION_EXISTS,
+        )
+    return DETERMINATION_NEEDS, _step(
+        "file_state",
+        "File and placeholder state",
+        "pass",
+        detail="No real file and no placeholder yet.",
+        outcome=DETERMINATION_NEEDS,
+    )
+
+
+def _apply_modifier_step(
+    *,
+    key: str,
+    label: str,
+    before: str,
+    after: str,
+    skip_detail: str | None = None,
+) -> dict[str, Any]:
+    if before == after and skip_detail:
+        return _step(key, label, "skip", detail=skip_detail)
+    if before != after:
+        return _step(
+            key,
+            label,
+            "applied",
+            detail=f"Changed from {_format_determination_label(before)} to {_format_determination_label(after)}.",
+            outcome=after,
+        )
+    return _step(key, label, "pass", detail="Did not change the outcome.")
+
+
+def _block_placeholder_step(
+    *,
+    entity,
+    before: str,
+    after: str,
+    has_file: bool,
+    is_deleted: bool,
+    has_placeholder: bool,
+) -> dict[str, Any]:
+    blocked = bool(getattr(entity, "block_placeholder", False))
+    if not blocked:
+        return _step(
+            "block_placeholder",
+            "Never placeholder",
+            "skip",
+            detail="Never is off.",
+        )
+    if has_file or is_deleted:
+        return _step(
+            "block_placeholder",
+            "Never placeholder",
+            "applied",
+            detail=(
+                "Never is set on this title. A real file is on disk or the title was removed, "
+                "so placeholders are not created or removed."
+            ),
+            outcome=before,
+        )
+    if before != after:
+        detail = (
+            f"Never set determination to {_format_determination_label(after)}."
+            if after != DETERMINATION_OBSOLETE
+            else "Never marks the existing placeholder obsolete so reconcile can remove it."
+        )
+        return _step(
+            "block_placeholder",
+            "Never placeholder",
+            "applied",
+            detail=detail,
+            outcome=after,
+        )
+    return _step(
+        "block_placeholder",
+        "Never placeholder",
+        "pass",
+        detail="Never is on; placeholders are already blocked for this title.",
+        outcome=after,
+    )
+
+
+def _force_placeholder_step(
+    *,
+    entity,
+    before: str,
+    after: str,
+    has_file: bool,
+    is_deleted: bool,
+    sibling_would_suppress: bool,
+) -> dict[str, Any]:
+    forced = bool(getattr(entity, "force_placeholder", False))
+    if not forced:
+        return _step(
+            "force_placeholder",
+            "Placeholder pin",
+            "skip",
+            detail="Pin is off (Auto).",
+        )
+    if has_file or is_deleted:
+        return _step(
+            "force_placeholder",
+            "Placeholder pin",
+            "applied",
+            detail=_pin_blocked_by_file_detail(is_deleted),
+            outcome=before,
+        )
+    if sibling_would_suppress and not bool(getattr(entity, "force_placeholder_despite_sibling", False)):
+        return _step(
+            "force_placeholder",
+            "Placeholder pin",
+            "skip",
+            detail=(
+                "Pin is set, but shared-instance sibling has a file and "
+                "override sibling suppression is off."
+            ),
+            outcome=before,
+        )
+    if before != after:
+        return _step(
+            "force_placeholder",
+            "Placeholder pin",
+            "applied",
+            detail=f"Pin set determination to {_format_determination_label(after)}.",
+            outcome=after,
+        )
+    return _step(
+        "force_placeholder",
+        "Placeholder pin",
+        "pass",
+        detail="Pin is on; determination already needed a placeholder.",
+        outcome=after,
+    )
+
+
+def _build_series_max_known_order_within_horizon(
+    session,
+    series_ids: list[int],
+    *,
+    lookahead_days: int,
+    now_date: date,
+) -> dict[int, tuple[int, int]]:
+    if not series_ids:
+        return {}
+    horizon = now_date + timedelta(days=int(lookahead_days)) if int(lookahead_days) >= 0 else None
+    known_rows = (
+        session.query(Season.series_id, Season.season_number, Episode.episode_number)
+        .join(Season, Episode.season_id == Season.id)
+        .filter(
+            Season.series_id.in_(list(series_ids)),
+            Episode.air_date.isnot(None),
+            Episode.is_deleted == False,  # noqa: E712
+        )
+        .filter(Episode.air_date <= horizon if horizon is not None else True)
+        .all()
+    )
+    out: dict[int, tuple[int, int]] = {}
+    for series_id, season_number, episode_number in known_rows:
+        if series_id is None:
+            continue
+        order = (int(season_number or 0), int(episode_number or 0))
+        sid = int(series_id)
+        prev = out.get(sid)
+        if prev is None or order > prev:
+            out[sid] = order
+    return out
+
+
+def explain_movie_determination(session, movie: Movie) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    placeholders_enabled = bool(settings.coming_soon_placeholders_enabled)
+    lookahead_days = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
+    has_placeholder = bool(getattr(movie, "has_placeholder", False))
+    has_file = bool(getattr(movie, "has_file", False))
+    is_deleted = bool(getattr(movie, "is_deleted", False))
+    target_date = _preferred_movie_release_date(movie)
+    date_label = _preferred_movie_date_label()
+
+    steps: list[dict[str, Any]] = []
+
+    calendar_outcome, calendar_step = _calendar_guard_result(
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        target_date=target_date,
+        release_status=getattr(movie, "radarr_release_status", None),
+        lookahead_days=lookahead_days,
+        placeholders_enabled=placeholders_enabled,
+        now_date=now_date,
+        date_label=date_label,
+    )
+    steps.append(calendar_step)
+
+    base, file_step = _file_state_result(
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        prior_outcome=calendar_outcome,
+    )
+    steps.append(file_step)
+
+    if has_placeholder and _movie_placeholder_path_drifts(movie):
+        base = DETERMINATION_OBSOLETE
+        expected = movie_placeholder_path(movie)
+        stored = getattr(movie, "placeholder_filepath", None)
+        steps.append(
+            _step(
+                "path_drift",
+                "Placeholder path",
+                "fail",
+                detail=f"Stored path does not match expected location ({stored!r} vs {expected!r}).",
+                outcome=base,
+            )
+        )
+    else:
+        steps.append(
+            _step(
+                "path_drift",
+                "Placeholder path",
+                "skip",
+                detail="No placeholder path drift detected.",
+            )
+        )
+
+    before = base
+    base = _apply_monitored_placeholder_suppression(
+        session,
+        base=base,
+        entity=movie,
+        media_type="movie",
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        movie_id=int(movie.id) if getattr(movie, "id", None) is not None else None,
+    )
+    monitored_skip = None
+    if not _skip_placeholders_when_monitored_enabled():
+        monitored_skip = "Skip-when-monitored is off."
+    elif has_file or is_deleted:
+        monitored_skip = "Skipped because a real file exists or the title was removed."
+    elif not bool(getattr(movie, "radarr_monitored", False)):
+        monitored_skip = "Title is not monitored in Radarr."
+    steps.append(
+        _apply_modifier_step(
+            key="monitored_suppression",
+            label="Monitored suppression",
+            before=before,
+            after=base,
+            skip_detail=monitored_skip,
+        )
+    )
+
+    before = base
+    sibling_has_file = sibling_movie_has_file(session, movie)
+    base = _apply_sibling_placeholder_suppression(
+        arr_type="radarr",
+        base=base,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_has_file=sibling_has_file,
+    )
+    sibling_skip = None
+    if not shared_placeholder_suppresses_creation("radarr"):
+        sibling_skip = "Shared-instance suppression is off."
+    elif has_file or is_deleted:
+        sibling_skip = "Skipped because a real file exists or the title was removed."
+    elif not sibling_has_file:
+        sibling_skip = "No sibling instance has this title on disk."
+    steps.append(
+        _apply_modifier_step(
+            key="sibling_suppression",
+            label="Shared-instance suppression",
+            before=before,
+            after=base,
+            skip_detail=sibling_skip,
+        )
+    )
+
+    sibling_block = _sibling_would_suppress_creation(
+        arr_type="radarr",
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_has_file=sibling_has_file,
+    )
+    before = base
+    base = _apply_block_placeholder(
+        base=base,
+        entity=movie,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    steps.append(
+        _block_placeholder_step(
+            entity=movie,
+            before=before,
+            after=base,
+            has_file=has_file,
+            is_deleted=is_deleted,
+            has_placeholder=has_placeholder,
+        )
+    )
+
+    before = base
+    base = _apply_force_placeholder(
+        base=base,
+        entity=movie,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_would_suppress=sibling_block,
+    )
+    steps.append(
+        _force_placeholder_step(
+            entity=movie,
+            before=before,
+            after=base,
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_would_suppress=sibling_block,
+        )
+    )
+
+    final = base
+    deciding = _explain_deciding_step_key(
+        steps,
+        final,
+        movie,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    title = str(getattr(movie, "title", "") or "Movie")
+    return {
+        "ok": True,
+        "media_type": "movie",
+        "title": title,
+        "determination": final,
+        "deciding_step_key": deciding,
+        "summary": _explain_summary(
+            final,
+            deciding,
+            steps,
+            movie,
+            has_file=has_file,
+            is_deleted=is_deleted,
+        ),
+        "steps": steps,
+    }
+
+
+def explain_episode_determination(session, episode: Episode) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    placeholders_enabled = bool(settings.coming_soon_placeholders_enabled)
+    lookahead_days = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
+    has_placeholder = bool(getattr(episode, "has_placeholder", False))
+    has_file = bool(getattr(episode, "has_file", False))
+    is_deleted = bool(getattr(episode, "is_deleted", False))
+
+    season = session.query(Season).filter(Season.id == episode.season_id).first()
+    series = (
+        session.query(Series).filter(Series.id == season.series_id).first()
+        if season and getattr(season, "series_id", None) is not None
+        else None
+    )
+    season_number = int(getattr(season, "season_number", 0) or 0) if season else 0
+    episode_number = int(getattr(episode, "episode_number", 0) or 0)
+    series_id = int(season.series_id) if season and getattr(season, "series_id", None) is not None else None
+    episode_meta = (
+        (series_id, season_number, episode_number) if series_id is not None else None
+    )
+
+    steps: list[dict[str, Any]] = []
+
+    include_specials = bool(getattr(settings, "INCLUDE_SPECIALS", False))
+    forced = bool(getattr(episode, "force_placeholder", False))
+    if not include_specials and season_number == 0 and not forced:
+        final = DETERMINATION_NOT_NEEDED
+        steps.append(
+            _step(
+                "episode_specials",
+                "Specials policy",
+                "fail",
+                detail="Season 0 specials are excluded by settings.",
+                outcome=final,
+            )
+        )
+        deciding = _deciding_step_key(steps, final)
+        title = str(getattr(episode, "title", "") or f"Episode {episode_number}")
+        return {
+            "ok": True,
+            "media_type": "episode",
+            "title": title,
+            "determination": final,
+            "deciding_step_key": deciding,
+            "summary": _build_summary(final, deciding, steps),
+            "steps": steps,
+        }
+    if not include_specials and season_number == 0 and forced:
+        steps.append(
+            _step(
+                "episode_specials",
+                "Specials policy",
+                "applied",
+                detail="Season 0 specials are excluded by settings, but pin is on.",
+            )
+        )
+    else:
+        steps.append(
+            _step(
+                "episode_specials",
+                "Specials policy",
+                "skip",
+                detail="Not an excluded special, or specials are included.",
+            )
+        )
+
+    target_date = getattr(episode, "air_date", None)
+    inferred_air_date = False
+    if (
+        target_date is None
+        and placeholders_enabled
+        and lookahead_days >= 0
+        and episode_meta is not None
+    ):
+        series_max = _build_series_max_known_order_within_horizon(
+            session,
+            [int(series_id)],
+            lookahead_days=lookahead_days,
+            now_date=now_date,
+        )
+        max_known = series_max.get(int(series_id))
+        if max_known is not None and max_known > (season_number, episode_number):
+            target_date = now_date
+            inferred_air_date = True
+
+    if inferred_air_date:
+        steps.append(
+            _step(
+                "episode_unknown_air_date",
+                "Unknown air date inference",
+                "applied",
+                detail="Air date unknown, but a later episode in the run has a known date inside lookahead.",
+                outcome=None,
+            )
+        )
+    else:
+        air_detail = (
+            f"Air date is {target_date.isoformat()}."
+            if target_date is not None
+            else "Air date is unknown."
+        )
+        steps.append(
+            _step(
+                "episode_unknown_air_date",
+                "Unknown air date inference",
+                "skip",
+                detail=air_detail,
+            )
+        )
+
+    calendar_outcome, calendar_step = _calendar_guard_result(
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        target_date=target_date,
+        release_status=None,
+        lookahead_days=lookahead_days,
+        placeholders_enabled=placeholders_enabled,
+        now_date=now_date,
+        date_label="Air date",
+    )
+    steps.append(calendar_step)
+
+    base, file_step = _file_state_result(
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        prior_outcome=calendar_outcome,
+    )
+    steps.append(file_step)
+
+    if has_placeholder and _episode_placeholder_path_drifts(session, episode):
+        base = DETERMINATION_OBSOLETE
+        expected = (
+            episode_placeholder_path(episode, season, series)
+            if season and series
+            else None
+        )
+        stored = getattr(episode, "placeholder_filepath", None)
+        steps.append(
+            _step(
+                "path_drift",
+                "Placeholder path",
+                "fail",
+                detail=f"Stored path does not match expected location ({stored!r} vs {expected!r}).",
+                outcome=base,
+            )
+        )
+    else:
+        steps.append(
+            _step(
+                "path_drift",
+                "Placeholder path",
+                "skip",
+                detail="No placeholder path drift detected.",
+            )
+        )
+
+    series_monitored = (
+        _series_monitored_for_episode(session, episode)
+        if _skip_placeholders_when_series_monitored_enabled()
+        else False
+    )
+    before = base
+    base = _apply_monitored_placeholder_suppression(
+        session,
+        base=base,
+        entity=episode,
+        media_type="episode",
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        episode_id=int(episode.id) if getattr(episode, "id", None) is not None else None,
+        series_monitored=series_monitored,
+    )
+    monitored_skip = None
+    if not _skip_placeholders_when_monitored_enabled():
+        monitored_skip = "Skip-when-monitored is off."
+    elif has_file or is_deleted:
+        monitored_skip = "Skipped because a real file exists or the episode was removed."
+    elif not bool(getattr(episode, "sonarr_monitored", False)) and not series_monitored:
+        monitored_skip = "Episode and series are not monitored in Sonarr."
+    steps.append(
+        _apply_modifier_step(
+            key="monitored_suppression",
+            label="Monitored suppression",
+            before=before,
+            after=base,
+            skip_detail=monitored_skip,
+        )
+    )
+
+    before = base
+    sibling_has_file = sibling_episode_has_file(session, episode)
+    base = _apply_sibling_placeholder_suppression(
+        arr_type="sonarr",
+        base=base,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_has_file=sibling_has_file,
+    )
+    sibling_skip = None
+    if not shared_placeholder_suppresses_creation("sonarr"):
+        sibling_skip = "Shared-instance suppression is off."
+    elif has_file or is_deleted:
+        sibling_skip = "Skipped because a real file exists or the episode was removed."
+    elif not sibling_has_file:
+        sibling_skip = "No sibling instance has this episode on disk."
+    steps.append(
+        _apply_modifier_step(
+            key="sibling_suppression",
+            label="Shared-instance suppression",
+            before=before,
+            after=base,
+            skip_detail=sibling_skip,
+        )
+    )
+
+    sibling_block = _sibling_would_suppress_creation(
+        arr_type="sonarr",
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_has_file=sibling_has_file,
+    )
+    before = base
+    base = _apply_block_placeholder(
+        base=base,
+        entity=episode,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    steps.append(
+        _block_placeholder_step(
+            entity=episode,
+            before=before,
+            after=base,
+            has_file=has_file,
+            is_deleted=is_deleted,
+            has_placeholder=has_placeholder,
+        )
+    )
+
+    before = base
+    base = _apply_force_placeholder(
+        base=base,
+        entity=episode,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_would_suppress=sibling_block,
+    )
+    steps.append(
+        _force_placeholder_step(
+            entity=episode,
+            before=before,
+            after=base,
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_would_suppress=sibling_block,
+        )
+    )
+
+    final = base
+    deciding = _explain_deciding_step_key(
+        steps,
+        final,
+        episode,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    ep_label = f"E{episode_number:02d}"
+    series_title = str(getattr(series, "title", "") or "Series") if series else "Series"
+    title = str(getattr(episode, "title", "") or f"Episode {episode_number}")
+    return {
+        "ok": True,
+        "media_type": "episode",
+        "title": f"{series_title} {ep_label} {title}".strip(),
+        "determination": final,
+        "deciding_step_key": deciding,
+        "summary": _explain_summary(
+            final,
+            deciding,
+            steps,
+            episode,
+            has_file=has_file,
+            is_deleted=is_deleted,
+        ),
+        "steps": steps,
+    }

--- a/services/source_of_truth/determination_explain.py
+++ b/services/source_of_truth/determination_explain.py
@@ -107,11 +107,11 @@ def _explain_deciding_step_key(
     pinned = bool(getattr(entity, "force_placeholder", False))
     blocked = bool(getattr(entity, "block_placeholder", False))
     if pinned and (has_file or is_deleted) and final == DETERMINATION_NOT_NEEDED:
-        return "force_placeholder"
+        return "placeholder_policy"
     if blocked and (has_file or is_deleted) and final == DETERMINATION_NOT_NEEDED:
-        return "block_placeholder"
+        return "placeholder_policy"
     if blocked and final in (DETERMINATION_NOT_NEEDED, DETERMINATION_OBSOLETE):
-        return "block_placeholder"
+        return "placeholder_policy"
     return _deciding_step_key(steps, final)
 
 
@@ -309,57 +309,7 @@ def _apply_modifier_step(
     return _step(key, label, "pass", detail="Did not change the outcome.")
 
 
-def _block_placeholder_step(
-    *,
-    entity,
-    before: str,
-    after: str,
-    has_file: bool,
-    is_deleted: bool,
-    has_placeholder: bool,
-) -> dict[str, Any]:
-    blocked = bool(getattr(entity, "block_placeholder", False))
-    if not blocked:
-        return _step(
-            "block_placeholder",
-            "Never placeholder",
-            "skip",
-            detail="Never is off.",
-        )
-    if has_file or is_deleted:
-        return _step(
-            "block_placeholder",
-            "Never placeholder",
-            "applied",
-            detail=(
-                "Never is set on this title. A real file is on disk or the title was removed, "
-                "so placeholders are not created or removed."
-            ),
-            outcome=before,
-        )
-    if before != after:
-        detail = (
-            f"Never set determination to {_format_determination_label(after)}."
-            if after != DETERMINATION_OBSOLETE
-            else "Never marks the existing placeholder obsolete so reconcile can remove it."
-        )
-        return _step(
-            "block_placeholder",
-            "Never placeholder",
-            "applied",
-            detail=detail,
-            outcome=after,
-        )
-    return _step(
-        "block_placeholder",
-        "Never placeholder",
-        "pass",
-        detail="Never is on; placeholders are already blocked for this title.",
-        outcome=after,
-    )
-
-
-def _force_placeholder_step(
+def _placeholder_policy_step(
     *,
     entity,
     before: str,
@@ -368,46 +318,81 @@ def _force_placeholder_step(
     is_deleted: bool,
     sibling_would_suppress: bool,
 ) -> dict[str, Any]:
-    forced = bool(getattr(entity, "force_placeholder", False))
-    if not forced:
+    """One Why? step for the Auto / Never / Pinned chip (not two flag rows)."""
+    from services.source_of_truth.placeholder_policy import policy_from_entity
+
+    policy = policy_from_entity(entity)
+    if policy == "auto":
         return _step(
-            "force_placeholder",
-            "Placeholder pin",
+            "placeholder_policy",
+            "Placeholder policy",
             "skip",
-            detail="Pin is off (Auto).",
+            detail="Policy is Auto: follow Placeholdarr settings.",
+        )
+    if policy == "never":
+        if has_file or is_deleted:
+            return _step(
+                "placeholder_policy",
+                "Placeholder policy",
+                "applied",
+                detail=(
+                    "Policy is Never. A real file is on disk or the title was removed, "
+                    "so placeholders are not created or removed."
+                ),
+                outcome=before,
+            )
+        if before != after:
+            detail = (
+                f"Policy is Never. Set determination to {_format_determination_label(after)}."
+                if after != DETERMINATION_OBSOLETE
+                else "Policy is Never. Marks the existing placeholder obsolete so it can be removed."
+            )
+            return _step(
+                "placeholder_policy",
+                "Placeholder policy",
+                "applied",
+                detail=detail,
+                outcome=after,
+            )
+        return _step(
+            "placeholder_policy",
+            "Placeholder policy",
+            "pass",
+            detail="Policy is Never. Placeholders are already blocked for this title.",
+            outcome=after,
         )
     if has_file or is_deleted:
         return _step(
-            "force_placeholder",
-            "Placeholder pin",
+            "placeholder_policy",
+            "Placeholder policy",
             "applied",
             detail=_pin_blocked_by_file_detail(is_deleted),
             outcome=before,
         )
     if sibling_would_suppress and not bool(getattr(entity, "force_placeholder_despite_sibling", False)):
         return _step(
-            "force_placeholder",
-            "Placeholder pin",
+            "placeholder_policy",
+            "Placeholder policy",
             "skip",
             detail=(
-                "Pin is set, but shared-instance sibling has a file and "
-                "override sibling suppression is off."
+                "Policy is Pinned, but a shared-instance sibling has a file and "
+                "Shared Placeholder Cleanup is on."
             ),
             outcome=before,
         )
     if before != after:
         return _step(
-            "force_placeholder",
-            "Placeholder pin",
+            "placeholder_policy",
+            "Placeholder policy",
             "applied",
-            detail=f"Pin set determination to {_format_determination_label(after)}.",
+            detail=f"Policy is Pinned. Set determination to {_format_determination_label(after)}.",
             outcome=after,
         )
     return _step(
-        "force_placeholder",
-        "Placeholder pin",
+        "placeholder_policy",
+        "Placeholder policy",
         "pass",
-        detail="Pin is on; determination already needed a placeholder.",
+        detail="Policy is Pinned. Determination already needed a placeholder.",
         outcome=after,
     )
 
@@ -570,18 +555,6 @@ def explain_movie_determination(session, movie: Movie) -> dict[str, Any]:
         has_file=has_file,
         is_deleted=is_deleted,
     )
-    steps.append(
-        _block_placeholder_step(
-            entity=movie,
-            before=before,
-            after=base,
-            has_file=has_file,
-            is_deleted=is_deleted,
-            has_placeholder=has_placeholder,
-        )
-    )
-
-    before = base
     base = _apply_force_placeholder(
         base=base,
         entity=movie,
@@ -591,7 +564,7 @@ def explain_movie_determination(session, movie: Movie) -> dict[str, Any]:
         sibling_would_suppress=sibling_block,
     )
     steps.append(
-        _force_placeholder_step(
+        _placeholder_policy_step(
             entity=movie,
             before=before,
             after=base,
@@ -681,7 +654,7 @@ def explain_episode_determination(session, episode: Episode) -> dict[str, Any]:
                 "episode_specials",
                 "Specials policy",
                 "applied",
-                detail="Season 0 specials are excluded by settings, but pin is on.",
+                detail="Season 0 specials are excluded by settings, but policy is Pinned.",
             )
         )
     else:
@@ -861,18 +834,6 @@ def explain_episode_determination(session, episode: Episode) -> dict[str, Any]:
         has_file=has_file,
         is_deleted=is_deleted,
     )
-    steps.append(
-        _block_placeholder_step(
-            entity=episode,
-            before=before,
-            after=base,
-            has_file=has_file,
-            is_deleted=is_deleted,
-            has_placeholder=has_placeholder,
-        )
-    )
-
-    before = base
     base = _apply_force_placeholder(
         base=base,
         entity=episode,
@@ -882,7 +843,7 @@ def explain_episode_determination(session, episode: Episode) -> dict[str, Any]:
         sibling_would_suppress=sibling_block,
     )
     steps.append(
-        _force_placeholder_step(
+        _placeholder_policy_step(
             entity=episode,
             before=before,
             after=base,

--- a/services/source_of_truth/determiner.py
+++ b/services/source_of_truth/determiner.py
@@ -229,6 +229,60 @@ def _apply_sibling_placeholder_suppression(
     return DETERMINATION_NOT_NEEDED
 
 
+def _sibling_would_suppress_creation(
+    *,
+    arr_type: str,
+    has_file: bool,
+    is_deleted: bool,
+    sibling_has_file: bool,
+) -> bool:
+    """True when shared-instance mode would suppress placeholder creation for this row."""
+    if not shared_placeholder_suppresses_creation(arr_type):
+        return False
+    if has_file or is_deleted or not sibling_has_file:
+        return False
+    return True
+
+
+def _apply_block_placeholder(
+    *,
+    base: str,
+    entity,
+    has_placeholder: bool,
+    has_file: bool,
+    is_deleted: bool,
+) -> str:
+    """User never pin: block placeholder unless file exists or title removed."""
+    if not bool(getattr(entity, "block_placeholder", False)):
+        return base
+    if has_file or is_deleted:
+        return base
+    if has_placeholder:
+        return DETERMINATION_OBSOLETE
+    return DETERMINATION_NOT_NEEDED
+
+
+def _apply_force_placeholder(
+    *,
+    base: str,
+    entity,
+    has_placeholder: bool,
+    has_file: bool,
+    is_deleted: bool,
+    sibling_would_suppress: bool,
+) -> str:
+    """User pin: force needs/exists unless file exists, deleted, or sibling blocks without override."""
+    if not bool(getattr(entity, "force_placeholder", False)):
+        return base
+    if has_file or is_deleted:
+        return base
+    if sibling_would_suppress and not bool(getattr(entity, "force_placeholder_despite_sibling", False)):
+        return base
+    if has_placeholder:
+        return DETERMINATION_EXISTS
+    return DETERMINATION_NEEDS
+
+
 def _resolve_movie_determination(
     session,
     movie: Movie,
@@ -263,13 +317,34 @@ def _resolve_movie_determination(
         is_deleted=is_deleted,
         movie_id=int(movie.id) if getattr(movie, "id", None) is not None else None,
     )
+    sibling_has_file = sibling_movie_has_file(session, movie)
     base = _apply_sibling_placeholder_suppression(
         arr_type="radarr",
         base=base,
         has_placeholder=has_placeholder,
         has_file=has_file,
         is_deleted=is_deleted,
-        sibling_has_file=sibling_movie_has_file(session, movie),
+        sibling_has_file=sibling_has_file,
+    )
+    base = _apply_block_placeholder(
+        base=base,
+        entity=movie,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    base = _apply_force_placeholder(
+        base=base,
+        entity=movie,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_would_suppress=_sibling_would_suppress_creation(
+            arr_type="radarr",
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_has_file=sibling_has_file,
+        ),
     )
     return base, False
 
@@ -329,13 +404,34 @@ def _resolve_episode_determination(
         episode_id=int(episode.id) if getattr(episode, "id", None) is not None else None,
         series_monitored=series_monitored,
     )
+    sibling_has_file = sibling_episode_has_file(session, episode)
     base = _apply_sibling_placeholder_suppression(
         arr_type="sonarr",
         base=base,
         has_placeholder=has_placeholder,
         has_file=has_file,
         is_deleted=is_deleted,
-        sibling_has_file=sibling_episode_has_file(session, episode),
+        sibling_has_file=sibling_has_file,
+    )
+    base = _apply_block_placeholder(
+        base=base,
+        entity=episode,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+    )
+    base = _apply_force_placeholder(
+        base=base,
+        entity=episode,
+        has_placeholder=has_placeholder,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_would_suppress=_sibling_would_suppress_creation(
+            arr_type="sonarr",
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_has_file=sibling_has_file,
+        ),
     )
     return base, False
 
@@ -895,8 +991,9 @@ def run_determination_pass() -> dict:
             episode_meta = episode_order_meta_by_id.get(int(episode.id)) if getattr(episode, "id", None) is not None else None
             season_number = int(episode_meta[1]) if episode_meta is not None else -1
             # Treat season 0 episodes as not_needed when specials are disabled
+            # (unless the user forced a placeholder for this episode).
             if not include_specials:
-                if season_number == 0:
+                if season_number == 0 and not bool(getattr(episode, "force_placeholder", False)):
                     value = DETERMINATION_NOT_NEEDED
                     stats[value] += 1
                     if getattr(episode, 'determination', None) != value:
@@ -1190,7 +1287,7 @@ def run_determination_for_entities_in_session(
         episode_meta = episode_order_meta_by_id.get(int(episode.id)) if getattr(episode, "id", None) is not None else None
         season_number = int(episode_meta[1]) if episode_meta is not None else -1
         if not include_specials:
-            if season_number == 0:
+            if season_number == 0 and not bool(getattr(episode, "force_placeholder", False)):
                 value = DETERMINATION_NOT_NEEDED
                 stats[value] += 1
                 if getattr(episode, 'determination', None) != value:

--- a/services/source_of_truth/determiner.py
+++ b/services/source_of_truth/determiner.py
@@ -18,6 +18,7 @@ from services.source_of_truth.arr_share_guard import (
     sibling_movie_has_file,
 )
 from services.source_of_truth.filesystem import configured_roots
+from services.source_of_truth.phase_metrics import PhaseTimer, log_phase_boundary
 from services.source_of_truth.status_intent import DisplayStatus
 
 
@@ -27,9 +28,12 @@ DETERMINATION_EXISTS = 'placeholder_exists'
 DETERMINATION_NEEDS = 'needs_placeholder'
 RECONCILE_PROGRESS_EVERY_ROWS = 5000
 RECONCILE_LINK_PROGRESS_EVERY_ROWS = 5000
+RECONCILE_LINK_CHUNK_SIZE = 2000
+RECONCILE_VALIDATE_CHUNK_SIZE = 500
 # Determination can run tens of thousands of ORM checks; log by row count and wall time so operators see steady progress.
 DETERMINATION_PROGRESS_EVERY_ROWS = 500
 DETERMINATION_PROGRESS_MIN_INTERVAL_S = 20.0
+DETERMINATION_CHUNK_SIZE = 2000
 
 
 def _determination_log_progress(
@@ -51,11 +55,13 @@ def _determination_log_progress(
         return
     last_log_mono[0] = now
     updates = int(stats.get("movies_changed", 0) or 0) if movie_phase else int(stats.get("episodes_changed", 0) or 0)
+    elapsed_total = now - started_mono
+    rows_per_s = idx / elapsed_total if elapsed_total > 0 else 0.0
     logger.info(
         f"Determination · {scope} · {label}: {idx}/{total} checked · "
         f"{'movie' if movie_phase else 'episode'}_rows_updated={updates} · "
         f"obsolete_placeholder={int(stats.get('obsolete_placeholder', 0) or 0)} · "
-        f"elapsed_s={now - started_mono:.1f}",
+        f"elapsed_s={elapsed_total:.1f} · rows_per_s={rows_per_s:.2f}",
         extra={'emoji_type': 'info'},
     )
 
@@ -496,299 +502,343 @@ def run_placeholder_link_reconcile() -> dict:
         return changed
 
     try:
-        logger.info("Placeholder reconcile started", extra={'emoji_type': 'info'})
-        # Reset derived state first so stale true flags cannot survive crashes.
-        stats['movies_reset'] = session.query(Movie).update(
-            {
-                Movie.has_placeholder: False,
-                Movie.placeholder_filepath: None,
-            },
-            synchronize_session=False,
-        )
-        stats['episodes_reset'] = session.query(Episode).update(
-            {
-                Episode.has_placeholder: False,
-                Episode.placeholder_filepath: None,
-            },
-            synchronize_session=False,
-        )
+        with PhaseTimer("placeholder_reconcile"):
+            logger.info("Placeholder reconcile started", extra={'emoji_type': 'info'})
+            # Reset derived state first so stale true flags cannot survive crashes.
+            stats['movies_reset'] = session.query(Movie).update(
+                {
+                    Movie.has_placeholder: False,
+                    Movie.placeholder_filepath: None,
+                },
+                synchronize_session=False,
+            )
+            stats['episodes_reset'] = session.query(Episode).update(
+                {
+                    Episode.has_placeholder: False,
+                    Episode.placeholder_filepath: None,
+                },
+                synchronize_session=False,
+            )
+            session.commit()
 
-        # Validate active placeholder rows before relinking.
-        roots = [os.path.abspath(root) for root in configured_roots() if root]
-        active_rows = session.query(Placeholder).filter(Placeholder.has_placeholder == True).all()  # noqa: E712
-        for idx, row in enumerate(active_rows, start=1):
-            path = getattr(row, 'path', None)
-            if not path:
-                row.has_placeholder = False
-                if hasattr(row, 'lifecycle_status'):
-                    row.lifecycle_status = 'MISSING'
-                if _disconnect_placeholder_row(row):
-                    stats['invalid_placeholders_disconnected'] += 1
-                session.add(row)
-                stats['invalid_placeholders_marked_missing'] += 1
-                continue
+            # Validate active placeholder rows before relinking.
+            roots = [os.path.abspath(root) for root in configured_roots() if root]
+            active_count = (
+                session.query(Placeholder)
+                .filter(Placeholder.has_placeholder == True)  # noqa: E712
+                .count()
+            )
+            idx = 0
+            last_id = 0
+            while True:
+                chunk = (
+                    session.query(Placeholder)
+                    .filter(
+                        Placeholder.has_placeholder == True,  # noqa: E712
+                        Placeholder.id > last_id,
+                    )
+                    .order_by(Placeholder.id)
+                    .limit(RECONCILE_VALIDATE_CHUNK_SIZE)
+                    .all()
+                )
+                if not chunk:
+                    break
+                for row in chunk:
+                    idx += 1
+                    path = getattr(row, 'path', None)
+                    if not path:
+                        row.has_placeholder = False
+                        if hasattr(row, 'lifecycle_status'):
+                            row.lifecycle_status = 'MISSING'
+                        if _disconnect_placeholder_row(row):
+                            stats['invalid_placeholders_disconnected'] += 1
+                        session.add(row)
+                        stats['invalid_placeholders_marked_missing'] += 1
+                        continue
 
-            abs_path = os.path.abspath(path)
-            exists = os.path.isfile(abs_path)
-            in_scope = False
-            for root in roots:
-                try:
-                    if os.path.commonpath([abs_path, root]) == root:
-                        in_scope = True
-                        break
-                except Exception:
-                    continue
+                    abs_path = os.path.abspath(path)
+                    exists = os.path.isfile(abs_path)
+                    in_scope = False
+                    for root in roots:
+                        try:
+                            if os.path.commonpath([abs_path, root]) == root:
+                                in_scope = True
+                                break
+                        except Exception:
+                            continue
 
-            if not exists or not in_scope:
-                remapped = False
-                file_name = os.path.basename(abs_path)
+                    if not exists or not in_scope:
+                        remapped = False
+                        file_name = os.path.basename(abs_path)
 
-                try:
-                    if getattr(row, 'movie_id', None):
-                        mv = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
-                        mv_folder = getattr(mv, 'placeholder_folder', None) if mv else None
-                        if mv_folder:
-                            candidate = os.path.join(mv_folder, file_name)
-                            if os.path.isfile(candidate):
-                                row.path = candidate
-                                row.has_placeholder = True
-                                if hasattr(row, 'last_observed_at'):
-                                    row.last_observed_at = func.now()
-                                remapped = True
-                    elif getattr(row, 'episode_id', None):
-                        ep = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
-                        ep_folder = getattr(ep, 'placeholder_folder', None) if ep else None
-                        if ep_folder:
-                            candidate = os.path.join(ep_folder, file_name)
-                            if os.path.isfile(candidate):
-                                row.path = candidate
-                                row.has_placeholder = True
-                                if hasattr(row, 'last_observed_at'):
-                                    row.last_observed_at = func.now()
-                                remapped = True
-                except Exception:
-                    remapped = False
-
-                if not remapped:
-                    try:
-                        if getattr(row, 'movie_id', None):
-                            mv2 = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
-                            if mv2:
-                                candidate = os.path.abspath(movie_placeholder_path(mv2))
-                                if os.path.isfile(candidate):
-                                    for root in roots:
-                                        try:
-                                            if os.path.commonpath([candidate, root]) == root:
-                                                row.path = candidate
-                                                row.has_placeholder = True
-                                                if hasattr(row, 'last_observed_at'):
-                                                    row.last_observed_at = func.now()
-                                                remapped = True
-                                                break
-                                        except Exception:
-                                            continue
-                        elif getattr(row, 'episode_id', None):
-                            ep2 = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
-                            if ep2:
-                                season2 = session.query(Season).filter(Season.id == ep2.season_id).first()
-                                series2 = (
-                                    session.query(Series).filter(Series.id == season2.series_id).first()
-                                    if season2
-                                    else None
-                                )
-                                if season2 and series2:
-                                    candidate = os.path.abspath(
-                                        episode_placeholder_path(ep2, season2, series2)
-                                    )
+                        try:
+                            if getattr(row, 'movie_id', None):
+                                mv = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
+                                mv_folder = getattr(mv, 'placeholder_folder', None) if mv else None
+                                if mv_folder:
+                                    candidate = os.path.join(mv_folder, file_name)
                                     if os.path.isfile(candidate):
-                                        for root in roots:
-                                            try:
-                                                if os.path.commonpath([candidate, root]) == root:
-                                                    row.path = candidate
-                                                    row.has_placeholder = True
-                                                    if hasattr(row, 'last_observed_at'):
-                                                        row.last_observed_at = func.now()
-                                                    remapped = True
-                                                    break
-                                            except Exception:
-                                                continue
-                    except Exception:
-                        pass
-
-                if not remapped:
-                    row.has_placeholder = False
-                    if hasattr(row, 'lifecycle_status'):
-                        row.lifecycle_status = 'MISSING'
-                    if _disconnect_placeholder_row(row):
-                        stats['invalid_placeholders_disconnected'] += 1
-                    stats['invalid_placeholders_marked_missing'] += 1
-
-                if hasattr(row, 'updated_at'):
-                    row.updated_at = func.now()
-                session.add(row)
-            else:
-                # Path is valid today, but Radarr/metadata may have moved the canonical folder while
-                # the dummy file still lives at the previous path. Leaving the stale path linked
-                # forces ``_movie_placeholder_path_drifts`` / episode drift → obsolete_placeholder on
-                # every determination until cleanup. Prefer the current canonical path when it exists.
-                try:
-                    if getattr(row, 'movie_id', None):
-                        mv_align = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
-                        if mv_align:
-                            canonical = os.path.abspath(movie_placeholder_path(mv_align))
-                            norm_cur = _normalize_placeholder_path(abs_path)
-                            norm_can = _normalize_placeholder_path(canonical)
-                            if (
-                                canonical
-                                and norm_can
-                                and norm_cur
-                                and norm_can != norm_cur
-                                and os.path.isfile(canonical)
-                            ):
-                                canon_in_scope = False
-                                for root in roots:
-                                    try:
-                                        if os.path.commonpath([canonical, root]) == root:
-                                            canon_in_scope = True
-                                            break
-                                    except Exception:
-                                        continue
-                                if canon_in_scope:
-                                    row.path = canonical
-                                    row.has_placeholder = True
-                                    if hasattr(row, 'last_observed_at'):
-                                        row.last_observed_at = func.now()
-                                    if hasattr(row, 'updated_at'):
-                                        row.updated_at = func.now()
-                                    session.add(row)
-                                    stats['canonical_path_realigned'] += 1
-                    elif getattr(row, 'episode_id', None):
-                        ep_align = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
-                        if ep_align:
-                            season_align = session.query(Season).filter(Season.id == ep_align.season_id).first()
-                            series_align = (
-                                session.query(Series).filter(Series.id == season_align.series_id).first()
-                                if season_align
-                                else None
-                            )
-                            if season_align and series_align:
-                                canonical = os.path.abspath(
-                                    episode_placeholder_path(ep_align, season_align, series_align)
-                                )
-                                norm_cur = _normalize_placeholder_path(abs_path)
-                                norm_can = _normalize_placeholder_path(canonical)
-                                if (
-                                    canonical
-                                    and norm_can
-                                    and norm_cur
-                                    and norm_can != norm_cur
-                                    and os.path.isfile(canonical)
-                                ):
-                                    canon_in_scope = False
-                                    for root in roots:
-                                        try:
-                                            if os.path.commonpath([canonical, root]) == root:
-                                                canon_in_scope = True
-                                                break
-                                        except Exception:
-                                            continue
-                                    if canon_in_scope:
-                                        row.path = canonical
+                                        row.path = candidate
                                         row.has_placeholder = True
                                         if hasattr(row, 'last_observed_at'):
                                             row.last_observed_at = func.now()
-                                        if hasattr(row, 'updated_at'):
-                                            row.updated_at = func.now()
-                                        session.add(row)
-                                        stats['canonical_path_realigned'] += 1
-                except Exception:
-                    pass
-            if idx % RECONCILE_PROGRESS_EVERY_ROWS == 0:
-                elapsed = time.monotonic() - started_mono
-                logger.info(
-                    "Placeholder reconcile progress (validate): "
-                    f"checked={idx}/{len(active_rows)} "
-                    f"invalid_marked_missing={stats['invalid_placeholders_marked_missing']} "
-                    f"disconnected={stats['invalid_placeholders_disconnected']} "
-                    f"elapsed_s={elapsed:.1f}",
-                    extra={'emoji_type': 'info'},
+                                        remapped = True
+                            elif getattr(row, 'episode_id', None):
+                                ep = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
+                                ep_folder = getattr(ep, 'placeholder_folder', None) if ep else None
+                                if ep_folder:
+                                    candidate = os.path.join(ep_folder, file_name)
+                                    if os.path.isfile(candidate):
+                                        row.path = candidate
+                                        row.has_placeholder = True
+                                        if hasattr(row, 'last_observed_at'):
+                                            row.last_observed_at = func.now()
+                                        remapped = True
+                        except Exception:
+                            remapped = False
+
+                        if not remapped:
+                            try:
+                                if getattr(row, 'movie_id', None):
+                                    mv2 = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
+                                    if mv2:
+                                        candidate = os.path.abspath(movie_placeholder_path(mv2))
+                                        if os.path.isfile(candidate):
+                                            for root in roots:
+                                                try:
+                                                    if os.path.commonpath([candidate, root]) == root:
+                                                        row.path = candidate
+                                                        row.has_placeholder = True
+                                                        if hasattr(row, 'last_observed_at'):
+                                                            row.last_observed_at = func.now()
+                                                        remapped = True
+                                                        break
+                                                except Exception:
+                                                    continue
+                                elif getattr(row, 'episode_id', None):
+                                    ep2 = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
+                                    if ep2:
+                                        season2 = session.query(Season).filter(Season.id == ep2.season_id).first()
+                                        series2 = (
+                                            session.query(Series).filter(Series.id == season2.series_id).first()
+                                            if season2
+                                            else None
+                                        )
+                                        if season2 and series2:
+                                            candidate = os.path.abspath(
+                                                episode_placeholder_path(ep2, season2, series2)
+                                            )
+                                            if os.path.isfile(candidate):
+                                                for root in roots:
+                                                    try:
+                                                        if os.path.commonpath([candidate, root]) == root:
+                                                            row.path = candidate
+                                                            row.has_placeholder = True
+                                                            if hasattr(row, 'last_observed_at'):
+                                                                row.last_observed_at = func.now()
+                                                            remapped = True
+                                                            break
+                                                    except Exception:
+                                                        continue
+                            except Exception:
+                                pass
+
+                        if not remapped:
+                            row.has_placeholder = False
+                            if hasattr(row, 'lifecycle_status'):
+                                row.lifecycle_status = 'MISSING'
+                            if _disconnect_placeholder_row(row):
+                                stats['invalid_placeholders_disconnected'] += 1
+                            stats['invalid_placeholders_marked_missing'] += 1
+
+                        if hasattr(row, 'updated_at'):
+                            row.updated_at = func.now()
+                        session.add(row)
+                    else:
+                        # Path is valid today, but Radarr/metadata may have moved the canonical folder while
+                        # the dummy file still lives at the previous path. Leaving the stale path linked
+                        # forces ``_movie_placeholder_path_drifts`` / episode drift → obsolete_placeholder on
+                        # every determination until cleanup. Prefer the current canonical path when it exists.
+                        try:
+                            if getattr(row, 'movie_id', None):
+                                mv_align = session.query(Movie).filter(Movie.id == int(row.movie_id)).first()
+                                if mv_align:
+                                    canonical = os.path.abspath(movie_placeholder_path(mv_align))
+                                    norm_cur = _normalize_placeholder_path(abs_path)
+                                    norm_can = _normalize_placeholder_path(canonical)
+                                    if (
+                                        canonical
+                                        and norm_can
+                                        and norm_cur
+                                        and norm_can != norm_cur
+                                        and os.path.isfile(canonical)
+                                    ):
+                                        canon_in_scope = False
+                                        for root in roots:
+                                            try:
+                                                if os.path.commonpath([canonical, root]) == root:
+                                                    canon_in_scope = True
+                                                    break
+                                            except Exception:
+                                                continue
+                                        if canon_in_scope:
+                                            row.path = canonical
+                                            row.has_placeholder = True
+                                            if hasattr(row, 'last_observed_at'):
+                                                row.last_observed_at = func.now()
+                                            if hasattr(row, 'updated_at'):
+                                                row.updated_at = func.now()
+                                            session.add(row)
+                                            stats['canonical_path_realigned'] += 1
+                            elif getattr(row, 'episode_id', None):
+                                ep_align = session.query(Episode).filter(Episode.id == int(row.episode_id)).first()
+                                if ep_align:
+                                    season_align = session.query(Season).filter(Season.id == ep_align.season_id).first()
+                                    series_align = (
+                                        session.query(Series).filter(Series.id == season_align.series_id).first()
+                                        if season_align
+                                        else None
+                                    )
+                                    if season_align and series_align:
+                                        canonical = os.path.abspath(
+                                            episode_placeholder_path(ep_align, season_align, series_align)
+                                        )
+                                        norm_cur = _normalize_placeholder_path(abs_path)
+                                        norm_can = _normalize_placeholder_path(canonical)
+                                        if (
+                                            canonical
+                                            and norm_can
+                                            and norm_cur
+                                            and norm_can != norm_cur
+                                            and os.path.isfile(canonical)
+                                        ):
+                                            canon_in_scope = False
+                                            for root in roots:
+                                                try:
+                                                    if os.path.commonpath([canonical, root]) == root:
+                                                        canon_in_scope = True
+                                                        break
+                                                except Exception:
+                                                    continue
+                                            if canon_in_scope:
+                                                row.path = canonical
+                                                row.has_placeholder = True
+                                                if hasattr(row, 'last_observed_at'):
+                                                    row.last_observed_at = func.now()
+                                                if hasattr(row, 'updated_at'):
+                                                    row.updated_at = func.now()
+                                                session.add(row)
+                                                stats['canonical_path_realigned'] += 1
+                        except Exception:
+                            pass
+                    if idx % RECONCILE_PROGRESS_EVERY_ROWS == 0:
+                        elapsed = time.monotonic() - started_mono
+                        logger.info(
+                            "Placeholder reconcile progress (validate): "
+                            f"checked={idx}/{active_count} "
+                            f"invalid_marked_missing={stats['invalid_placeholders_marked_missing']} "
+                            f"disconnected={stats['invalid_placeholders_disconnected']} "
+                            f"elapsed_s={elapsed:.1f}",
+                            extra={'emoji_type': 'info'},
+                        )
+                chunk_last_id = int(chunk[-1].id)
+                session.commit()
+                session.expunge_all()
+                last_id = chunk_last_id
+
+            session.commit()
+            session.expunge_all()
+
+            # Build canonical path per linked Movie from active Placeholder rows.
+            movie_rows = (
+                session.query(Placeholder.movie_id, Placeholder.path)
+                .filter(
+                    Placeholder.has_placeholder == True,  # noqa: E712
+                    Placeholder.movie_id.isnot(None),
                 )
-
-        # Build canonical path per linked Movie from active Placeholder rows.
-        movie_rows = (
-            session.query(Placeholder.movie_id, Placeholder.path)
-            .filter(
-                Placeholder.has_placeholder == True,  # noqa: E712
-                Placeholder.movie_id.isnot(None),
+                .order_by(Placeholder.last_observed_at.desc(), Placeholder.id.desc())
+                .all()
             )
-            .order_by(Placeholder.last_observed_at.desc(), Placeholder.id.desc())
-            .all()
-        )
-        stats['movie_placeholders_seen'] = len(movie_rows)
-        movie_path_by_id: dict[int, str | None] = {}
-        for movie_id, path in movie_rows:
-            if movie_id not in movie_path_by_id:
-                movie_path_by_id[movie_id] = path
+            stats['movie_placeholders_seen'] = len(movie_rows)
+            movie_path_by_id: dict[int, str | None] = {}
+            for movie_id, path in movie_rows:
+                if movie_id not in movie_path_by_id:
+                    movie_path_by_id[movie_id] = path
 
-        if movie_path_by_id:
-            movies = session.query(Movie).filter(Movie.id.in_(list(movie_path_by_id.keys()))).all()
-            for idx, movie in enumerate(movies, start=1):
-                movie.has_placeholder = True
-                movie.placeholder_filepath = movie_path_by_id.get(movie.id)
-                session.add(movie)
-                stats['movies_linked'] += 1
-                if idx % RECONCILE_LINK_PROGRESS_EVERY_ROWS == 0:
-                    elapsed = time.monotonic() - started_mono
-                    logger.info(
-                        "Placeholder reconcile progress (movies link): "
-                        f"linked={idx}/{len(movies)} "
-                        f"elapsed_s={elapsed:.1f}",
-                        extra={'emoji_type': 'info'},
-                    )
+            if movie_path_by_id:
+                movie_ids = list(movie_path_by_id.keys())
+                for chunk_start in range(0, len(movie_ids), RECONCILE_LINK_CHUNK_SIZE):
+                    chunk_ids = movie_ids[chunk_start : chunk_start + RECONCILE_LINK_CHUNK_SIZE]
+                    movies = session.query(Movie).filter(Movie.id.in_(chunk_ids)).all()
+                    for movie in movies:
+                        movie.has_placeholder = True
+                        movie.placeholder_filepath = movie_path_by_id.get(movie.id)
+                        session.add(movie)
+                        stats['movies_linked'] += 1
+                    session.commit()
+                    session.expunge_all()
+                    linked = min(chunk_start + len(chunk_ids), len(movie_ids))
+                    if linked % RECONCILE_LINK_PROGRESS_EVERY_ROWS == 0 or linked == len(movie_ids):
+                        elapsed = time.monotonic() - started_mono
+                        logger.info(
+                            "Placeholder reconcile progress (movies link): "
+                            f"linked={linked}/{len(movie_ids)} "
+                            f"elapsed_s={elapsed:.1f}",
+                            extra={'emoji_type': 'info'},
+                        )
 
-        # Build canonical path per linked Episode from active Placeholder rows.
-        episode_rows = (
-            session.query(Placeholder.episode_id, Placeholder.path)
-            .filter(
-                Placeholder.has_placeholder == True,  # noqa: E712
-                Placeholder.episode_id.isnot(None),
+            # Build canonical path per linked Episode from active Placeholder rows.
+            episode_rows = (
+                session.query(Placeholder.episode_id, Placeholder.path)
+                .filter(
+                    Placeholder.has_placeholder == True,  # noqa: E712
+                    Placeholder.episode_id.isnot(None),
+                )
+                .order_by(Placeholder.last_observed_at.desc(), Placeholder.id.desc())
+                .all()
             )
-            .order_by(Placeholder.last_observed_at.desc(), Placeholder.id.desc())
-            .all()
-        )
-        stats['episode_placeholders_seen'] = len(episode_rows)
-        episode_path_by_id: dict[int, str | None] = {}
-        for episode_id, path in episode_rows:
-            if episode_id not in episode_path_by_id:
-                episode_path_by_id[episode_id] = path
+            stats['episode_placeholders_seen'] = len(episode_rows)
+            episode_path_by_id: dict[int, str | None] = {}
+            for episode_id, path in episode_rows:
+                if episode_id not in episode_path_by_id:
+                    episode_path_by_id[episode_id] = path
 
-        if episode_path_by_id:
-            episodes = session.query(Episode).filter(Episode.id.in_(list(episode_path_by_id.keys()))).all()
-            for idx, episode in enumerate(episodes, start=1):
-                episode.has_placeholder = True
-                episode.placeholder_filepath = episode_path_by_id.get(episode.id)
-                session.add(episode)
-                stats['episodes_linked'] += 1
-                if idx % RECONCILE_LINK_PROGRESS_EVERY_ROWS == 0:
-                    elapsed = time.monotonic() - started_mono
-                    logger.info(
-                        "Placeholder reconcile progress (episodes link): "
-                        f"linked={idx}/{len(episodes)} "
-                        f"elapsed_s={elapsed:.1f}",
-                        extra={'emoji_type': 'info'},
-                    )
+            if episode_path_by_id:
+                episode_ids = list(episode_path_by_id.keys())
+                for chunk_start in range(0, len(episode_ids), RECONCILE_LINK_CHUNK_SIZE):
+                    chunk_ids = episode_ids[chunk_start : chunk_start + RECONCILE_LINK_CHUNK_SIZE]
+                    episodes = session.query(Episode).filter(Episode.id.in_(chunk_ids)).all()
+                    for episode in episodes:
+                        episode.has_placeholder = True
+                        episode.placeholder_filepath = episode_path_by_id.get(episode.id)
+                        session.add(episode)
+                        stats['episodes_linked'] += 1
+                    session.commit()
+                    session.expunge_all()
+                    linked = min(chunk_start + len(chunk_ids), len(episode_ids))
+                    if linked % RECONCILE_LINK_PROGRESS_EVERY_ROWS == 0 or linked == len(episode_ids):
+                        elapsed = time.monotonic() - started_mono
+                        logger.info(
+                            "Placeholder reconcile progress (episodes link): "
+                            f"linked={linked}/{len(episode_ids)} "
+                            f"elapsed_s={elapsed:.1f}",
+                            extra={'emoji_type': 'info'},
+                        )
 
-        from services.series_episode_stats_hooks import refresh_series_stats_after_bulk
+            from services.series_episode_stats_hooks import refresh_series_stats_after_bulk
 
-        refresh_series_stats_after_bulk(session, full=True)
-        session.commit()
-        elapsed = time.monotonic() - started_mono
-        logger.info(
-            f"Placeholder reconcile elapsed_s={elapsed:.1f}",
-            extra={'emoji_type': 'info'},
-        )
-        logger.info(f"Placeholder reconcile complete: {stats}", extra={'emoji_type': 'success'})
-        return stats
+            refresh_series_stats_after_bulk(session, full=True)
+            session.commit()
+            elapsed = time.monotonic() - started_mono
+            log_phase_boundary(
+                "placeholder_reconcile",
+                event="complete",
+                elapsed_s=elapsed,
+                rows=active_count,
+                extra={"movies_linked": stats['movies_linked'], "episodes_linked": stats['episodes_linked']},
+            )
+            logger.info(f"Placeholder reconcile complete: {stats}", extra={'emoji_type': 'success'})
+            return stats
     except Exception as e:
         session.rollback()
         logger.error(f"Placeholder reconcile failed: {e}", extra={'emoji_type': 'error'})
@@ -888,114 +938,180 @@ def run_determination_pass() -> dict:
     }
 
     try:
-        started_mono = time.monotonic()
-        last_log_movies: list[float] = [started_mono]
-        last_log_episodes: list[float] = [started_mono]
-        placeholders_enabled = bool(settings.coming_soon_placeholders_enabled)
-        lookahead_days = int(getattr(settings, 'CALENDAR_LOOKAHEAD_DAYS', 30) or 30)
-        now_date = datetime.now(timezone.utc).date()
+        with PhaseTimer("determination"):
+            started_mono = time.monotonic()
+            last_log_movies: list[float] = [started_mono]
+            last_log_episodes: list[float] = [started_mono]
+            placeholders_enabled = bool(settings.coming_soon_placeholders_enabled)
+            lookahead_days = int(getattr(settings, 'CALENDAR_LOOKAHEAD_DAYS', 30) or 30)
+            now_date = datetime.now(timezone.utc).date()
 
-        movies = session.query(Movie).all()
-        stats['movies_total'] = len(movies)
-        logger.info(
-            f"Determination · full_scan · movies: {len(movies)} rows to check",
-            extra={'emoji_type': 'info'},
-        )
-        for idx, movie in enumerate(movies, start=1):
-            value, path_drift = _resolve_movie_determination(
-                session,
-                movie,
-                placeholders_enabled=placeholders_enabled,
-                lookahead_days=lookahead_days,
-                now_date=now_date,
+            movies = session.query(Movie).all()
+            stats['movies_total'] = len(movies)
+            logger.info(
+                f"Determination · full_scan · movies: {len(movies)} rows to check",
+                extra={'emoji_type': 'info'},
             )
-            if path_drift:
-                stats['path_drift_movies'] += 1
-                logger.debug(
-                    f'Placeholder path drift movie_id={movie.id} tmdbid={getattr(movie, "tmdbid", None)} '
-                    f'expected={movie_placeholder_path(movie)!r} stored={getattr(movie, "placeholder_filepath", None)!r}',
-                    extra={'emoji_type': 'debug'},
+            for idx, movie in enumerate(movies, start=1):
+                value, path_drift = _resolve_movie_determination(
+                    session,
+                    movie,
+                    placeholders_enabled=placeholders_enabled,
+                    lookahead_days=lookahead_days,
+                    now_date=now_date,
                 )
-            stats[value] += 1
-            if getattr(movie, 'determination', None) != value:
-                movie.determination = value
-                movie.determination_updated_at = func.now()
-                session.add(movie)
-                stats['movies_changed'] += 1
-            _determination_log_progress(
-                scope="full_scan",
-                label="movies",
-                idx=idx,
-                total=len(movies),
-                stats=stats,
-                started_mono=started_mono,
-                last_log_mono=last_log_movies,
-                movie_phase=True,
+                if path_drift:
+                    stats['path_drift_movies'] += 1
+                    logger.debug(
+                        f'Placeholder path drift movie_id={movie.id} tmdbid={getattr(movie, "tmdbid", None)} '
+                        f'expected={movie_placeholder_path(movie)!r} stored={getattr(movie, "placeholder_filepath", None)!r}',
+                        extra={'emoji_type': 'debug'},
+                    )
+                stats[value] += 1
+                if getattr(movie, 'determination', None) != value:
+                    movie.determination = value
+                    movie.determination_updated_at = func.now()
+                    session.add(movie)
+                    stats['movies_changed'] += 1
+                _determination_log_progress(
+                    scope="full_scan",
+                    label="movies",
+                    idx=idx,
+                    total=len(movies),
+                    stats=stats,
+                    started_mono=started_mono,
+                    last_log_mono=last_log_movies,
+                    movie_phase=True,
+                )
+            session.commit()
+            session.expunge_all()
+
+            include_specials = bool(getattr(settings, 'INCLUDE_SPECIALS', False))
+            stats['episodes_total'] = int(session.query(Episode).count() or 0)
+            logger.info(
+                f"Determination · full_scan · episodes: {stats['episodes_total']} rows to check",
+                extra={'emoji_type': 'info'},
             )
 
-        include_specials = bool(getattr(settings, 'INCLUDE_SPECIALS', False))
-        episodes = session.query(Episode).all()
-        stats['episodes_total'] = len(episodes)
-        logger.info(
-            f"Determination · full_scan · episodes: {len(episodes)} rows to check",
-            extra={'emoji_type': 'info'},
-        )
-        episode_ids = [int(getattr(ep, "id")) for ep in episodes if getattr(ep, "id", None) is not None]
-        season_rows = (
-            session.query(Episode.id, Season.series_id, Season.season_number, Episode.episode_number)
-            .join(Season, Episode.season_id == Season.id)
-            .filter(Episode.id.in_(episode_ids))
-            .all()
-            if episode_ids
-            else []
-        )
-        episode_order_meta_by_id: dict[int, tuple[int, int, int]] = {}
-        series_ids: set[int] = set()
-        for eid, series_id, season_number, episode_number in season_rows:
-            if eid is None or series_id is None:
-                continue
-            ep_meta = (
-                int(series_id),
-                int(season_number or 0),
-                int(episode_number or 0),
+            season_rows = (
+                session.query(Episode.id, Season.series_id, Season.season_number, Episode.episode_number)
+                .join(Season, Episode.season_id == Season.id)
+                .all()
             )
-            episode_order_meta_by_id[int(eid)] = ep_meta
-            series_ids.add(int(series_id))
+            episode_order_meta_by_id: dict[int, tuple[int, int, int]] = {}
+            series_ids: set[int] = set()
+            for eid, series_id, season_number, episode_number in season_rows:
+                if eid is None or series_id is None:
+                    continue
+                ep_meta = (
+                    int(series_id),
+                    int(season_number or 0),
+                    int(episode_number or 0),
+                )
+                episode_order_meta_by_id[int(eid)] = ep_meta
+                series_ids.add(int(series_id))
+            session.expunge_all()
 
-        horizon = now_date + timedelta(days=int(lookahead_days)) if int(lookahead_days) >= 0 else None
-        known_rows = (
-            session.query(Season.series_id, Season.season_number, Episode.episode_number)
-            .join(Season, Episode.season_id == Season.id)
-            .filter(
-                Season.series_id.in_(list(series_ids)),
-                Episode.air_date.isnot(None),
-                Episode.is_deleted == False,  # noqa: E712
+            horizon = now_date + timedelta(days=int(lookahead_days)) if int(lookahead_days) >= 0 else None
+            known_rows = (
+                session.query(Season.series_id, Season.season_number, Episode.episode_number)
+                .join(Season, Episode.season_id == Season.id)
+                .filter(
+                    Season.series_id.in_(list(series_ids)),
+                    Episode.air_date.isnot(None),
+                    Episode.is_deleted == False,  # noqa: E712
+                )
+                .filter(Episode.air_date <= horizon if horizon is not None else True)
+                .all()
+                if series_ids
+                else []
             )
-            .filter(Episode.air_date <= horizon if horizon is not None else True)
-            .all()
-            if series_ids
-            else []
-        )
-        series_max_known_order_within_horizon: dict[int, tuple[int, int]] = {}
-        for series_id, season_number, episode_number in known_rows:
-            if series_id is None:
-                continue
-            order = (int(season_number or 0), int(episode_number or 0))
-            sid = int(series_id)
-            prev = series_max_known_order_within_horizon.get(sid)
-            if prev is None or order > prev:
-                series_max_known_order_within_horizon[sid] = order
+            series_max_known_order_within_horizon: dict[int, tuple[int, int]] = {}
+            for series_id, season_number, episode_number in known_rows:
+                if series_id is None:
+                    continue
+                order = (int(season_number or 0), int(episode_number or 0))
+                sid = int(series_id)
+                prev = series_max_known_order_within_horizon.get(sid)
+                if prev is None or order > prev:
+                    series_max_known_order_within_horizon[sid] = order
+            session.expunge_all()
 
-        last_log_episodes[0] = time.monotonic()
-        for idx, episode in enumerate(episodes, start=1):
-            episode_meta = episode_order_meta_by_id.get(int(episode.id)) if getattr(episode, "id", None) is not None else None
-            season_number = int(episode_meta[1]) if episode_meta is not None else -1
-            # Treat season 0 episodes as not_needed when specials are disabled
-            # (unless the user forced a placeholder for this episode).
-            if not include_specials:
-                if season_number == 0 and not bool(getattr(episode, "force_placeholder", False)):
-                    value = DETERMINATION_NOT_NEEDED
+            last_log_episodes[0] = time.monotonic()
+            last_id = 0
+            processed = 0
+            total_episodes = stats['episodes_total']
+            while True:
+                chunk = (
+                    session.query(Episode)
+                    .filter(Episode.id > last_id)
+                    .order_by(Episode.id)
+                    .limit(DETERMINATION_CHUNK_SIZE)
+                    .all()
+                )
+                if not chunk:
+                    break
+                for episode in chunk:
+                    processed += 1
+                    idx = processed
+                    episode_meta = (
+                        episode_order_meta_by_id.get(int(episode.id))
+                        if getattr(episode, "id", None) is not None
+                        else None
+                    )
+                    season_number = int(episode_meta[1]) if episode_meta is not None else -1
+                    if not include_specials:
+                        if season_number == 0 and not bool(getattr(episode, "force_placeholder", False)):
+                            value = DETERMINATION_NOT_NEEDED
+                            stats[value] += 1
+                            if getattr(episode, 'determination', None) != value:
+                                episode.determination = value
+                                episode.determination_updated_at = func.now()
+                                session.add(episode)
+                                stats['episodes_changed'] += 1
+                            _determination_log_progress(
+                                scope="full_scan",
+                                label="episodes",
+                                idx=idx,
+                                total=total_episodes,
+                                stats=stats,
+                                started_mono=started_mono,
+                                last_log_mono=last_log_episodes,
+                                movie_phase=False,
+                            )
+                            continue
+                    value, path_drift = _resolve_episode_determination(
+                        session,
+                        episode,
+                        placeholders_enabled=placeholders_enabled,
+                        lookahead_days=lookahead_days,
+                        now_date=now_date,
+                        episode_order_meta=episode_meta,
+                        series_max_known_order_within_horizon=series_max_known_order_within_horizon,
+                    )
+                    if path_drift:
+                        stats['path_drift_episodes'] += 1
+                        season = session.query(Season).filter(Season.id == episode.season_id).first()
+                        series = (
+                            session.query(Series).filter(Series.id == season.series_id).first()
+                            if season
+                            else None
+                        )
+                        exp_repr = (
+                            episode_placeholder_path(episode, season, series)
+                            if season and series
+                            else None
+                        )
+                        logger.debug(
+                            f'Placeholder path drift episode_id={episode.id} stored={getattr(episode, "placeholder_filepath", None)!r} '
+                            f'expected={exp_repr!r}',
+                            extra={'emoji_type': 'debug'},
+                        )
                     stats[value] += 1
+                    if value == DETERMINATION_NOT_NEEDED:
+                        bucket = _classify_episode_not_needed_bucket(episode, now_date=now_date)
+                        if bucket:
+                            stats[bucket] += 1
                     if getattr(episode, 'determination', None) != value:
                         episode.determination = value
                         episode.determination_updated_at = func.now()
@@ -1005,64 +1121,19 @@ def run_determination_pass() -> dict:
                         scope="full_scan",
                         label="episodes",
                         idx=idx,
-                        total=len(episodes),
+                        total=total_episodes,
                         stats=stats,
                         started_mono=started_mono,
                         last_log_mono=last_log_episodes,
                         movie_phase=False,
                     )
-                    continue
-            value, path_drift = _resolve_episode_determination(
-                session,
-                episode,
-                placeholders_enabled=placeholders_enabled,
-                lookahead_days=lookahead_days,
-                now_date=now_date,
-                episode_order_meta=episode_meta,
-                series_max_known_order_within_horizon=series_max_known_order_within_horizon,
-            )
-            if path_drift:
-                stats['path_drift_episodes'] += 1
-                season = session.query(Season).filter(Season.id == episode.season_id).first()
-                series = (
-                    session.query(Series).filter(Series.id == season.series_id).first()
-                    if season
-                    else None
-                )
-                exp_repr = (
-                    episode_placeholder_path(episode, season, series)
-                    if season and series
-                    else None
-                )
-                logger.debug(
-                    f'Placeholder path drift episode_id={episode.id} stored={getattr(episode, "placeholder_filepath", None)!r} '
-                    f'expected={exp_repr!r}',
-                    extra={'emoji_type': 'debug'},
-                )
-            stats[value] += 1
-            if value == DETERMINATION_NOT_NEEDED:
-                bucket = _classify_episode_not_needed_bucket(episode, now_date=now_date)
-                if bucket:
-                    stats[bucket] += 1
-            if getattr(episode, 'determination', None) != value:
-                episode.determination = value
-                episode.determination_updated_at = func.now()
-                session.add(episode)
-                stats['episodes_changed'] += 1
-            _determination_log_progress(
-                scope="full_scan",
-                label="episodes",
-                idx=idx,
-                total=len(episodes),
-                stats=stats,
-                started_mono=started_mono,
-                last_log_mono=last_log_episodes,
-                movie_phase=False,
-            )
+                chunk_last_id = int(chunk[-1].id)
+                session.commit()
+                session.expunge_all()
+                last_id = chunk_last_id
 
-        session.commit()
-        logger.info(f"Determination · full_scan · complete: {stats}", extra={'emoji_type': 'success'})
-        return stats
+            logger.info(f"Determination · full_scan · complete: {stats}", extra={'emoji_type': 'success'})
+            return stats
     except Exception as e:
         session.rollback()
         logger.error(f"Determination · full_scan · failed: {e}", extra={'emoji_type': 'error'})

--- a/services/source_of_truth/entity_reconcile.py
+++ b/services/source_of_truth/entity_reconcile.py
@@ -203,6 +203,72 @@ def _find_active_reconcile_job(session, entity_type: str, entity_id: int) -> Job
     return None
 
 
+def _find_pending_reconcile_job(session, entity_type: str, entity_id: int) -> Job | None:
+    rows = (
+        session.query(Job)
+        .filter(
+            Job.job_type == ENTITY_RECONCILE_JOB_TYPE,
+            Job.status == "PENDING",
+        )
+        .order_by(Job.id.desc())
+        .limit(50)
+        .all()
+    )
+    want_type = str(entity_type).strip().lower()
+    want_id = int(entity_id)
+    for row in rows:
+        payload = _payload_dict(row)
+        if str(payload.get("entity_type") or "").strip().lower() != want_type:
+            continue
+        try:
+            if int(payload.get("entity_id")) != want_id:
+                continue
+        except (TypeError, ValueError):
+            continue
+        return row
+    return None
+
+
+def _enqueue_followup_reconcile_if_needed(
+    session,
+    *,
+    entity_type: str,
+    entity_id: int,
+    display_title: str,
+    source: str,
+) -> int | None:
+    """Queue a follow-up reconcile when policy changes during an in-flight job."""
+    if _find_pending_reconcile_job(session, entity_type, entity_id) is not None:
+        return None
+    kind = str(entity_type).strip().lower()
+    eid = int(entity_id)
+    body: dict[str, Any] = {
+        "entity_type": kind,
+        "entity_id": eid,
+        "source": f"followup:{source}",
+        "display_title": display_title,
+        "step": STEP_QUEUED,
+        "step_label": _step_label_for(STEP_QUEUED),
+    }
+    job = Job(
+        job_type=ENTITY_RECONCILE_JOB_TYPE,
+        payload=body,
+        status="PENDING",
+        max_attempts=3,
+        priority=PRIORITY_INTERACTIVE,
+        group_id=f"entity_reconcile:{body['entity_type']}:{body['entity_id']}",
+    )
+    session.add(job)
+    session.commit()
+    _log_reconcile_info(
+        kind,
+        display_title,
+        "Queued follow-up reconcile after in-flight job",
+        job_id=int(job.id),
+    )
+    return int(job.id)
+
+
 def _episode_row_ids_for_series(session, series_id: int) -> list[int]:
     rows = (
         session.query(Episode.id)
@@ -447,10 +513,18 @@ def enqueue_entity_reconcile(
                 "Already running — reusing in-flight job",
                 job_id=int(existing.id),
             )
+            followup_job_id = _enqueue_followup_reconcile_if_needed(
+                session,
+                entity_type=kind,
+                entity_id=eid,
+                display_title=display_title,
+                source=str(source or "").strip(),
+            )
             return {
                 "ok": True,
                 "job_id": int(existing.id),
                 "reused": True,
+                "followup_job_id": followup_job_id,
                 "step": payload.get("step") or STEP_QUEUED,
                 "step_label": payload.get("step_label") or _step_label_for(STEP_QUEUED),
             }

--- a/services/source_of_truth/event_handlers.py
+++ b/services/source_of_truth/event_handlers.py
@@ -22,7 +22,6 @@ from services.source_of_truth.arr_api import (
     fetch_radarr_movie,
     fetch_sonarr_episodes,
     fetch_sonarr_series_item,
-    fetch_sonarr_episode_item,
 )
 from services.source_of_truth.arr_share_guard import expand_determination_entity_ids
 from services.source_of_truth.determiner import (
@@ -44,6 +43,7 @@ from services.source_of_truth.sync_runner import (
     _episode_fields,
     _movie_fields,
     _resolve_episode_file_payload,
+    _resolve_episode_sync_payload,
     _series_fields,
     _upsert_episode,
     _upsert_movie,
@@ -263,14 +263,10 @@ def process_series_add_event(payload: dict[str, Any], instance: str | None = Non
                 stats["seasons_upserted"] += 1
 
             sonarr_ep_id = ep.get("id")
-            # Fetch detailed episode payload to capture thumbnails/runtime (bulk /episode omits them)
-            if sonarr_ep_id:
-                detailed_ep = fetch_sonarr_episode_item(int(sonarr_ep_id), url=base_url, api_key=api_key)
-                if detailed_ep:
-                    ep = detailed_ep
+            ep_effective = _resolve_episode_sync_payload(ep, base_url, api_key)
 
-            episode_file = _resolve_episode_file_payload(ep, base_url, api_key)
-            ep_fields = _episode_fields(series_row, season_row, ep, episode_file)
+            episode_file = _resolve_episode_file_payload(ep_effective, base_url, api_key)
+            ep_fields = _episode_fields(series_row, season_row, ep_effective, episode_file)
 
             overview = str(ep.get("overview") or "").strip()
             if overview and season_number not in season_overview_by_number:

--- a/services/source_of_truth/event_playback.py
+++ b/services/source_of_truth/event_playback.py
@@ -4,7 +4,7 @@ import os
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import and_, func, or_, text
+from sqlalchemy import and_, or_, text
 
 from core.config import settings
 from core.logger import logger
@@ -907,6 +907,58 @@ def _episode_lookahead() -> int:
         return 5
 
 
+def _forward_episode_window(
+    scoped_query,
+    *,
+    season_number: int,
+    episode_number: int,
+    lookahead: int,
+) -> list[Episode]:
+    """Next ``lookahead`` episodes in airing order from the played episode (may cross seasons)."""
+    return (
+        scoped_query
+        .filter(
+            or_(
+                Season.season_number > int(season_number),
+                and_(Season.season_number == int(season_number), Episode.episode_number >= int(episode_number)),
+            )
+        )
+        .order_by(Season.season_number.asc(), Episode.episode_number.asc())
+        .limit(int(lookahead))
+        .all()
+    )
+
+
+def _series_last_episode(scoped_query):
+    """Last episode Placeholdarr stores for the series (respects scoped_query specials filter)."""
+    return (
+        scoped_query
+        .order_by(Season.season_number.desc(), Episode.episode_number.desc())
+        .first()
+    )
+
+
+def _window_includes_later_season(window: list[Episode], season_number: int) -> bool:
+    return any(
+        int(getattr(getattr(ep, 'season', None), 'season_number', 0) or 0) > int(season_number)
+        for ep in window
+    )
+
+
+def _window_reaches_series_end(window: list[Episode], last_episode: Episode | None) -> bool:
+    if not window or not last_episode:
+        return False
+    final_window_episode = window[-1]
+    final_target_season = final_window_episode.season.season_number if final_window_episode.season else 0
+    final_target_episode = int(final_window_episode.episode_number or 0)
+    max_season = last_episode.season.season_number if last_episode.season else 0
+    max_episode = int(last_episode.episode_number or 0)
+    return bool(
+        final_target_season > max_season
+        or (final_target_season == max_season and final_target_episode >= max_episode)
+    )
+
+
 def _collect_episode_targets(session, series_row: Series, season_number: int | None, episode_number: int | None) -> tuple[list[Episode], dict[str, Any]]:
     mode = _play_mode()
     include_specials = bool(getattr(settings, 'INCLUDE_SPECIALS', False))
@@ -951,20 +1003,16 @@ def _collect_episode_targets(session, series_row: Series, season_number: int | N
         )
         targets.extend(season_targets)
 
-        max_in_season = None
         if episode_number is not None:
-            max_in_season = (
-                session.query(Episode)
-                .join(Season, Episode.season_id == Season.id)
-                .filter(
-                    Season.series_id == series_row.id,
-                    Season.season_number == season_number,
-                    Episode.is_deleted == False,  # noqa: E712
-                )
-                .order_by(Episode.episode_number.desc())
-                .first()
+            window = _forward_episode_window(
+                scoped_query,
+                season_number=int(season_number),
+                episode_number=int(episode_number),
+                lookahead=lookahead,
             )
-            if max_in_season and int(episode_number) >= int(max_in_season.episode_number or 0):
+            metadata['window_size'] = len(window)
+
+            if _window_includes_later_season(window, int(season_number)):
                 next_targets = (
                     scoped_query
                     .filter(
@@ -977,20 +1025,10 @@ def _collect_episode_targets(session, series_row: Series, season_number: int | N
                 targets.extend(next_targets)
                 metadata['season_boundary_next_included'] = True
 
-        # Match Episode-mode behavior: when the user reaches the end of the highest season Placeholdarr
-        # stores, mark the whole series monitored in Sonarr so newly-added future seasons/episodes are picked up.
-        max_season_q = session.query(func.max(Season.season_number)).filter(Season.series_id == series_row.id)
-        if not include_specials:
-            max_season_q = max_season_q.filter(Season.season_number > 0)
-        max_season_num = max_season_q.scalar()
-        if (
-            episode_number is not None
-            and max_in_season is not None
-            and max_season_num is not None
-            and int(season_number) == int(max_season_num)
-            and int(episode_number) >= int(max_in_season.episode_number or 0)
-        ):
-            metadata['reached_end'] = True
+            # Match Episode-mode behavior: when the lookahead window reaches the end of known
+            # episodes, mark the whole series monitored in Sonarr for newly-added seasons.
+            last_episode = _series_last_episode(scoped_query)
+            metadata['reached_end'] = _window_reaches_series_end(window, last_episode)
 
         metadata['scope'] = 'season'
         return targets, metadata
@@ -998,41 +1036,16 @@ def _collect_episode_targets(session, series_row: Series, season_number: int | N
     if episode_number is None:
         return [], {'mode': mode, 'reason': 'missing_episode_number'}
 
-    window = (
-        scoped_query
-        .filter(
-            or_(
-                Season.season_number > int(season_number),
-                and_(Season.season_number == int(season_number), Episode.episode_number >= int(episode_number)),
-            )
-        )
-        .order_by(Season.season_number.asc(), Episode.episode_number.asc())
-        .limit(int(lookahead))
-        .all()
+    window = _forward_episode_window(
+        scoped_query,
+        season_number=int(season_number),
+        episode_number=int(episode_number),
+        lookahead=lookahead,
     )
     targets.extend([ep for ep in window if not bool(getattr(ep, 'has_file', False))])
 
-    last_episode = (
-        session.query(Episode)
-        .join(Season, Episode.season_id == Season.id)
-        .filter(
-            Season.series_id == series_row.id,
-            Episode.is_deleted == False,  # noqa: E712
-            (Season.season_number > 0) if not include_specials else True,
-        )
-        .order_by(Season.season_number.desc(), Episode.episode_number.desc())
-        .first()
-    )
-    if window and last_episode:
-        final_window_episode = window[-1]
-        final_target_season = final_window_episode.season.season_number if final_window_episode.season else 0
-        final_target_episode = int(final_window_episode.episode_number or 0)
-        max_season = last_episode.season.season_number if last_episode.season else 0
-        max_episode = int(last_episode.episode_number or 0)
-        metadata['reached_end'] = bool(
-            final_target_season > max_season
-            or (final_target_season == max_season and final_target_episode >= max_episode)
-        )
+    last_episode = _series_last_episode(scoped_query)
+    metadata['reached_end'] = _window_reaches_series_end(window, last_episode)
     metadata['window_size'] = len(window)
     metadata['target_count'] = len(targets)
 

--- a/services/source_of_truth/force_placeholder.py
+++ b/services/source_of_truth/force_placeholder.py
@@ -1,0 +1,216 @@
+"""Force-placeholder pin preview and apply helpers for library detail UI."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+from core.config import settings
+from services.postgres.models import Episode, Movie, Season
+from services.source_of_truth.arr_share_guard import (
+    shared_placeholder_suppresses_creation,
+    sibling_episode_has_file,
+    sibling_movie_has_file,
+)
+from services.source_of_truth.determiner import (
+    _preferred_movie_release_date,
+    _series_monitored_for_episode,
+    _sibling_would_suppress_creation,
+    _skip_placeholders_when_monitored_enabled,
+    _skip_placeholders_when_series_monitored_enabled,
+)
+
+
+def _preferred_movie_date_label() -> str:
+    preferred = str(getattr(settings, "PREFERRED_MOVIE_DATE_TYPE", "inCinemas") or "inCinemas").strip()
+    mapping = {
+        "inCinemas": "theatrical release",
+        "digitalRelease": "digital release",
+        "physicalRelease": "physical release",
+    }
+    return mapping.get(preferred, "theatrical release")
+
+
+def _calendar_would_block(
+    *,
+    has_file: bool,
+    is_deleted: bool,
+    target_date: date | None,
+    release_status: str | None,
+    now_date: date,
+) -> bool:
+    if not bool(settings.coming_soon_placeholders_enabled):
+        return False
+    if has_file or is_deleted:
+        return False
+    lookahead = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
+    if lookahead < 0:
+        return False
+    if target_date is None:
+        return str(release_status or "").strip().lower() != "released"
+    days_until = (target_date - now_date).days
+    if lookahead == 0:
+        return days_until > 0
+    return days_until > lookahead
+
+
+def _movie_blocking_reasons(session, movie: Movie, *, now_date: date) -> list[str]:
+    reasons: list[str] = []
+    has_file = bool(getattr(movie, "has_file", False))
+    is_deleted = bool(getattr(movie, "is_deleted", False))
+    target_date = _preferred_movie_release_date(movie)
+    if _calendar_would_block(
+        has_file=has_file,
+        is_deleted=is_deleted,
+        target_date=target_date,
+        release_status=getattr(movie, "radarr_release_status", None),
+        now_date=now_date,
+    ):
+        label = _preferred_movie_date_label()
+        if target_date is None:
+            reasons.append(f"Outside calendar window ({label} date unknown).")
+        else:
+            days = (target_date - now_date).days
+            reasons.append(
+                f"Outside calendar window ({label} {target_date.isoformat()}, {days} days away)."
+            )
+    if (
+        _skip_placeholders_when_monitored_enabled()
+        and not has_file
+        and not is_deleted
+        and bool(getattr(movie, "radarr_monitored", False))
+    ):
+        reasons.append("Skip-when-monitored is on and this title is monitored in Radarr.")
+    return reasons
+
+
+def _episode_blocking_reasons(session, episode: Episode, *, now_date: date) -> list[str]:
+    reasons: list[str] = []
+    has_file = bool(getattr(episode, "has_file", False))
+    is_deleted = bool(getattr(episode, "is_deleted", False))
+    season = session.query(Season).filter(Season.id == episode.season_id).first()
+    season_number = int(getattr(season, "season_number", 0) or 0) if season else 0
+    include_specials = bool(getattr(settings, "INCLUDE_SPECIALS", False))
+    if not include_specials and season_number == 0:
+        reasons.append("Season 0 specials are excluded by settings.")
+    air_date = getattr(episode, "air_date", None)
+    if _calendar_would_block(
+        has_file=has_file,
+        is_deleted=is_deleted,
+        target_date=air_date,
+        release_status=None,
+        now_date=now_date,
+    ):
+        if air_date is None:
+            reasons.append("Outside calendar window (air date unknown).")
+        else:
+            days = (air_date - now_date).days
+            reasons.append(f"Outside calendar window (airs {air_date.isoformat()}, {days} days away).")
+    series_monitored = (
+        _series_monitored_for_episode(session, episode)
+        if _skip_placeholders_when_series_monitored_enabled()
+        else False
+    )
+    if (
+        _skip_placeholders_when_monitored_enabled()
+        and not has_file
+        and not is_deleted
+        and (bool(getattr(episode, "sonarr_monitored", False)) or series_monitored)
+    ):
+        reasons.append("Skip-when-monitored is on and this episode (or series) is monitored in Sonarr.")
+    return reasons
+
+
+def preview_movie_force_placeholder(session, movie: Movie) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    has_file = bool(getattr(movie, "has_file", False))
+    is_deleted = bool(getattr(movie, "is_deleted", False))
+    sibling_has_file = sibling_movie_has_file(session, movie)
+    shared_on = shared_placeholder_suppresses_creation("radarr")
+    can_force = not has_file and not is_deleted
+    block_message = None
+    if has_file:
+        block_message = "A real file already exists. Pin does nothing in that case."
+    elif is_deleted:
+        block_message = "This title was removed from Radarr. Pin cannot be applied."
+    return {
+        "ok": True,
+        "media_type": "movie",
+        "title": str(getattr(movie, "title", "") or "Movie"),
+        "force_placeholder": bool(getattr(movie, "force_placeholder", False)),
+        "force_placeholder_despite_sibling": bool(
+            getattr(movie, "force_placeholder_despite_sibling", False)
+        ),
+        "can_force": can_force,
+        "block_message": block_message,
+        "has_file": has_file,
+        "is_deleted": is_deleted,
+        "blocking_reasons": _movie_blocking_reasons(session, movie, now_date=now_date),
+        "sibling_has_file": sibling_has_file,
+        "shared_suppression_enabled": shared_on,
+        "sibling_option_available": bool(
+            can_force and shared_on and sibling_has_file
+        ),
+        "sibling_would_suppress": _sibling_would_suppress_creation(
+            arr_type="radarr",
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_has_file=sibling_has_file,
+        ),
+    }
+
+
+def preview_episode_force_placeholder(session, episode: Episode) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    has_file = bool(getattr(episode, "has_file", False))
+    is_deleted = bool(getattr(episode, "is_deleted", False))
+    sibling_has_file = sibling_episode_has_file(session, episode)
+    shared_on = shared_placeholder_suppresses_creation("sonarr")
+    can_force = not has_file and not is_deleted
+    block_message = None
+    if has_file:
+        block_message = "A real file already exists. Pin does nothing in that case."
+    elif is_deleted:
+        block_message = "This episode was removed from Sonarr. Pin cannot be applied."
+    title = str(getattr(episode, "title", "") or f"Episode {getattr(episode, 'episode_number', '')}")
+    return {
+        "ok": True,
+        "media_type": "episode",
+        "title": title,
+        "force_placeholder": bool(getattr(episode, "force_placeholder", False)),
+        "force_placeholder_despite_sibling": bool(
+            getattr(episode, "force_placeholder_despite_sibling", False)
+        ),
+        "can_force": can_force,
+        "block_message": block_message,
+        "has_file": has_file,
+        "is_deleted": is_deleted,
+        "blocking_reasons": _episode_blocking_reasons(session, episode, now_date=now_date),
+        "sibling_has_file": sibling_has_file,
+        "shared_suppression_enabled": shared_on,
+        "sibling_option_available": bool(
+            can_force and shared_on and sibling_has_file
+        ),
+        "sibling_would_suppress": _sibling_would_suppress_creation(
+            arr_type="sonarr",
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_has_file=sibling_has_file,
+        ),
+    }
+
+
+def apply_force_placeholder_flags(
+    entity: Movie | Episode,
+    *,
+    enabled: bool,
+    despite_sibling: bool,
+) -> None:
+    """Mutate entity force flags. Caller owns session commit."""
+    from services.source_of_truth.placeholder_policy import apply_placeholder_policy
+
+    apply_placeholder_policy(
+        entity,
+        policy="pinned" if enabled else "auto",
+        despite_sibling=despite_sibling,
+    )

--- a/services/source_of_truth/materializer.py
+++ b/services/source_of_truth/materializer.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from sqlalchemy import func, or_
 
+from services.source_of_truth.calendar_phase import (
+    compute_dummy_variant_for_episode,
+    compute_dummy_variant_for_movie,
+)
 from core.config import settings
 from core.logger import logger, start_verbose_stall_heartbeat
 from services.media_servers.refresh import refresh_all_path_batches_with_section_fallback, refresh_selected_sections
@@ -232,40 +236,12 @@ def _target_refresh_section_ids(*, has_movies: bool, has_episodes: bool) -> list
 
 def _compute_initial_dummy_variant_for_episode(episode: Episode) -> str:
     """Return 'coming_soon' or 'request' for dummy file selection at episode creation time."""
-    lookahead_days = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
-    if not settings.coming_soon_placeholders_enabled:
-        return "request"
-    if lookahead_days <= 0:
-        return "request"
-    air_date = getattr(episode, "air_date", None)
-    if not air_date:
-        return "request"
-    days_until = (air_date - datetime.now(timezone.utc).date()).days
-    if days_until < 0 or days_until > lookahead_days:
-        return "request"
-    return "coming_soon"
+    return compute_dummy_variant_for_episode(episode)
 
 
 def _compute_initial_dummy_variant_for_movie(movie: Movie) -> str:
     """Return 'coming_soon' or 'request' for dummy file selection at movie creation time."""
-    lookahead_days = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
-    if not settings.coming_soon_placeholders_enabled:
-        return "request"
-    if lookahead_days <= 0:
-        return "request"
-    preferred = str(getattr(settings, "PREFERRED_MOVIE_DATE_TYPE", "inCinemas") or "inCinemas").strip()
-    release_map = {
-        "inCinemas": "theater_release_date",
-        "digitalRelease": "digital_release_date",
-        "physicalRelease": "physical_release_date",
-    }
-    release_date = getattr(movie, release_map.get(preferred, "theater_release_date"), None)
-    if not release_date:
-        return "request"
-    days_until = (release_date - datetime.now(timezone.utc).date()).days
-    if days_until < 0 or days_until > lookahead_days:
-        return "request"
-    return "coming_soon"
+    return compute_dummy_variant_for_movie(movie)
 
 
 def _dummy_file_path_for_variant(variant: str) -> str:

--- a/services/source_of_truth/materializer.py
+++ b/services/source_of_truth/materializer.py
@@ -658,6 +658,8 @@ def apply_movie_materialization(movie_id: int, session=None, activity_reason: st
 
             movie.has_placeholder = False
             movie.placeholder_filepath = None
+            movie.determination = DETERMINATION_NOT_NEEDED
+            movie.determination_updated_at = func.now()
             movie.updated_at = func.now()
             _sync_content_placeholder_status(session, movie_id=movie.id, episode_id=None)
             session.add(movie)
@@ -782,6 +784,8 @@ def apply_episode_materialization(episode_id: int, session=None, activity_reason
 
             episode.has_placeholder = False
             episode.placeholder_filepath = None
+            episode.determination = DETERMINATION_NOT_NEEDED
+            episode.determination_updated_at = func.now()
             episode.updated_at = func.now()
             _sync_content_placeholder_status(session, movie_id=None, episode_id=episode.id)
             session.add(episode)

--- a/services/source_of_truth/media_refresh_handler.py
+++ b/services/source_of_truth/media_refresh_handler.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from sqlalchemy.orm.attributes import flag_modified
+
 from core.config import settings
 from core.logger import logger, start_verbose_stall_heartbeat
 from services.media_servers.refresh import (
@@ -57,6 +59,29 @@ KIND_DELAYED_FINAL = "delayed_final"
 # we don't loop forever on a configuration issue.
 _MAX_REENQUEUE_ATTEMPTS = 5
 
+# Path-batch refresh kinds that should merge into one pending job instead of fanning out.
+_COALESCE_KINDS = frozenset({KIND_DELAYED_FINAL, KIND_OVERLAP_PATH_BATCH})
+
+
+def _coalesce_group_id(kind: str) -> str:
+    return f"media_refresh:{kind}"
+
+
+def _merge_path_payload(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(existing)
+    for key in ("created_paths", "delete_paths"):
+        old_paths = merged.get(key) or []
+        new_paths = incoming.get(key) or []
+        if not isinstance(old_paths, list):
+            old_paths = list(old_paths) if old_paths else []
+        if not isinstance(new_paths, list):
+            new_paths = list(new_paths) if new_paths else []
+        merged[key] = sorted(set(str(p) for p in old_paths if p) | set(str(p) for p in new_paths if p))
+    for flag in ("has_movies", "has_episodes", "include_plex", "include_jellyfin", "include_emby"):
+        merged[flag] = bool(merged.get(flag)) or bool(incoming.get(flag))
+    merged["kind"] = str(incoming.get("kind") or existing.get("kind") or "")
+    return merged
+
 
 def use_job_driven_refresh() -> bool:
     return bool(getattr(settings, "USE_JOB_DRIVEN_REFRESH", True))
@@ -70,11 +95,16 @@ def enqueue_media_refresh_job(
     delay_seconds: float = 0.0,
     group_id: str | None = None,
     max_attempts: int = 5,
+    coalesce: bool | None = None,
 ) -> Job:
     """Add a media_refresh Job to the session. Caller is responsible for committing.
 
     Mirrors the contract of `threading.Timer(delay_seconds, fn).start()` — the
     callers pass the same delay (5, 20) currently in use.
+
+    When ``coalesce`` is true (default for delayed_final and overlap_path_batch),
+    an existing PENDING job with the same group_id has paths merged and run_after
+    pushed later so one refresh covers the combined path set.
     """
     job_payload: dict[str, Any] = {"kind": str(kind)}
     if payload:
@@ -86,13 +116,47 @@ def enqueue_media_refresh_job(
     from services.source_of_truth.job_priority import default_priority_for
 
     run_after = datetime.now(timezone.utc) + timedelta(seconds=max(0.0, float(delay_seconds)))
+    should_coalesce = coalesce if coalesce is not None else kind in _COALESCE_KINDS
+    resolved_group_id = group_id
+    if should_coalesce:
+        resolved_group_id = group_id or _coalesce_group_id(kind)
+        existing = (
+            session.query(Job)
+            .filter(
+                Job.job_type == MEDIA_REFRESH_JOB_TYPE,
+                Job.status == "PENDING",
+                Job.group_id == resolved_group_id,
+            )
+            .order_by(Job.id.desc())
+            .first()
+        )
+        if existing is not None:
+            old_payload = dict(existing.payload or {})
+            if str(old_payload.get("kind") or "") != str(kind):
+                old_payload = {}
+            merged_payload = _merge_path_payload(old_payload, job_payload)
+            existing.payload = merged_payload
+            flag_modified(existing, "payload")
+            prev_run_after = existing.run_after
+            if prev_run_after is None or prev_run_after < run_after:
+                existing.run_after = run_after
+            existing.updated_at = datetime.now(timezone.utc)
+            session.add(existing)
+            logger.info(
+                f"media_refresh coalesced kind={kind} group_id={resolved_group_id} "
+                f"created_paths={len(merged_payload.get('created_paths') or [])} "
+                f"delete_paths={len(merged_payload.get('delete_paths') or [])}",
+                extra={"emoji_type": "info"},
+            )
+            return existing
+
     job = Job(
         job_type=MEDIA_REFRESH_JOB_TYPE,
         payload=job_payload,
         status="PENDING",
         run_after=run_after,
         max_attempts=int(max_attempts),
-        group_id=group_id,
+        group_id=resolved_group_id,
         priority=default_priority_for(MEDIA_REFRESH_JOB_TYPE),
     )
     session.add(job)

--- a/services/source_of_truth/phase_metrics.py
+++ b/services/source_of_truth/phase_metrics.py
@@ -1,0 +1,91 @@
+"""Lightweight phase boundary metrics for sync/RAM observability."""
+
+from __future__ import annotations
+
+import resource
+import time
+from typing import Any
+
+from core.logger import logger
+
+
+def process_rss_mb() -> float | None:
+    """Return this process max RSS in MiB (Linux: ru_maxrss is KiB)."""
+    try:
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        return float(usage.ru_maxrss) / 1024.0
+    except Exception:
+        return None
+
+
+def arr_cache_snapshot() -> dict[str, int]:
+    try:
+        from services.source_of_truth.arr_api import cache_stats
+
+        return cache_stats()
+    except Exception:
+        return {"entries": 0, "max_entries": 0}
+
+
+def _format_metrics(
+    *,
+    elapsed_s: float | None = None,
+    rows: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> str:
+    parts: list[str] = []
+    rss = process_rss_mb()
+    if rss is not None:
+        parts.append(f"rss_mb={rss:.1f}")
+    cache = arr_cache_snapshot()
+    parts.append(f"arr_cache_entries={int(cache.get('entries') or 0)}")
+    if elapsed_s is not None:
+        parts.append(f"elapsed_s={elapsed_s:.1f}")
+    if rows is not None and elapsed_s is not None and elapsed_s > 0:
+        parts.append(f"rows_per_s={rows / elapsed_s:.2f}")
+    if extra:
+        for key, value in extra.items():
+            parts.append(f"{key}={value}")
+    return " · ".join(parts)
+
+
+def log_phase_boundary(
+    phase: str,
+    *,
+    event: str,
+    elapsed_s: float | None = None,
+    rows: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Emit a single structured line at phase start/end for operator grep."""
+    metrics = _format_metrics(elapsed_s=elapsed_s, rows=rows, extra=extra)
+    logger.info(
+        f"Phase metric · {phase} · {event} · {metrics}",
+        extra={"emoji_type": "info"},
+    )
+
+
+class PhaseTimer:
+    """Context manager that logs start/end with RSS and cache size."""
+
+    def __init__(self, phase: str, *, rows: int | None = None, extra: dict[str, Any] | None = None):
+        self.phase = phase
+        self.rows = rows
+        self.extra = extra
+        self._started_mono: float | None = None
+
+    def __enter__(self) -> PhaseTimer:
+        self._started_mono = time.monotonic()
+        log_phase_boundary(self.phase, event="start", extra=self.extra)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        elapsed = time.monotonic() - (self._started_mono or time.monotonic())
+        event = "failed" if exc_type else "end"
+        log_phase_boundary(
+            self.phase,
+            event=event,
+            elapsed_s=elapsed,
+            rows=self.rows,
+            extra=self.extra,
+        )

--- a/services/source_of_truth/placeholder_policy.py
+++ b/services/source_of_truth/placeholder_policy.py
@@ -1,0 +1,301 @@
+"""Placeholder policy (auto / pinned / never) preview and apply for library detail UI."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from sqlalchemy import func
+
+from services.postgres.db import get_session
+from services.postgres.models import Episode, Movie
+from services.source_of_truth.arr_share_guard import (
+    shared_placeholder_suppresses_creation,
+    sibling_episode_has_file,
+    sibling_movie_has_file,
+)
+from services.source_of_truth.determiner import (
+    DETERMINATION_EXISTS,
+    DETERMINATION_NEEDS,
+    DETERMINATION_NOT_NEEDED,
+    DETERMINATION_OBSOLETE,
+    _sibling_would_suppress_creation,
+)
+from services.source_of_truth.force_placeholder import (
+    _episode_blocking_reasons,
+    _movie_blocking_reasons,
+)
+from services.source_of_truth.materializer import (
+    apply_episode_materialization,
+    apply_movie_materialization,
+)
+
+PlaceholderPolicy = Literal["auto", "pinned", "never"]
+
+_ACTIVITY_REASON = "Placeholder policy"
+
+
+def policy_from_entity(entity: Movie | Episode) -> PlaceholderPolicy:
+    if bool(getattr(entity, "force_placeholder", False)):
+        return "pinned"
+    if bool(getattr(entity, "block_placeholder", False)):
+        return "never"
+    return "auto"
+
+
+def apply_placeholder_policy(
+    entity: Movie | Episode,
+    *,
+    policy: PlaceholderPolicy,
+    despite_sibling: bool = False,
+) -> None:
+    """Mutate entity policy flags. Caller owns session commit.
+
+    despite_sibling is ignored; multi-instance behavior follows Shared Placeholder Cleanup settings.
+    """
+    del despite_sibling
+    pol = str(policy or "auto").strip().lower()
+    if pol == "pinned":
+        entity.force_placeholder = True
+        entity.force_placeholder_despite_sibling = False
+        entity.block_placeholder = False
+    elif pol == "never":
+        entity.force_placeholder = False
+        entity.force_placeholder_despite_sibling = False
+        entity.block_placeholder = True
+    else:
+        entity.force_placeholder = False
+        entity.force_placeholder_despite_sibling = False
+        entity.block_placeholder = False
+
+
+def _policy_target_determination(
+    entity: Movie | Episode,
+    *,
+    arr_type: str,
+    sibling_has_file: bool,
+) -> str:
+    """Map pinned/never intent to a determination without full calendar rules."""
+    has_placeholder = bool(getattr(entity, "has_placeholder", False))
+    has_file = bool(getattr(entity, "has_file", False))
+    is_deleted = bool(getattr(entity, "is_deleted", False))
+    policy = policy_from_entity(entity)
+
+    if policy == "never":
+        if has_file or is_deleted:
+            return DETERMINATION_NOT_NEEDED
+        if has_placeholder:
+            return DETERMINATION_OBSOLETE
+        return DETERMINATION_NOT_NEEDED
+
+    # pinned
+    if has_file or is_deleted:
+        return DETERMINATION_NOT_NEEDED
+    sibling_block = _sibling_would_suppress_creation(
+        arr_type=arr_type,
+        has_file=has_file,
+        is_deleted=is_deleted,
+        sibling_has_file=sibling_has_file,
+    )
+    if sibling_block and not bool(getattr(entity, "force_placeholder_despite_sibling", False)):
+        return DETERMINATION_OBSOLETE if has_placeholder else DETERMINATION_NOT_NEEDED
+    if has_placeholder:
+        return DETERMINATION_EXISTS
+    return DETERMINATION_NEEDS
+
+
+def _entity_state_snapshot(entity: Movie | Episode) -> dict[str, Any]:
+    return {
+        "placeholder_policy": policy_from_entity(entity),
+        "force_placeholder": bool(getattr(entity, "force_placeholder", False)),
+        "block_placeholder": bool(getattr(entity, "block_placeholder", False)),
+        "has_file": bool(getattr(entity, "has_file", False)),
+        "has_placeholder": bool(getattr(entity, "has_placeholder", False)),
+    }
+
+
+def apply_movie_placeholder_policy_fast(movie_id: int) -> dict[str, Any]:
+    """Create/remove movie placeholder from current pinned/never flags (no Arr reconcile)."""
+    session = get_session()
+    try:
+        movie = session.query(Movie).filter(Movie.id == int(movie_id)).first()
+        if not movie:
+            return {"ok": False, "message": "Movie not found", "job_id": None}
+        sibling_has_file = sibling_movie_has_file(session, movie)
+        target = _policy_target_determination(
+            movie,
+            arr_type="radarr",
+            sibling_has_file=sibling_has_file,
+        )
+        movie.determination = target
+        movie.determination_updated_at = func.now()
+        session.add(movie)
+        if target not in (DETERMINATION_NEEDS, DETERMINATION_OBSOLETE):
+            session.commit()
+            return {
+                "ok": True,
+                "action": "noop",
+                "job_id": None,
+                **_entity_state_snapshot(movie),
+            }
+        out = apply_movie_materialization(
+            int(movie_id),
+            session=session,
+            activity_reason=_ACTIVITY_REASON,
+        )
+        if not out.get("ok", True):
+            session.rollback()
+            return {
+                "ok": False,
+                "message": str(out.get("reason") or "Placeholder update failed"),
+                "job_id": None,
+            }
+        session.commit()
+        session.refresh(movie)
+        return {
+            "ok": True,
+            "action": out.get("action") or "noop",
+            "path": out.get("path"),
+            "job_id": None,
+            **_entity_state_snapshot(movie),
+        }
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        return {"ok": False, "message": str(exc), "job_id": None}
+    finally:
+        session.close()
+
+
+def apply_episode_placeholder_policy_fast(episode_id: int) -> dict[str, Any]:
+    """Create/remove episode placeholder from current pinned/never flags (no Arr reconcile)."""
+    session = get_session()
+    try:
+        episode = session.query(Episode).filter(Episode.id == int(episode_id)).first()
+        if not episode:
+            return {"ok": False, "message": "Episode not found", "job_id": None}
+        sibling_has_file = sibling_episode_has_file(session, episode)
+        target = _policy_target_determination(
+            episode,
+            arr_type="sonarr",
+            sibling_has_file=sibling_has_file,
+        )
+        episode.determination = target
+        episode.determination_updated_at = func.now()
+        session.add(episode)
+        if target not in (DETERMINATION_NEEDS, DETERMINATION_OBSOLETE):
+            session.commit()
+            return {
+                "ok": True,
+                "action": "noop",
+                "job_id": None,
+                **_entity_state_snapshot(episode),
+            }
+        out = apply_episode_materialization(
+            int(episode_id),
+            session=session,
+            activity_reason=_ACTIVITY_REASON,
+        )
+        if not out.get("ok", True):
+            session.rollback()
+            return {
+                "ok": False,
+                "message": str(out.get("reason") or "Placeholder update failed"),
+                "job_id": None,
+            }
+        session.commit()
+        session.refresh(episode)
+        return {
+            "ok": True,
+            "action": out.get("action") or "noop",
+            "path": out.get("path"),
+            "job_id": None,
+            **_entity_state_snapshot(episode),
+        }
+    except Exception as exc:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        return {"ok": False, "message": str(exc), "job_id": None}
+    finally:
+        session.close()
+
+
+def _base_preview(
+    *,
+    media_type: str,
+    title: str,
+    entity: Movie | Episode,
+    session,
+    arr_type: str,
+    sibling_has_file: bool,
+    blocking_reasons: list[str],
+) -> dict[str, Any]:
+    has_file = bool(getattr(entity, "has_file", False))
+    is_deleted = bool(getattr(entity, "is_deleted", False))
+    has_placeholder = bool(getattr(entity, "has_placeholder", False))
+    shared_on = shared_placeholder_suppresses_creation(arr_type)
+    policy = policy_from_entity(entity)
+    block_message = None
+    if is_deleted:
+        block_message = "This title was removed from the library. Pin cannot be applied."
+    return {
+        "ok": True,
+        "media_type": media_type,
+        "title": title,
+        "placeholder_policy": policy,
+        "force_placeholder": bool(getattr(entity, "force_placeholder", False)),
+        "block_placeholder": bool(getattr(entity, "block_placeholder", False)),
+        "force_placeholder_despite_sibling": bool(
+            getattr(entity, "force_placeholder_despite_sibling", False)
+        ),
+        "can_force": not is_deleted,
+        "block_message": block_message,
+        "has_file": has_file,
+        "has_placeholder": has_placeholder,
+        "is_deleted": is_deleted,
+        "blocking_reasons": blocking_reasons,
+        "sibling_has_file": sibling_has_file,
+        "shared_suppression_enabled": shared_on,
+        "sibling_option_available": bool(not is_deleted and shared_on and sibling_has_file),
+        "sibling_would_suppress": _sibling_would_suppress_creation(
+            arr_type=arr_type,
+            has_file=has_file,
+            is_deleted=is_deleted,
+            sibling_has_file=sibling_has_file,
+        ),
+    }
+
+
+def preview_movie_placeholder_policy(session, movie: Movie) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    sibling_has_file = sibling_movie_has_file(session, movie)
+    return _base_preview(
+        media_type="movie",
+        title=str(getattr(movie, "title", "") or "Movie"),
+        entity=movie,
+        session=session,
+        arr_type="radarr",
+        sibling_has_file=sibling_has_file,
+        blocking_reasons=_movie_blocking_reasons(session, movie, now_date=now_date),
+    )
+
+
+def preview_episode_placeholder_policy(session, episode: Episode) -> dict[str, Any]:
+    now_date = datetime.now(timezone.utc).date()
+    sibling_has_file = sibling_episode_has_file(session, episode)
+    title = str(getattr(episode, "title", "") or f"Episode {getattr(episode, 'episode_number', '')}")
+    return _base_preview(
+        media_type="episode",
+        title=title,
+        entity=episode,
+        session=session,
+        arr_type="sonarr",
+        sibling_has_file=sibling_has_file,
+        blocking_reasons=_episode_blocking_reasons(session, episode, now_date=now_date),
+    )
+
+

--- a/services/source_of_truth/placeholder_policy.py
+++ b/services/source_of_truth/placeholder_policy.py
@@ -152,6 +152,10 @@ def apply_movie_placeholder_policy_fast(movie_id: int) -> dict[str, Any]:
             }
         session.commit()
         session.refresh(movie)
+        from services.source_of_truth.calendar_phase import refresh_pinned_entity_calendar_status
+
+        refresh_pinned_entity_calendar_status(session, movie)
+        session.commit()
         return {
             "ok": True,
             "action": out.get("action") or "noop",
@@ -207,6 +211,10 @@ def apply_episode_placeholder_policy_fast(episode_id: int) -> dict[str, Any]:
             }
         session.commit()
         session.refresh(episode)
+        from services.source_of_truth.calendar_phase import refresh_pinned_entity_calendar_status
+
+        refresh_pinned_entity_calendar_status(session, episode)
+        session.commit()
         return {
             "ok": True,
             "action": out.get("action") or "noop",

--- a/services/source_of_truth/status_orchestrator.py
+++ b/services/source_of_truth/status_orchestrator.py
@@ -24,6 +24,11 @@ from datetime import date, datetime, timezone
 from sqlalchemy.orm import Session
 
 from core.config import settings
+from services.source_of_truth.calendar_phase import (
+    _compute_calendar_decision,
+    _placeholder_force_pinned,
+    _preferred_movie_release_date,
+)
 from services.source_of_truth.status_intent import StatusIntent, StatusSource, DisplayStatus
 from services.postgres.models import Placeholder, Movie, Series, Season, Episode, EventLog
 from services.postgres.db import get_session
@@ -116,28 +121,27 @@ class StatusOrchestrator:
 
         This keeps event-driven materialization aligned with calendar-phase logic so
         newly created future items are not stuck as REQUEST until a later calendar pass.
+        Pinned placeholders bypass the calendar lookahead window and show countdown
+        or TBD/TBA labels like in-window calendar sync items.
         """
-        lookahead_days = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
+        snap_lookahead = int(getattr(settings, "CALENDAR_LOOKAHEAD_DAYS", 30) or 30)
         placeholders_enabled = bool(settings.coming_soon_placeholders_enabled)
         countdown_enabled = bool(getattr(settings, "ENABLE_COMING_SOON_COUNTDOWN", True))
         now_date = datetime.now(timezone.utc).date()
+        force_pinned = _placeholder_force_pinned(session, placeholder)
 
         media_type = None
         target_date = None
         has_file = False
+        release_type = None
+        release_type_preferred = False
 
         if getattr(placeholder, "movie_id", None):
             movie = session.get(Movie, int(placeholder.movie_id))
             if movie:
                 media_type = "movie"
                 has_file = bool(getattr(movie, "has_file", False))
-                preferred = str(getattr(settings, "PREFERRED_MOVIE_DATE_TYPE", "inCinemas") or "inCinemas").strip()
-                release_map = {
-                    "inCinemas": "theater_release_date",
-                    "digitalRelease": "digital_release_date",
-                    "physicalRelease": "physical_release_date",
-                }
-                target_date = getattr(movie, release_map.get(preferred, "theater_release_date"), None)
+                target_date, release_type, release_type_preferred = _preferred_movie_release_date(movie)
 
         elif getattr(placeholder, "episode_id", None):
             episode = session.get(Episode, int(placeholder.episode_id))
@@ -153,93 +157,36 @@ class StatusOrchestrator:
                 {"event_type": "creation", "reason": "unlinked_placeholder"},
             )
 
-        if has_file:
-            return (
-                DisplayStatus.AVAILABLE.value,
-                "Media file is available",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": None},
-            )
-
-        if not target_date:
-            return (
-                DisplayStatus.REQUEST.value,
-                "No release date available",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": None},
-            )
-
-        # Ensure target_date is a date object (not datetime) for safe subtraction
-        if hasattr(target_date, "date") and not isinstance(target_date, date):
+        if target_date is not None and hasattr(target_date, "date") and not isinstance(target_date, date):
             target_date = target_date.date()
 
-        days_until = (target_date - now_date).days
+        decision = _compute_calendar_decision(
+            target_date=target_date,
+            has_file=has_file,
+            media_type=media_type,
+            lookahead_days=snap_lookahead,
+            countdown_enabled=countdown_enabled,
+            placeholders_enabled=placeholders_enabled,
+            now_date=now_date,
+            release_type=release_type,
+            release_type_preferred=release_type_preferred,
+            force_pinned=force_pinned,
+        )
         logger.debug(
             f"Computing initial creation status for Placeholder[{placeholder.id}]: "
-            f"target_date={target_date} ({type(target_date)}), "
-            f"now_date={now_date} ({type(now_date)}), "
-            f"days_until={days_until}, "
-            f"lookahead_days={lookahead_days}, "
-            f"placeholders_enabled={placeholders_enabled}"
-        )
-        if not placeholders_enabled:
-            return (
-                DisplayStatus.REQUEST.value,
-                "Calendar placeholders disabled",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-
-        if lookahead_days == 0:
-            return (
-                DisplayStatus.REQUEST.value,
-                "Calendar lookahead disabled",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-
-        if days_until < 0:
-            return (
-                DisplayStatus.REQUEST.value,
-                "Release date passed; waiting for import",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-
-        if lookahead_days > 0 and days_until > lookahead_days:
-            return (
-                DisplayStatus.REQUEST.value,
-                f"Outside lookahead window ({lookahead_days} days)",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-
-        if not countdown_enabled:
-            label = "Airing soon" if media_type == "episode" else "Coming Soon"
-            return (
-                DisplayStatus.COMING_SOON.value,
-                label,
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-
-        if days_until == 0:
-            return (
-                DisplayStatus.COMING_SOON_TODAY.value,
-                "Airing today" if media_type == "episode" else "Coming Soon (Today)",
-                {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
-            )
-        if days_until <= 6:
-            status = DisplayStatus.COMING_SOON_1.value
-        elif days_until <= 13:
-            status = DisplayStatus.COMING_SOON_7.value
-        elif days_until <= 29:
-            status = DisplayStatus.COMING_SOON_14.value
-        else:
-            status = DisplayStatus.COMING_SOON_30.value
-
-        reason = "Airing in 1 day" if media_type == "episode" and days_until == 1 else (
-            f"Airing in {days_until} days" if media_type == "episode" else (
-                "Coming Soon (1 day)" if days_until == 1 else f"Coming Soon ({days_until} days)"
-            )
+            f"target_date={target_date}, now_date={now_date}, "
+            f"days_until={decision.days_until}, force_pinned={force_pinned}, "
+            f"status={decision.status}, reason={decision.reason!r}"
         )
         return (
-            status,
-            reason,
-            {"event_type": "creation", "media_type": media_type, "days_until_release": days_until},
+            decision.status,
+            decision.reason,
+            {
+                "event_type": "creation",
+                "media_type": media_type,
+                "days_until_release": decision.days_until,
+                "force_pinned": force_pinned,
+            },
         )
     
     # =========================================================================

--- a/services/source_of_truth/sync_runner.py
+++ b/services/source_of_truth/sync_runner.py
@@ -19,6 +19,7 @@ from services.source_of_truth.arr_api import (
     fetch_sonarr_series_item,
     fetch_sonarr_episode_item,
 )
+from services.source_of_truth.phase_metrics import log_phase_boundary
 
 
 def _extract_year(value, fallback: int = 0) -> int:
@@ -157,6 +158,24 @@ def _resolve_episode_file_payload(entry: Dict, base_url: str, api_key: str) -> D
         if isinstance(fetched, dict):
             return fetched
     return ep_file if isinstance(ep_file, dict) else {}
+
+
+def _resolve_episode_sync_payload(ep: Dict, base_url: str, api_key: str) -> Dict:
+    """Use bulk /episode rows from fetch_sonarr_episodes (includeImages + includeEpisodeFile).
+
+    Per-id GET is a last resort when still art is missing (older Sonarr or cache miss).
+    Episode file paths are resolved in _resolve_episode_file_payload (embedded object or /episodefile).
+    """
+    if not isinstance(ep, dict):
+        return ep
+    if _extract_image_url(ep, ('screenshot', 'still', 'cover')):
+        return ep
+    sonarr_ep_id = ep.get('id')
+    if sonarr_ep_id:
+        detailed = fetch_sonarr_episode_item(int(sonarr_ep_id), url=base_url, api_key=api_key)
+        if isinstance(detailed, dict):
+            return detailed
+    return ep
 
 
 def _derive_movie_arr_status(entry: Dict) -> str | None:
@@ -693,14 +712,11 @@ def run_full_sync(
                     series_title = str(s_fields.get('title') or series_entry.get('title') or 'series')
                     if total_episodes_in_series > 0:
                         logger.info(
-                            f"Enriching {total_episodes_in_series} episodes for '{series_title}'...",
+                            f"Syncing {total_episodes_in_series} episodes for '{series_title}'...",
                             extra={'emoji_type': 'info'},
                         )
                     for ep in episodes:
-                        sonarr_ep_id = ep.get('id')
-                        # Fetch detailed episode payload to capture thumbnails and extended metadata (episodes in bulk omit images)
-                        detailed_ep = fetch_sonarr_episode_item(int(sonarr_ep_id), url=base_url, api_key=api_key) if sonarr_ep_id else None
-                        ep_effective = detailed_ep if detailed_ep else ep
+                        ep_effective = _resolve_episode_sync_payload(ep, base_url, api_key)
                         episode_file = _resolve_episode_file_payload(ep_effective, base_url, api_key)
                         prepared_episodes.append((ep, ep_effective, episode_file))
 
@@ -811,6 +827,17 @@ def run_full_sync(
 
         elapsed = (datetime.now(timezone.utc) - started_at).total_seconds()
         stats['duration_seconds'] = round(elapsed, 2)
+        log_phase_boundary(
+            "arr_full_sync",
+            event="end",
+            elapsed_s=elapsed,
+            rows=int(stats.get("episodes_seen") or 0) + int(stats.get("movies_seen") or 0),
+            extra={
+                "instance_key": str(instance_key or ""),
+                "episodes_seen": int(stats.get("episodes_seen") or 0),
+                "movies_seen": int(stats.get("movies_seen") or 0),
+            },
+        )
         logger.info(f"Source-of-truth fullsync complete: {stats}", extra={'emoji_type': 'success'})
         # If the user saved Status Message changes with "Next full sync", materialize them
         # now so existing placeholders pick up the new templates.
@@ -1055,10 +1082,7 @@ def sync_sonarr_series_specials_season0_backfill(
                     stats["seasons_created"] += 1
 
                 sonarr_ep_id = ep.get("id")
-                detailed_ep = (
-                    fetch_sonarr_episode_item(int(sonarr_ep_id), url=base_url, api_key=api_key) if sonarr_ep_id else None
-                )
-                ep_effective = detailed_ep if detailed_ep else ep
+                ep_effective = _resolve_episode_sync_payload(ep, base_url, api_key)
 
                 episode_file = _resolve_episode_file_payload(ep_effective, base_url, api_key)
                 ep_fields = _episode_fields(series_row, season_row, ep_effective, episode_file)
@@ -1276,12 +1300,9 @@ def sync_sonarr_series_by_ids(
                 if season_created:
                     stats['seasons_created'] += 1
 
-                # Fetch detailed episode payload to capture thumbnails/meta (bulk /episode omits them)
+                # Use bulk row when sufficient; detail GET only for missing episodeFile embed.
                 sonarr_ep_id = ep.get('id')
-                if sonarr_ep_id:
-                    detailed_ep = fetch_sonarr_episode_item(int(sonarr_ep_id), url=base_url, api_key=api_key)
-                    if detailed_ep:
-                        ep = detailed_ep
+                ep = _resolve_episode_sync_payload(ep, base_url, api_key)
 
                 episode_file = _resolve_episode_file_payload(ep, base_url, api_key)
                 ep_fields = _episode_fields(series_row, season_row, ep, episode_file)

--- a/services/whats_new.py
+++ b/services/whats_new.py
@@ -108,6 +108,26 @@ NOTICES: tuple[WhatsNewNotice, ...] = (
         cta_path="/settings/media-integrations",
         requires_ack=True,
     ),
+    WhatsNewNotice(
+        id="placeholder-policy-0-9-23",
+        since_version="0.9.23",
+        title="Pin to Always/Never placeholder; Season search uses Lookahead",
+        body=(
+            "Movies and episodes now support Auto, Never, and Pinned placeholder policy from library detail. "
+            "Pinned keeps a placeholder even when calendar or monitored rules would skip the title; "
+            "Never blocks creation and can remove an existing placeholder. "
+            "Changes apply immediately after you save (Creating… / Removing… feedback on the row). "
+            "Open Why? on any title for a step-by-step determination audit showing why it does or does not have a placeholder.\n\n"
+            "Pinned placeholders show Coming Soon countdowns outside the calendar window. "
+            "When the preferred release or air date is still unknown, status shows TBD/TBA "
+            "(for example, Theatrical TBD for movies). Calendar tasks keep countdown text updated.\n\n"
+            "Season search mode now uses Lookahead range too: the current season is always included, "
+            "and the next season is monitored and searched when its first episode enters your configured window."
+        ),
+        cta_label="Open Movies",
+        cta_path="/library",
+        requires_ack=True,
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- **Placeholder policy**: Auto, Never, and Pinned on movies and episodes; save applies immediately with Creating… / Removing… feedback.
- **Determination explain**: Why? on movie detail and episode rows opens a step-by-step placeholder audit.
- **Pinned Coming Soon**: Pinned titles show countdowns outside the calendar window; missing dates show TBD/TBA; calendar phase keeps days updated.
- **Full sync performance**: Bounded ARR cache, chunked determination and reconcile, bulk Sonarr episode sync, and phase RSS/timing logs.
- **Season mode lookahead**: Lookahead range triggers next-season monitor and search when the first next-season episode enters the window.
- **Playback future episodes**: Suppress-on-playback skips any not-yet-aired episode, not only titles outside calendar lookahead.
## Added
- **Never placeholder**: Block placeholder creation per title; existing placeholders can be removed on sync.
- **Pinned placeholder**: Pin movies and episodes to create a placeholder despite calendar/monitored/specials rules. Does not create a placeholder when a real file exists.
- **Pinned vs shared instances**: Multi-instance sibling behavior follows Shared Placeholder Cleanup settings (no per-title override in the UI).
- **Determination explain**: "Why?" on movie detail and episode rows opens a step-by-step audit of placeholder determination.
- **What's new (0.9.23)**: Startup ack notice for placeholder policy, pinned Coming Soon/TBD, and Season mode lookahead.
## Changed
- **ARR HTTP cache**: Cap size with LRU eviction (512 entries); phase logs report entry count.
- **Determination pass**: Episode full scan runs in 2000-row chunks with commit/expunge; progress logs rows/sec.
- **Placeholder reconcile**: Stream active placeholder rows; chunk movie/episode link updates.
- **Placeholder reconcile cursor**: Validate pass uses ID-chunked queries instead of server-side cursors so mid-pass commits are safe.
- **Sonarr episode sync**: Bulk `/episode?seriesId=` requests use `includeEpisodeFile` and `includeImages` (one call per series); per-id GET only when still art is missing.
- **media_refresh coalesce**: Merge pending delayed_final and overlap_path_batch jobs into one path batch.
- **Phase metric logs**: RSS, ARR cache size, elapsed_s, and rows/sec at phase start/end.
- **Season mode lookahead**: Lookahead range controls when the next season is monitored and searched; the current season is always included.
- **Lookahead settings copy**: Settings and onboarding describe lookahead for Episode and Season modes.
- **Determination explain**: When a title is pinned but a real file is on disk, summary and the policy step explain that calendar, monitored, and sibling rules would be overridden, but no placeholder is needed.
- **Determination explain (policy)**: Why? uses one Placeholder policy step (Auto / Never / Pinned) instead of separate Never and Pin rows.
- **Placeholder policy cycle**: Movie meta strip and episode rows use Auto / Never / Pinned; save after a short pause; sync immediately; no confirm modals.
- **Placeholder policy feedback**: Episodes show Creating… / Removing… on the status chip; movies show the same text beside the pin.
- **Pinned / Never apply**: Create or remove the placeholder immediately from the stated policy (no full Arr reconcile). Auto still runs a full title sync.
- **Pinned placeholder status**: Pinned titles show Coming Soon countdowns outside the calendar window; missing dates show TBD/TBA (e.g. Theatrical TBD).
- **Pinned status refresh**: Saving pin on an existing placeholder updates status immediately; calendar phase includes pinned rows for daily countdown updates.
## Fixed
- **Obsolete settle**: After a placeholder is removed, determination settles to `not needed` instead of staying on `obsolete placeholder`.
- **Playback future-episode suppress**: "Do not search future episodes on playback" now skips any episode whose air date is still in the future, instead of only episodes beyond the calendar lookahead window.